### PR TITLE
Sky.Live diff/patch: tighten input authority + node-identity preservation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ legacy-ts-compiler/node_modules/
 # direnv / nix-direnv cache
 /.direnv/
 /.envrc.local
+sky.zip

--- a/docs/skylive/input-authority-protocol.md
+++ b/docs/skylive/input-authority-protocol.md
@@ -1,0 +1,563 @@
+# Sky.Live input authority protocol
+
+Design spec for the reliability layer that guarantees **no keystroke is ever lost**, regardless of latency, race conditions, dropped requests, out-of-order responses, page navigation, or server restarts. Supersedes the purely-positional morph algorithm documented in [architecture.md](architecture.md).
+
+Status: **design — not yet implemented**. Approval gate before code lands.
+
+## Motivation
+
+The current runtime has three structural weaknesses:
+
+1. **Positional sky-ids collide across pages.** `assignSkyIDs` in `live.go:836` emits `r.0.1.2` — purely the walk index. Two pages that share an outer wrapper (`<div class="container">`) but diverge internally end up with matching ids at structurally different elements. The diff at `diffNodes` in `live.go:911` recurses into them, tries to patch, and emits wrong HTML.
+
+2. **No patch preservation for focused inputs on the JSON path.** `__skyApplyPatches` in `live.go:2160` does `el.innerHTML = p.html` blindly. If the server sends an innerHTML patch at any ancestor of a focused input, the input is wiped mid-keystroke. Only the `__skyMorph` path (used for full-HTML responses, not the common event path) has any focus protection, and it only covers same-tag matches.
+
+3. **No ordering or replay protection.** Two fetches in flight can return in reversed order; the client applies both in arrival order. The older response clobbers the newer.
+
+Under mild load on sendcrafts, this produces visible input duplication on page navigation and occasional keystroke loss. Under adversarial conditions (slow 3G, tab-switching while typing, concurrent submits) it becomes unusable.
+
+The fix is a coordinated protocol change: **stable structural identities, monotonic sequence numbers, and client-side authority for dirty DOM state.**
+
+## Guarantees
+
+The protocol guarantees, for any Sky.Live app recompiled against the new runtime:
+
+- **G1: Keystroke preservation.** A character typed into an input element will not be lost to any combination of server latency, dropped patches, out-of-order responses, or patch applications — up to the point where the user blurs the input, submits, or navigates.
+- **G2: Navigation durability.** Pending debounced input values are flushed to the server before any navigation Msg is dispatched.
+- **G3: Monotonic consistency.** Patches are applied in sequence order. Stale patches are silently dropped.
+- **G4: Collision-free identity.** No two VNodes in a single render tree share a sky-id. Structurally-different subtrees across renders never collide.
+- **G5: Zero app-side changes.** Existing Sky and Sky.Live apps gain all of G1–G4 automatically after rebuild. No new syntax, no required attributes.
+
+Explicitly **not** guaranteed (out of scope for v1):
+- Offline buffering (if network is down for minutes, the loader surfaces the error).
+- Multi-tab conflict resolution (last writer wins, per current session-mutex behaviour).
+- Server-restart resync (next event returns 404; client must reload).
+
+## Wire format
+
+### Sky-id grammar
+
+```
+sky-id    = "r"                                        -- root
+          | parent-id "." index "#" tag [ ":" key ]
+
+parent-id = sky-id
+index     = 1*DIGIT
+tag       = 1*ALPHA                                    -- lowercase HTML tag
+key       = 1*( ALPHA / DIGIT / "-" / "_" )            -- disambiguator
+```
+
+**Key priority** (first match wins):
+1. Explicit `Html.keyed "k" node` wrapper → `k`.
+2. `name` attribute on `input`, `textarea`, `select`, `form`, `button`, `fieldset` → the attribute value.
+3. No key.
+
+Examples:
+
+| VNode | sky-id |
+|---|---|
+| root `<div id="sky-root">` | `r` |
+| first child `<div>` (CSS stylesheet) | `r.0#div` |
+| `<header>` at index 1 | `r.1#header` |
+| Email input inside a form | `r.2#main.0#form.3#input:email` |
+| Keyed list item | `r.4#ul.0#li:todo-42` |
+
+**Properties:**
+- Unique within a single render (structural walk produces unique paths).
+- Stable across renders when the element is structurally the same (same walk path, same tag, same key).
+- Automatically differentiates across renders when structure diverges (different tag → different id).
+
+### Request: `POST /_sky/event`
+
+```json
+{
+  "sessionId": "3f2a8b...",
+  "seq": 42,
+  "msg": "UpdateEmail",
+  "args": ["alice@example.com"],
+  "handlerId": "r.2#main.0#form.3#input:email.input",
+  "inputState": {
+    "r.2#main.0#form.3#input:email": {
+      "value": "alice@example.com",
+      "seq": 42
+    },
+    "r.2#main.0#form.5#input:password": {
+      "value": "hunter2",
+      "seq": 40
+    }
+  }
+}
+```
+
+New fields:
+- **`seq`** (int64, monotonic per session, client-owned): every `POST /_sky/event` increments it. Starts at 1 on first event.
+- **`inputState`** (object, optional): snapshot of every input the client considers "dirty". The key is the input's sky-id. Each entry records the *current* DOM value and the seq when the user last typed it. Server uses this to reconcile its idea of the model with reality.
+
+Backward compat: old clients omit `seq` and `inputState`. Server treats missing `seq` as `0` (oldest), missing `inputState` as empty.
+
+### Response: event reply
+
+When the server has usable patches to send back as JSON:
+
+```json
+{
+  "seq": 42,
+  "ackInputs": {
+    "r.2#main.0#form.3#input:email": 42,
+    "r.2#main.0#form.5#input:password": 40
+  },
+  "patches": [
+    {"id": "r.2#main.0#form.3#input:email", "attrs": {"value": "alice@example.com"}},
+    {"id": "r.1#header.0#span:greeting", "text": "Hi, Alice"}
+  ]
+}
+```
+
+New fields:
+- **`seq`** (int64): a **single session-wide monotonic** stamp — not an echo of `req.seq`. The server bumps `sess.outSeq` whenever it produces an outgoing frame (event reply OR SSE patch). This makes cross-channel ordering well-defined: a later frame always has a higher seq than every earlier frame, regardless of channel. Client tracks one `__skyLastAppliedSeq` and drops anything `≤` it.
+- **`ackInputs`** (object, optional): per input sky-id, the largest `inputState[id].seq` the server has processed. Client uses this to retire "dirty" flags once the server has caught up.
+- **`respondingTo`** (int64, optional): the `req.seq` this reply is answering. Informational only; the authoritative ordering signal is `seq`. Omitted on SSE frames (nothing to respond to).
+
+When the server needs to send a full HTML body (first interaction, or patches all target root):
+
+- `Content-Type: text/html`
+- `X-Sky-Seq: 99` header (single session-wide seq, same counter as JSON path)
+- `X-Sky-Ack-Inputs: {"r.2#...": 42, ...}` header (JSON-encoded compact form)
+
+### Batched events: `POST /_sky/event` with `batch` field
+
+Used by `__skyFlushAllPendingSync` on tab unload (via `navigator.sendBeacon`). Same endpoint as single events — no second route:
+
+```json
+{
+  "sessionId": "3f2a8b...",
+  "batch": [
+    {"seq": 42, "msg": "UpdateEmail", "args": ["a@b.com"], "handlerId": "..."},
+    {"seq": 43, "msg": "UpdatePhone", "args": ["+44..."],  "handlerId": "..."}
+  ]
+}
+```
+
+Server processes batch entries sequentially under `sess.mu`, dispatching each Msg as if it arrived on its own. Response body is ignored by `sendBeacon`, but the server still stamps out frames (via SSE) so other clients / tabs observe the state changes. When `batch` is set, top-level `msg`/`args`/`handlerId`/`seq` are ignored.
+
+### SSE frames: `GET /_sky/subscribe`
+
+```
+event: patch
+data: {"seq": 99, "ackInputs": {}, "patches": [...]}
+```
+
+Same shape as the JSON event reply. SSE frames and event replies share the **single session-wide `sess.outSeq` counter** — every mutation of session state produces the next seq, regardless of what triggered it. The server already has a single linearisation point (`sess.mu`), so there's one true ordering; exposing it as one counter lets the client resolve cross-channel races correctly. A Cmd goroutine that completes during an in-flight event reply will have its SSE frame stamped *after* the reply if the reply's dispatch ran first, or *before* if the goroutine's dispatch ran first — and the client applies in that exact order.
+
+## Client state
+
+```js
+// Top-level session state.
+var __skyClientSeq = 0;             // monotonic; client-owned, tagged on every outgoing event
+var __skyLastAppliedSeq = 0;        // monotonic; server-owned, drop any frame with seq ≤ this
+var __skyInputs = {};               // per sky-id → InputEntry
+```
+
+Two counters, different directions: `__skyClientSeq` is what the client stamps on outgoing events (so the server can match an inputState snapshot to its producing event). `__skyLastAppliedSeq` tracks the server's session-wide `outSeq` — a single counter covering both event replies and SSE frames, because the server has a single mutation order.
+
+```ts
+interface InputEntry {
+  liveValue: string;       // most recent DOM value the user typed
+  lastSentSeq: number;     // seq when this value was bundled into inputState
+  lastAckedSeq: number;    // largest seq the server has acked for this id
+  pendingDebounceId: number | null;  // window.setTimeout handle
+  pendingSend: {msgName: string; args: any[]; hid: string} | null;
+}
+```
+
+### State transitions (per input `I`)
+
+| Event | Update |
+|---|---|
+| `input` fires on `I` | `I.liveValue := el.value` |
+| Debounce schedules a send | `I.pendingSend := {...}`, `I.pendingDebounceId := setTimeout(…)` |
+| `__skySend` flushes `I` | `I.lastSentSeq := ++__skySeq`, include `I` in `req.inputState`, clear pending |
+| Response arrives with `ackInputs[I.id] = N` | `I.lastAckedSeq := max(I.lastAckedSeq, N)` |
+| Patch arrives with `attrs.value` on `I` | See "Authority rule" below |
+| `I` becomes unmounted (not in new DOM) | `delete __skyInputs[I.id]` |
+
+### Authority rule (client-side patch filter)
+
+When `__skyApplyPatches` processes a patch `p` targeting an element that is an input/textarea/select with `attrs.value`, `attrs.checked`, or `attrs.selected`:
+
+```
+entry = __skyInputs[p.id]
+el    = querySelector([sky-id=p.id])
+
+if entry exists AND (el is focused OR entry.pendingDebounceId != null):
+    DROP the value/checked/selected keys from p.attrs
+    // apply the rest of the patch (class, style, aria-*, etc.)
+
+else if entry exists AND p.attrs.value == entry.liveValue:
+    DROP (server is echoing our own value — no-op)
+
+else if response.seq <= entry.lastAckedSeq:
+    DROP the whole patch (stale)
+
+else:
+    APPLY
+    entry.liveValue = p.attrs.value   // realign
+```
+
+The same filter runs for innerHTML patches targeting ancestors of a focused/dirty input: **an innerHTML patch that would wipe a dirty input is rewritten to a scoped patch that preserves the input's subtree.** Implementation: before applying `innerHTML`, scan the new HTML for sky-ids, diff against existing dirty inputs, and if a dirty input is inside the target, fall back to per-element patching for that subtree (morph-style).
+
+This preserves G1 even when the server sends a "wipe your whole form and rebuild" patch.
+
+## Server state
+
+```go
+type liveSession struct {
+    // ... existing fields ...
+
+    // Single monotonic counter for every outgoing frame (event reply OR
+    // SSE patch). Bumped under sess.mu, so reflects the session's actual
+    // linearisation order. Client uses this as the authoritative sequence.
+    outSeq int64
+
+    // Per-input-id → largest client seq the server has observed.
+    // Used to populate ackInputs on every response. Evicted when the
+    // corresponding input is no longer in the rendered tree.
+    inputSeqs map[string]int64
+}
+```
+
+**Why one counter not two:** every state mutation (dispatching a user event, completing a Cmd goroutine, applying a subscription tick) passes through `dispatch()` which holds `sess.mu`. There's exactly one true order. A single counter surfaces that order to the client; two counters would let the client accidentally reorder unrelated mutations that the server had already serialised.
+
+### Server-side input reconciliation — fused into diff
+
+Rather than pre-walk `prev` to rewrite values (O(n) extra pass, requires an index to be efficient at scale), the client's `inputState` is passed **directly into `diffNodes`** as a lookup table. The diff already walks the tree — we just consult the lookup at input nodes:
+
+```go
+func diffNodes(old, new_ *VNode, clientState map[string]string, out *[]Patch) {
+    // ... existing tag/kind check, attr diff ...
+
+    // When diffing an input-tag value/checked/selected attr, treat the
+    // client-reported value as the effective old value. This prevents the
+    // diff from emitting a patch that reverts the user's in-progress typing.
+    if isInputTag(new_.Tag) {
+        if cv, ok := clientState[old.SkyID]; ok {
+            if new_.Attrs["value"] == cv {
+                delete(attrChanges, "value")  // server matches DOM — no patch
+            }
+            // else: server genuinely wants to overwrite (form reset, etc.)
+            //       emit the patch; Step 3 client filter decides whether to apply
+        }
+    }
+
+    // ... recurse into children with same clientState ...
+}
+```
+
+On every `POST /_sky/event`:
+
+```
+1. Read req.seq, req.inputState.
+2. For each (id, {value, seq}) in req.inputState:
+     if sess.inputSeqs[id] < seq:
+         sess.inputSeqs[id] = seq
+3. Build clientState map[sky-id]string from req.inputState.
+4. Dispatch Msg as usual.
+5. Call diffNodes(prev, new_, clientState, &patches).
+6. Reply with {seq: ++sess.outSeq, respondingTo: req.seq,
+               ackInputs: subsetOfInputSeqsInPrevTree, patches}.
+```
+
+**Why fused, not pre-pass:** the diff already walks both trees. Adding a pre-pass walks the tree twice for no benefit. Adding an index on `prev` means maintaining invalidation on every mutation — another rule to get wrong. The fused approach costs O(hash-lookup) per input node, zero extra allocations, and no state to invalidate.
+
+**What "client authority" means on the server:** the diff is a hint, not a veto. If `update` decides `model.email = "Bob"` (form reset, admin edit, whatever), `new_.Attrs["value"]` becomes `"Bob"`, which doesn't match the client's reported value, so the diff emits `value="Bob"`. The Step 3 client filter then decides — if the user is *currently* typing into that field, the filter drops the `value` attr and the user keeps typing; otherwise the patch applies. Server model stays authoritative; client input stays unclobbered. Both invariants hold simultaneously.
+
+## Invariants enforced
+
+| Invariant | Mechanism | Location |
+|---|---|---|
+| I1 — Client authority | Patch filter drops `value`/`checked`/`selected` when input is focused/dirty | `__skyApplyPatches`, `__skyMorph` |
+| I2 — Monotonic application | `response.seq ≤ lastApplied` → drop | `__skyApplyPatches`, SSE handler |
+| I3 — Navigation flush | Intercept `<a>` click inside sky-root → flush debounces synchronously → send nav Msg | `__skyBindEvents`, `beforeunload` |
+| I4 — Identity collision-free | Structural sky-ids with tag+key | `assignSkyIDs` in `live.go` |
+| I5 — Server diff uses real DOM | `alignPrevTreeValue` merges `req.inputState` into `prev` before diffing | `/_sky/event` handler |
+
+## Failure-mode matrix
+
+| Scenario | Before | After | Invariant |
+|---|---|---|---|
+| Type fast, server responds slow with old `value` | Input reverts to old value mid-type | Patch dropped; user's value kept | I1 + I5 |
+| Two sends in flight, responses arrive reversed | Older response clobbers newer | Older patch dropped via seq check | I2 |
+| Click `<a>` while typing | Final keystrokes lost | Debounce flushed before nav leaves | I3 |
+| Navigate to page with same outer wrapper | Inputs duplicate / wrong attrs | Different sky-ids; clean replace | I4 |
+| SSE delivers duplicate frame | Frame applied twice | Second frame dropped via seq | I2 |
+| Form reset via `update` sets model.email = "" | Works today, still works after | `value=""` patch applied; empty input takes effect | (no regression) |
+| User types, tab-switches, comes back | Works if debounce already flushed via blur | Same: `focusout` handler flushes | I3 (existing) |
+| Server sends innerHTML at parent of focused input | Input wiped, value lost | Scoped morph preserves dirty input subtree | I1 |
+| Slow-3G + rapid typing | Characters skip or double | Smooth; buffered locally, flushed in seq order | I1 + I2 |
+
+## Implementation plan
+
+Ordered; each step is independently landable and reviewable.
+
+### Step 1 — Structural sky-ids (Fix B)
+
+**File:** `runtime-go/rt/live.go`
+
+Replace `assignSkyIDs` (line 836) with:
+
+```go
+func assignSkyIDs(n *VNode, path string) {
+    if n.Kind != "element" {
+        return
+    }
+    seg := path
+    if path == "r" {
+        n.SkyID = "r"
+    } else {
+        n.SkyID = path
+    }
+    for i := range n.Children {
+        child := &n.Children[i]
+        childSeg := seg + "." + itoa(i) + "#" + child.Tag
+        if k := skyIDKey(child); k != "" {
+            childSeg += ":" + k
+        }
+        assignSkyIDs(child, childSeg)
+    }
+}
+
+func skyIDKey(n *VNode) string {
+    if k, ok := n.Attrs["sky-key"]; ok && k != "" {
+        return sanitiseKey(k)
+    }
+    switch n.Tag {
+    case "input", "textarea", "select", "form", "button", "fieldset":
+        if k, ok := n.Attrs["name"]; ok && k != "" {
+            return sanitiseKey(k)
+        }
+    }
+    return ""
+}
+
+func sanitiseKey(s string) string {
+    // Replace anything that's not [A-Za-z0-9_-] with _.
+    // Prevents sky-id parse ambiguity and HTML injection.
+    var b strings.Builder
+    for _, r := range s {
+        switch {
+        case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_':
+            b.WriteRune(r)
+        default:
+            b.WriteByte('_')
+        }
+    }
+    return b.String()
+}
+```
+
+**Also:** `Html.keyed` helper added to `sky-stdlib/Sky/Html.sky` (opt-in; sets `sky-key` attribute, consumed by `skyIDKey` above):
+
+```elm
+keyed : String -> VNode -> VNode
+keyed k node = Html.attr "sky-key" k node
+```
+
+**Verification:** `scripts/example-sweep.sh` must pass. Every example renders; HTML diff against main shows only sky-id format changes (longer ids, no layout change).
+
+### Step 2 — Wire format bump
+
+**Files:** `runtime-go/rt/live.go` (Go), embedded JS at line 2030+.
+
+Add `seq`, `inputState`, `ackInputs` fields to request/response structs. Populate but don't yet enforce — behaviour identical to today. This is the "stub" step that makes the protocol upgradable.
+
+Go struct additions:
+```go
+type eventRequest struct {
+    SessionID  string                    `json:"sessionId"`
+    Seq        int64                     `json:"seq,omitempty"`
+    Msg        string                    `json:"msg"`
+    Args       []any                     `json:"args,omitempty"`
+    HandlerID  string                    `json:"handlerId,omitempty"`
+    InputState map[string]inputStateEntry `json:"inputState,omitempty"`
+}
+type inputStateEntry struct {
+    Value string `json:"value"`
+    Seq   int64  `json:"seq"`
+}
+type eventResponse struct {
+    Seq        int64            `json:"seq,omitempty"`
+    AckInputs  map[string]int64 `json:"ackInputs,omitempty"`
+    Patches    []Patch          `json:"patches"`
+}
+```
+
+Client JS:
+- On `__skySend`: bump `__skySeq`, include it in body.
+- On response: capture `resp.seq` into `__skyLastAppliedEventSeq` (not enforced yet).
+- On `input` event: capture `el.value` into `__skyInputs[sky-id].liveValue` (not yet used in filters).
+
+### Step 3 — I1 client authority
+
+**Files:** embedded JS at line 2030+ in `live.go`.
+
+Wire the patch filter. `__skyApplyPatches` consults `__skyInputs` for every patch targeting an input/textarea/select:
+
+```js
+function __skyApplyPatches(resp) {
+  var patches = resp.patches || [];
+  // Ingest ackInputs first so the filter can see the latest acks.
+  if (resp.ackInputs) {
+    var ids = Object.keys(resp.ackInputs);
+    for (var k = 0; k < ids.length; k++) {
+      var e = __skyInputs[ids[k]];
+      if (e) e.lastAckedSeq = Math.max(e.lastAckedSeq, resp.ackInputs[ids[k]]);
+    }
+  }
+  for (var i = 0; i < patches.length; i++) {
+    var p = patches[i];
+    var el = document.querySelector('[sky-id="' + p.id.replace(/"/g, '\\"') + '"]');
+    if (!el) continue;
+    __skyFilterPatch(p, el);    // mutates p in place per authority rule
+    __skyApplyOne(p, el);
+  }
+  __skyBindEvents(document);
+}
+```
+
+`__skyFilterPatch` implements the authority rule from the client state section. `__skyApplyOne` holds the existing `innerHTML` / `textContent` / attr application logic.
+
+For innerHTML patches that contain dirty inputs: parse the new HTML with a DOMParser, check whether any dirty input id is present, and if so, convert the innerHTML patch into a morph (walk new vs. old, skip dirty inputs, apply rest).
+
+### Step 4 — I2 stale drop
+
+**File:** same JS block.
+
+Activate the seq check:
+
+```js
+function __skyApplyPatches(resp) {
+  if (resp.seq !== undefined && resp.seq <= __skyLastAppliedEventSeq) {
+    return;  // stale — a newer response already landed
+  }
+  __skyLastAppliedEventSeq = Math.max(__skyLastAppliedEventSeq, resp.seq || 0);
+  // ... rest as in Step 3
+}
+```
+
+SSE handler uses `__skyLastAppliedSubSeq` (separate counter) for subscription frames.
+
+### Step 5 — I3 flush on unmount
+
+**File:** same JS block.
+
+Intercept `<a href>` clicks inside sky-root:
+
+```js
+document.addEventListener('click', function(ev) {
+  var a = ev.target.closest && ev.target.closest('a[href]');
+  if (!a) return;
+  if (!document.getElementById('sky-root').contains(a)) return;
+  // External links: let the browser handle, but flush first.
+  if (/^https?:/.test(a.href) && a.host !== location.host) {
+    __skyFlushAllPending();
+    return;
+  }
+  // Internal nav: let Sky.Live's client-side router handle it, but flush first.
+  __skyFlushAllPending();
+  // Don't preventDefault — the existing router takes over.
+}, true);
+
+window.addEventListener('beforeunload', function() {
+  __skyFlushAllPendingSync();  // uses navigator.sendBeacon
+});
+
+function __skyFlushAllPending() {
+  var ids = Object.keys(__skyInputs);
+  for (var i = 0; i < ids.length; i++) {
+    var e = __skyInputs[ids[i]];
+    if (e.pendingDebounceId !== null) {
+      clearTimeout(e.pendingDebounceId);
+      e.pendingDebounceId = null;
+      if (e.pendingSend) {
+        __skySend(e.pendingSend.msgName, e.pendingSend.args, e.pendingSend.hid,
+                  {noLoader: true});
+        e.pendingSend = null;
+      }
+    }
+  }
+}
+
+function __skyFlushAllPendingSync() {
+  var ids = Object.keys(__skyInputs);
+  var batch = [];
+  for (var i = 0; i < ids.length; i++) {
+    var e = __skyInputs[ids[i]];
+    if (e.pendingSend) batch.push(e.pendingSend);
+  }
+  if (batch.length === 0) return;
+  navigator.sendBeacon('/_sky/event-batch', JSON.stringify({
+    sessionId: __skySid, batch: batch
+  }));
+}
+```
+
+`/_sky/event-batch` is a new server endpoint that processes a batch of events in order before the tab closes. Best-effort — browsers guarantee `sendBeacon` delivery but not ordering across multiple beacons; a single batched beacon is reliable.
+
+### Step 6 — Adversarial test matrix
+
+**Go tests** in `runtime-go/rt/live_test.go`:
+
+- `TestSkyIDStructural` — two VNode trees with same positional layout but different tags; `assignSkyIDs` gives different ids.
+- `TestSkyIDStableAcrossRenders` — same tree rendered twice produces same ids.
+- `TestSkyIDKeyedList` — keyed list reorder: ids follow items, not positions.
+- `TestEventSeqMonotonic` — `eventSeq` increments per event, survives marshalling round-trip.
+- `TestInputStateReconciliation` — `alignPrevTreeValue` merges client inputState into prev tree.
+- `TestAckInputsEmitted` — response echoes server's view of every dirty input.
+
+**Browser tests** via Playwright (new dep) or an example-driven manual matrix (`examples/19-reliability`):
+
+1. Type "hello" with 500ms server latency — all 5 characters appear.
+2. Type + click `<a href>` mid-keystroke — server logs show final value.
+3. Type on page A, navigate to page B — no orphan value, no state bleed.
+4. Fire two submits in rapid succession — server serializes, client shows consistent final state.
+5. SSE send duplicate frame — DOM not double-mutated.
+6. innerHTML patch at `<form>` while `<input>` focused — input survives with user's value.
+7. Kill server mid-fetch — client retries, no silent data loss.
+8. Throttle to slow-3G, type continuously — no character loss.
+
+### Step 7 — Verify on sendcrafts
+
+Rebuild sendcrafts' compiler binary (`cabal install` in sky repo), rebuild sendcrafts (`sky build src/Main.sky`). Manual check:
+
+- signIn → signUp transition: no duplicated inputs.
+- Type email, navigate away, come back: server remembers last typed value (via `inputState` flush).
+- Open two tabs, edit session from both: one wins per session mutex (existing behaviour, documented).
+
+## Backward compatibility
+
+- **Runtime bump:** all Sky.Live apps must recompile to get the new runtime. No opt-out flag; the runtime is embedded via Template Haskell and shipped with the compiler binary.
+- **Wire format:** additive. New fields are optional; omitting them produces the pre-upgrade behaviour.
+- **Sky-id format:** changes visible in DOM (`sky-id="r.0#div.1#form..."` instead of `sky-id="r.0.1..."`). Tests that assert on sky-id strings must update. Dev tools scripts that query by `[sky-id^="r."]` continue to work.
+- **No CLAUDE.md changes needed.** The public API (`Live.app`, `Html.*`, `Server.*`) is unchanged. `Html.keyed` is a new opt-in helper, documented but not required.
+
+## Open questions — resolved
+
+1. **Batch endpoint:** single endpoint. `POST /_sky/event` accepts an optional `batch` field; when present, top-level `msg`/`args`/`handlerId`/`seq` are ignored. One route, one mental model.
+
+2. **Single session-wide seq counter.** The server's `sess.mu` is the single linearisation point for all mutations; exposing it as one monotonic counter lets the client resolve cross-channel races correctly. Two counters would leak implementation detail (separate request/subscription tracking) and make cross-channel ordering ambiguous. Client tracks one `__skyLastAppliedSeq`.
+
+3. **Fused client-value alignment.** `clientState map[string]string` parameter passed to `diffNodes`. No pre-pass, no index to maintain, no invalidation rule. Consulted O(1) per input node during the walk the diff already performs.
+
+4. **No patch reordering.** Current DFS emission order is correct. Ancestor `innerHTML` patches are self-healing — they carry the full rendered subtree, so clobbered descendant patches don't corrupt DOM state (just waste client work). Step 3's filter with innerHTML-preserving-dirty-input morph handles the edge cases categorically. Emission-ordering optimisations (suppressing descendant patches when an ancestor `innerHTML` will be emitted) are a future perf tweak, not a correctness fix.
+
+## Approval gate
+
+This doc is the contract. Before any of Steps 1–7 lands, the following must be confirmed:
+
+- [ ] Sky-id grammar accepted.
+- [ ] Wire format (request, response, SSE, headers) accepted.
+- [ ] Invariants I1–I5 cover the guarantees G1–G5.
+- [ ] Failure-mode matrix is complete (flag any missing scenario).
+- [ ] Implementation sequence + verification strategy accepted.
+
+Once approved, implementation proceeds in the step order above, one commit per step. Each commit ships its own regression test. No step is marked complete until `scripts/example-sweep.sh` passes clean-slate.

--- a/docs/skylive/input-authority-protocol.md
+++ b/docs/skylive/input-authority-protocol.md
@@ -505,16 +505,50 @@ function __skyFlushAllPendingSync() {
 
 ### Step 6 — Adversarial test matrix
 
-**Go tests** in `runtime-go/rt/live_test.go`:
+**Go tests landed alongside Steps 1–5** (exhaustive per-step coverage
+was written as each step landed rather than deferred to a single
+catch-up step):
 
-- `TestSkyIDStructural` — two VNode trees with same positional layout but different tags; `assignSkyIDs` gives different ids.
-- `TestSkyIDStableAcrossRenders` — same tree rendered twice produces same ids.
-- `TestSkyIDKeyedList` — keyed list reorder: ids follow items, not positions.
-- `TestEventSeqMonotonic` — `eventSeq` increments per event, survives marshalling round-trip.
-- `TestInputStateReconciliation` — `alignPrevTreeValue` merges client inputState into prev tree.
-- `TestAckInputsEmitted` — response echoes server's view of every dirty input.
+Step 1 — `runtime-go/rt/live_skyid_test.go`:
+- `TestSkyIDCollisionFree` — the signIn/signUp repro.
+- `TestSkyIDStableAcrossRenders` — identical trees → identical ids.
+- `TestSkyIDNameBasedKey` — inputs with `name` keep identity across reorder.
+- `TestSkyIDExplicitKey` — `sky-key` attr wins over name.
+- `TestSkyIDKeySanitisation` — hostile keys can't escape grammar.
+- `TestSkyIDTextChildrenDontGetIDs` — positional index preserved.
 
-**Browser tests** via Playwright (new dep) or an example-driven manual matrix (`examples/19-reliability`):
+Step 2 — `runtime-go/rt/live_protocol_test.go`:
+- `TestOutSeqMonotonic` — nextOutSeq strictly increments.
+- `TestIngestInputStateKeepsMaxSeq` — per-id monotone seq.
+- `TestAckInputsEvictsUnmounted` — removes ids not in prevTree.
+- `TestEncodeSSEFrameShape` — valid JSON envelope.
+- `TestWriteEventJSONEnvelope` / `...NoPatchesEmitsEmptyArray` — envelope shape.
+- `TestWriteEventHTMLSetsProtocolHeaders` / `...OmitsEmptyAck` — header shape.
+- `TestHandleEventRoundTripsSeq` — full handler round-trip.
+- `TestHandleEventBatch` — sendBeacon batch path → 204.
+
+Step 3 — `runtime-go/rt/live_authority_test.go`:
+- `TestDiffAlignsToClientValue` — server matches client → no patch.
+- `TestDiffOverridesClientWhenServerDisagrees` — patch still emitted on genuine override.
+- `TestDiffLegacyCallerNilClientState` — legacy behaviour preserved.
+- `TestDiffNonInputTagIgnoresClientState` — only form fields aligned.
+- `TestDiffAuthorityAttrsChecked` — `checked` attr alignment works.
+
+Step 6 — `runtime-go/rt/live_adversarial_test.go`:
+- `TestConcurrentEventsSerialise` — 20 concurrent POSTs → 20 distinct seqs.
+- `TestSeqCountsCoverEveryOutgoingFrame` — SSE frame + event reply interleave on one counter.
+- `TestDiffAlignsInsideNestedForm` — deep-tree alignment.
+- `TestLegacyFieldsPreserved` — pre-upgrade clients keep working.
+
+**Browser tests deferred to a follow-up branch** — adding Playwright
+(or `chromedp`) to this repo is a non-trivial tooling commitment and
+keeps this PR focused on the runtime contract. The JS logic (patch
+filter, stale-drop, beacon flush) is small and mechanically derived
+from the Go-side invariants that *are* tested; Step 7 validates
+end-to-end against a real app (sendcrafts) for the regression the
+protocol was designed to fix.
+
+Manual smoke checklist (for the follow-up automation):
 
 1. Type "hello" with 500ms server latency — all 5 characters appear.
 2. Type + click `<a href>` mid-keystroke — server logs show final value.

--- a/runtime-go/rt/live.go
+++ b/runtime-go/rt/live.go
@@ -2426,13 +2426,19 @@ function __skyInputsSnapshot() {
 // into client state. seq advances __skyLastAppliedSeq monotonically;
 // ackInputs retires per-input dirty flags so the next snapshot omits
 // caught-up fields.
-// __skyIsDirty — element is "dirty" (user-authoritative) when it is
-// currently focused, has a pending debounced send keyed by its
-// data-sky-hid, or the client has typed past the server's last ack
-// for its sky-id. The patch filter reads this to decide whether to
-// apply value/checked/selected attrs or innerHTML replacements.
+// __skyIsDirty — a typable form field (input / textarea / select)
+// whose DOM state is authoritative over the server's view. The check
+// is scoped to those tags ONLY: buttons, anchors, divs and other
+// focused-but-non-typable elements have no keystrokes to preserve,
+// so treating them as dirty would wrongly block patches that wipe
+// their containing subtree (e.g. navigating from a "new game"
+// screen into a board view, where the focused button legitimately
+// disappears). Scope signals: focus, pending debounce keyed by
+// data-sky-hid, or an unacked typed value at the input's sky-id.
 function __skyIsDirty(el) {
   if (!el || el.nodeType !== 1) return false;
+  var tag = el.tagName;
+  if (tag !== "INPUT" && tag !== "TEXTAREA" && tag !== "SELECT") return false;
   if (el === document.activeElement) return true;
   var hid = el.getAttribute && el.getAttribute("data-sky-hid");
   if (hid && __skyInputPending[hid]) return true;
@@ -2447,9 +2453,11 @@ function __skyIsDirty(el) {
 // __skyContainsDirty — true when el or any descendant form field
 // is dirty. Used before innerHTML replacement to decide whether the
 // safe path (raw innerHTML) or the protecting path (morph) applies.
+// Only walks input-like descendants: the scope mirrors __skyIsDirty.
 function __skyContainsDirty(el) {
+  if (!el) return false;
   if (__skyIsDirty(el)) return true;
-  if (!el || !el.querySelectorAll) return false;
+  if (!el.querySelectorAll) return false;
   var nodes = el.querySelectorAll("input, textarea, select");
   for (var i = 0; i < nodes.length; i++) {
     if (__skyIsDirty(nodes[i])) return true;

--- a/runtime-go/rt/live.go
+++ b/runtime-go/rt/live.go
@@ -2450,21 +2450,6 @@ function __skyIsDirty(el) {
   return false;
 }
 
-// __skyContainsDirty — true when el or any descendant form field
-// is dirty. Used before innerHTML replacement to decide whether the
-// safe path (raw innerHTML) or the protecting path (morph) applies.
-// Only walks input-like descendants: the scope mirrors __skyIsDirty.
-function __skyContainsDirty(el) {
-  if (!el) return false;
-  if (__skyIsDirty(el)) return true;
-  if (!el.querySelectorAll) return false;
-  var nodes = el.querySelectorAll("input, textarea, select");
-  for (var i = 0; i < nodes.length; i++) {
-    if (__skyIsDirty(nodes[i])) return true;
-  }
-  return false;
-}
-
 function __skyIngestSeq(seq, ackInputs) {
   if (typeof seq === "number" && seq > __skyLastAppliedSeq) {
     __skyLastAppliedSeq = seq;
@@ -2494,50 +2479,107 @@ function __skyHandleResponse(seq, ackInputs, applyFn) {
   applyFn();
 }
 
-// __skyPatch: replace sky-root's content with the fragment in `+"`"+`t`+"`"+`,
-// preserving the active element (focus + caret/selection) and scroll
-// position across the swap. Without this, typing in an input that
-// triggers onInput would lose focus on every keystroke.
+// ── Focus preservation ───────────────────────────────────────
+// Sky.Live renders whole subtrees via innerHTML replacement (both on
+// JSON patches that carry p.html and on full-HTML navigations). The
+// browser's innerHTML parser is atomic and correct — there's no
+// visibly intermediate state — but it destroys descendants, which
+// loses focus + caret position on any focused input.
+//
+// Snapshot BEFORE the replacement, restore AFTER: walk back to the
+// same input in the new DOM using its stable identifier (priority:
+// id > sky-id > tag+name), then re-focus and restore selection.
+// When the focused input had in-flight typed text (i.e. is still
+// "dirty" by the authority check), the user's value wins over
+// whatever the server rendered.
+//
+// This is the same pattern morphdom / Idiomorph use; it's simpler
+// and categorically correct compared to ad-hoc tree walking, which
+// cannot reliably handle structural shifts (e.g. a nav click that
+// changes the whole page) without producing duplicate or orphaned
+// nodes.
+function __skyFocusSnapshot() {
+  var el = document.activeElement;
+  if (!el || el === document.body || el === document.documentElement) return null;
+  var tag = el.tagName;
+  if (tag !== "INPUT" && tag !== "TEXTAREA" && tag !== "SELECT") return null;
+  var snap = {
+    id:             el.id || "",
+    sid:            (el.getAttribute && el.getAttribute("sky-id")) || "",
+    name:           (el.getAttribute && el.getAttribute("name")) || "",
+    tag:            tag,
+    value:          ("value" in el) ? el.value : "",
+    selectionStart: null,
+    selectionEnd:   null,
+    scrollTop:      el.scrollTop || 0,
+  };
+  try {
+    snap.selectionStart = el.selectionStart;
+    snap.selectionEnd   = el.selectionEnd;
+  } catch (_) { /* some input types (number, email) throw on selection read */ }
+  return snap;
+}
+
+function __skyFocusLocate(snap, scope) {
+  if (!snap) return null;
+  scope = scope || document;
+  var el = null;
+  if (snap.id) {
+    el = document.getElementById(snap.id);
+    if (el) return el;
+  }
+  if (snap.sid) {
+    el = scope.querySelector('[sky-id="' + snap.sid.replace(/"/g, '\\"') + '"]');
+    if (el) return el;
+  }
+  if (snap.name) {
+    el = scope.querySelector(snap.tag.toLowerCase() + '[name="' + snap.name + '"]');
+    if (el) return el;
+  }
+  return null;
+}
+
+function __skyFocusRestore(snap, scope) {
+  if (!snap) return;
+  var el = __skyFocusLocate(snap, scope);
+  if (!el) return;
+  // Preserve the user's in-flight typing: if the snapshot value
+  // differs from what the server just rendered, the user was in
+  // the middle of editing and their DOM wins. Without this, a
+  // concurrent server patch carrying a stale value would clobber
+  // keystrokes the user typed between the patch being generated
+  // and it landing.
+  if (snap.value !== undefined && ("value" in el) && el.value !== snap.value) {
+    el.value = snap.value;
+  }
+  try { el.focus({preventScroll: true}); } catch (_) { el.focus(); }
+  if (typeof el.setSelectionRange === "function" &&
+      snap.selectionStart !== null && snap.selectionEnd !== null) {
+    try { el.setSelectionRange(snap.selectionStart, snap.selectionEnd); } catch (_) {}
+  }
+  if (snap.scrollTop) el.scrollTop = snap.scrollTop;
+}
+
+// __skyPatch: atomic innerHTML replacement for full-body responses
+// (sky-nav click, popstate, full-HTML fallback). The browser's
+// innerHTML parser handles the swap correctly in one step — no
+// intermediate state, no duplicate/orphan nodes from ad-hoc tree
+// walks. Focus + selection are preserved via snapshot/restore.
 function __skyPatch(t) {
   var root = document.getElementById("sky-root");
   if (!root) return;
+  // Strip the full-document envelope when present (sky-nav fetches
+  // return <!doctype><html>...</html>). The regex captures exactly
+  // the rendered body, same as before.
   var m = t.match(/<div id="sky-root">([\s\S]*?)<\/div><script>/);
   if (m) t = m[1];
   var scrollX = window.scrollX, scrollY = window.scrollY;
-  // Morphdom-lite: parse new HTML, walk by sky-id, patch in-place.
-  // Input elements that are focused or have pending debounces are
-  // NEVER touched — the user's live value is the source of truth.
-  var tmp = document.createElement("div");
-  tmp.innerHTML = t;
-  __skyMorph(root, tmp);
+  var snap = __skyFocusSnapshot();
+  root.innerHTML = t;
   window.scrollTo(scrollX, scrollY);
-  // Re-bind sky-* events for the fresh DOM subtree.
   __skyBindEvents(document);
-  // Process data-sky-eval attributes (e.g. skySignOut() on sign-out).
   __skyRunEvals(root);
-}
-
-// __skyElementKey: stable key used to re-locate the focused element in
-// the patched DOM. Priority: id > name > sky-id (runtime-assigned).
-// sky-id is the critical fallback — inputs without id/name (the common
-// case for form fields) would otherwise lose focus on every patch.
-function __skyElementKey(el) {
-  if (!el || el === document.body) return null;
-  if (el.id) return {kind: "id", v: el.id};
-  if (el.name) return {kind: "name", v: el.name, tag: el.tagName};
-  var skyId = el.getAttribute && el.getAttribute("sky-id");
-  if (skyId) return {kind: "sky-id", v: skyId};
-  return null;
-}
-function __skyFindByKey(scope, key) {
-  if (key.kind === "id") return document.getElementById(key.v);
-  if (key.kind === "name") {
-    return scope.querySelector(key.tag.toLowerCase() + '[name="' + key.v + '"]');
-  }
-  if (key.kind === "sky-id") {
-    return scope.querySelector('[sky-id="' + key.v.replace(/"/g, '\\"') + '"]');
-  }
-  return null;
+  __skyFocusRestore(snap, root);
 }
 
 // ── Loading indicator ────────────────────────────────────────
@@ -2738,29 +2780,33 @@ function __skySend(msgName, args, handlerId, opts) {
   }).catch(function() { __skyLoaderEnd(); });
 }
 
-// Apply a list of sky-id addressed patches with the input authority
-// filter (I1): value/checked/selected attrs on dirty inputs are
-// dropped so the user's live DOM wins, and innerHTML replacements
-// that would wipe a dirty subtree are re-routed through the morph
-// algorithm (which preserves focused / pending inputs).
+// Apply a list of sky-id addressed patches with input authority (I1):
+// value/checked/selected attrs on dirty inputs are dropped so the
+// user's DOM wins; innerHTML patches use the browser's atomic
+// innerHTML parser (not an ad-hoc tree walk) and focus + selection
+// are preserved via snapshot/restore on either side of the mutation.
+//
+// A single focus snapshot covers the whole batch — if a patch wipes
+// the subtree containing the focused input, the restore locates it
+// by sky-id/name/id in the new DOM and puts the user's typed value
+// back. Between patches the DOM is intermediate but never visibly
+// so (applyPatches runs to completion synchronously before the
+// browser paints).
 function __skyApplyPatches(patches) {
+  if (!patches || patches.length === 0) return;
+  var snap = __skyFocusSnapshot();
   for (var i = 0; i < patches.length; i++) {
     var p = patches[i];
     var el = document.querySelector('[sky-id="' + p.id.replace(/"/g, '\\"') + '"]');
     if (!el) continue;
-    if (p.text !== undefined && p.text !== null) el.textContent = p.text;
+    if (p.text !== undefined && p.text !== null) {
+      el.textContent = p.text;
+    }
     if (p.html !== undefined && p.html !== null) {
-      // If any dirty input lives inside this subtree, route the
-      // replacement through __skyMorph — it knows to skip focused /
-      // pending inputs rather than wipe them. Otherwise take the
-      // fast path (native innerHTML assignment).
-      if (__skyContainsDirty(el)) {
-        var tmp = document.createElement("div");
-        tmp.innerHTML = p.html;
-        __skyMorph(el, tmp);
-      } else {
-        el.innerHTML = p.html;
-      }
+      // Atomic innerHTML replacement. Focus/keystroke preservation
+      // handled globally by the surrounding snapshot/restore — no
+      // ad-hoc tree walk required.
+      el.innerHTML = p.html;
     }
     if (p.attrs) {
       var dirty = __skyIsDirty(el);
@@ -2789,6 +2835,7 @@ function __skyApplyPatches(patches) {
   }
   // Any new sky-* attribute in the patched DOM needs a listener.
   __skyBindEvents(document);
+  __skyFocusRestore(snap);
 }
 
 // ── TEA event binding ────────────────────────────────────────
@@ -2802,103 +2849,6 @@ function __skyBindEvents(root) {
                 "mousedown", "mouseup"];
   for (var i = 0; i < events.length; i++) {
     __skyBindOne(root, events[i]);
-  }
-}
-
-// ── Morphdom-lite ────────────────────────────────────────────
-// Walk old and new DOM trees by sky-id. Patch in-place instead of
-// innerHTML replacement. Focused/pending inputs are never touched.
-function __skyMorph(oldParent, newParent) {
-  var oldKids = oldParent.childNodes;
-  var newKids = newParent.childNodes;
-  // Build sky-id index for old children
-  var oldById = {};
-  for (var i = 0; i < oldKids.length; i++) {
-    var sid = oldKids[i].getAttribute ? oldKids[i].getAttribute("sky-id") : null;
-    if (sid) oldById[sid] = oldKids[i];
-  }
-  // Walk new children
-  for (var j = 0; j < newKids.length; j++) {
-    var newNode = newKids[j];
-    var newSid = newNode.getAttribute ? newNode.getAttribute("sky-id") : null;
-    var oldNode = newSid ? oldById[newSid] : (j < oldKids.length ? oldKids[j] : null);
-    if (!oldNode) {
-      // New node — append
-      oldParent.appendChild(newNode.cloneNode(true));
-      continue;
-    }
-    if (oldNode.nodeType === 3 && newNode.nodeType === 3) {
-      // Text nodes — update if different
-      if (oldNode.textContent !== newNode.textContent) {
-        oldNode.textContent = newNode.textContent;
-      }
-      continue;
-    }
-    if (oldNode.nodeType !== newNode.nodeType || oldNode.tagName !== (newNode.tagName || "")) {
-      // Different node type — replace entirely UNLESS the old subtree
-      // contains dirty state (focused input, pending debounce, unacked
-      // keystrokes). Stomping it would lose the user's typing; skip
-      // this node and let the next event round-trip reconcile.
-      if (oldNode.nodeType === 1 && __skyContainsDirty(oldNode)) {
-        continue;
-      }
-      oldParent.replaceChild(newNode.cloneNode(true), oldNode);
-      continue;
-    }
-    // Same element type — check if it's a protected input. Fold the
-    // __skyIsDirty signals (focus, pending debounce, unacked seq) so
-    // the "don't touch value" skip also fires for inputs the user
-    // edited but hasn't yet blurred.
-    var tag = (oldNode.tagName || "").toUpperCase();
-    var isInput = tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT";
-    if (isInput && __skyIsDirty(oldNode)) {
-      // SKIP — user is typing here. Don't touch value/checked/selected.
-      __skyPatchAttrs(oldNode, newNode, true);
-      continue;
-    }
-    // Patch attributes
-    __skyPatchAttrs(oldNode, newNode, false);
-    // Recurse into children
-    if (newNode.childNodes.length > 0 || oldNode.childNodes.length > 0) {
-      __skyMorph(oldNode, newNode);
-    }
-  }
-  // Remove excess old children
-  while (oldParent.childNodes.length > newKids.length) {
-    oldParent.removeChild(oldParent.lastChild);
-  }
-}
-
-function __skyPatchAttrs(oldEl, newEl, skipValue) {
-  if (!oldEl.attributes || !newEl.attributes) return;
-  // Remove attrs not in new. skipValue is the "protected input"
-  // signal — it means don't touch the user-driven attrs on this
-  // element (value, checked, selected all in one bucket).
-  var isUserAuthorityAttr = function(n) {
-    return skipValue && (n === "value" || n === "checked" || n === "selected");
-  };
-  var toRemove = [];
-  for (var i = 0; i < oldEl.attributes.length; i++) {
-    var name = oldEl.attributes[i].name;
-    if (isUserAuthorityAttr(name)) continue;
-    if (!newEl.hasAttribute(name)) toRemove.push(name);
-  }
-  for (var r = 0; r < toRemove.length; r++) oldEl.removeAttribute(toRemove[r]);
-  // Set/update attrs from new
-  for (var j = 0; j < newEl.attributes.length; j++) {
-    var attr = newEl.attributes[j];
-    if (isUserAuthorityAttr(attr.name)) continue;
-    if (oldEl.getAttribute(attr.name) !== attr.value) {
-      oldEl.setAttribute(attr.name, attr.value);
-    }
-  }
-  // For non-protected inputs, sync .value from attribute
-  if (!skipValue) {
-    var t = (oldEl.tagName || "").toUpperCase();
-    if (t === "INPUT" || t === "TEXTAREA" || t === "SELECT") {
-      var newVal = newEl.getAttribute("value") || newEl.value || "";
-      if (oldEl.value !== newVal) oldEl.value = newVal;
-    }
   }
 }
 

--- a/runtime-go/rt/live.go
+++ b/runtime-go/rt/live.go
@@ -830,17 +830,71 @@ func isDOMEventName(ev string) bool {
 
 
 // assignSkyIDs walks a tree and stamps every element (not text/raw) with
-// a deterministic structural path id. Having stable IDs means the diff
-// algorithm can address a specific element between renders without us
-// having to rely on React-style key props.
+// a deterministic structural path id. Each non-root segment is
+// `.<index>#<tag>[:<key>]` — the embedded tag means two structurally
+// different subtrees never share an id at the same positional depth
+// (e.g. a signIn `<input>` and a signUp `<fieldset>` at index 3 get
+// different ids), so the diff walker cannot accidentally merge them.
+// When an element carries a stable key (explicit `sky-key` attribute,
+// or implicit from `name` on form-bearing tags), it's appended so
+// keyed list items and named form fields keep identity across reorder.
+// See docs/skylive/input-authority-protocol.md §Sky-id grammar.
 func assignSkyIDs(n *VNode, path string) {
 	if n.Kind != "element" {
 		return
 	}
 	n.SkyID = path
 	for i := range n.Children {
-		assignSkyIDs(&n.Children[i], path+"."+itoa(i))
+		child := &n.Children[i]
+		if child.Kind != "element" {
+			// Text/raw children don't get sky-ids; skip the tag lookup but
+			// keep their positional index as-is so element siblings get the
+			// same index they'd have had under the old scheme.
+			continue
+		}
+		seg := path + "." + itoa(i) + "#" + child.Tag
+		if k := skyIDKey(child); k != "" {
+			seg += ":" + k
+		}
+		assignSkyIDs(child, seg)
 	}
+}
+
+// skyIDKey returns a stable disambiguator for `n`, or "" if none applies.
+// Priority: explicit `sky-key` attribute (set by `Html.keyed`) first,
+// then `name` on form-bearing tags. Any matched value is sanitised to
+// `[A-Za-z0-9_-]+` so it can't corrupt the sky-id grammar.
+func skyIDKey(n *VNode) string {
+	if k, ok := n.Attrs["sky-key"]; ok && k != "" {
+		return sanitiseSkyIDKey(k)
+	}
+	switch n.Tag {
+	case "input", "textarea", "select", "form", "button", "fieldset":
+		if k, ok := n.Attrs["name"]; ok && k != "" {
+			return sanitiseSkyIDKey(k)
+		}
+	}
+	return ""
+}
+
+// sanitiseSkyIDKey replaces anything outside `[A-Za-z0-9_-]` with `_`.
+// Prevents the key from breaking sky-id parsing, CSS selector escaping,
+// or HTML attribute quoting.
+func sanitiseSkyIDKey(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9',
+			r == '-', r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	return b.String()
 }
 
 

--- a/runtime-go/rt/live.go
+++ b/runtime-go/rt/live.go
@@ -977,14 +977,23 @@ type batchedEvent struct {
 // tree is missing (first render) the caller should fall back to a full
 // innerHTML replace — diffTrees returns a single patch with the full
 // new HTML.
-func diffTrees(old, new_ *VNode) []Patch {
+//
+// clientState is an optional per-sky-id map of "what the DOM actually
+// shows right now" reported by the client in its last inputState
+// snapshot. When present and a new_ element is a form field (input /
+// textarea / select) whose value/checked/selected matches the client-
+// reported value, we skip emitting the attr patch — the server
+// re-deriving the user's own typing and shipping it back to them
+// would otherwise race against ongoing keystrokes. See
+// docs/skylive/input-authority-protocol.md §I5.
+func diffTrees(old, new_ *VNode, clientState map[string]string) []Patch {
 	var out []Patch
-	diffNodes(old, new_, &out)
+	diffNodes(old, new_, clientState, &out)
 	return out
 }
 
 
-func diffNodes(old, new_ *VNode, out *[]Patch) {
+func diffNodes(old, new_ *VNode, clientState map[string]string, out *[]Patch) {
 	if old == nil || new_ == nil {
 		return
 	}
@@ -994,10 +1003,22 @@ func diffNodes(old, new_ *VNode, out *[]Patch) {
 		*out = append(*out, Patch{ID: old.SkyID, HTML: &html})
 		return
 	}
-	// Attrs diff
+	// Attrs diff — with client-value alignment for form fields so the
+	// diff can't emit a value attr that reverts the user's typing.
 	var attrChanges map[string]string
+	inputTag := isFormInputTag(new_.Tag)
+	clientVal, hasClient := "", false
+	if inputTag && clientState != nil && new_.SkyID != "" {
+		clientVal, hasClient = clientState[new_.SkyID]
+	}
 	for k, nv := range new_.Attrs {
 		if ov, ok := old.Attrs[k]; !ok || ov != nv {
+			if hasClient && isAuthorityControlledAttr(k) && nv == clientVal {
+				// Server's intended value matches what the DOM actually
+				// shows — no patch needed. Any keystrokes in flight stay
+				// unclobbered; the client already has this value.
+				continue
+			}
 			if attrChanges == nil {
 				attrChanges = map[string]string{}
 			}
@@ -1071,8 +1092,24 @@ func diffNodes(old, new_ *VNode, out *[]Patch) {
 			}
 			return
 		}
-		diffNodes(oc, nc, out)
+		diffNodes(oc, nc, clientState, out)
 	}
+}
+
+// isFormInputTag — tags whose value/checked/selected attrs are
+// directly driven by the user rather than the server's model. A
+// diff targeting these must defer to the client's in-flight typing
+// (client-value alignment in diffNodes).
+func isFormInputTag(t string) bool {
+	return t == "input" || t == "textarea" || t == "select"
+}
+
+// isAuthorityControlledAttr — attrs the user drives directly on
+// input/textarea/select. These get filtered through the client-
+// value alignment check; everything else (class, style, aria-*,
+// disabled, placeholder) diffs normally.
+func isAuthorityControlledAttr(k string) bool {
+	return k == "value" || k == "checked" || k == "selected"
 }
 
 
@@ -1980,7 +2017,7 @@ func (app *liveApp) handleEvent(w http.ResponseWriter, r *http.Request) {
 	// every patch is a full-HTML replace anyway, fall back to the full
 	// innerHTML body.
 	if prev != nil && newTree != nil {
-		patches := diffTrees(prev, newTree)
+		patches := diffTrees(prev, newTree, clientStateFromRequest(req.InputState))
 		if len(patches) > 0 && !patchesAreFullReplace(patches) {
 			writeEventJSON(w, respSeq, req.Seq, respAck, patches)
 			return
@@ -2389,6 +2426,37 @@ function __skyInputsSnapshot() {
 // into client state. seq advances __skyLastAppliedSeq monotonically;
 // ackInputs retires per-input dirty flags so the next snapshot omits
 // caught-up fields.
+// __skyIsDirty — element is "dirty" (user-authoritative) when it is
+// currently focused, has a pending debounced send keyed by its
+// data-sky-hid, or the client has typed past the server's last ack
+// for its sky-id. The patch filter reads this to decide whether to
+// apply value/checked/selected attrs or innerHTML replacements.
+function __skyIsDirty(el) {
+  if (!el || el.nodeType !== 1) return false;
+  if (el === document.activeElement) return true;
+  var hid = el.getAttribute && el.getAttribute("data-sky-hid");
+  if (hid && __skyInputPending[hid]) return true;
+  var sid = el.getAttribute && el.getAttribute("sky-id");
+  if (sid) {
+    var e = __skyInputs[sid];
+    if (e && e.lastSentSeq > e.lastAckedSeq) return true;
+  }
+  return false;
+}
+
+// __skyContainsDirty — true when el or any descendant form field
+// is dirty. Used before innerHTML replacement to decide whether the
+// safe path (raw innerHTML) or the protecting path (morph) applies.
+function __skyContainsDirty(el) {
+  if (__skyIsDirty(el)) return true;
+  if (!el || !el.querySelectorAll) return false;
+  var nodes = el.querySelectorAll("input, textarea, select");
+  for (var i = 0; i < nodes.length; i++) {
+    if (__skyIsDirty(nodes[i])) return true;
+  }
+  return false;
+}
+
 function __skyIngestSeq(seq, ackInputs) {
   if (typeof seq === "number" && seq > __skyLastAppliedSeq) {
     __skyLastAppliedSeq = seq;
@@ -2556,20 +2624,42 @@ function __skySend(msgName, args, handlerId, opts) {
   }).catch(function() { __skyLoaderEnd(); });
 }
 
-// Apply a list of sky-id addressed patches without reflowing the whole
-// document. Preserves input focus + caret naturally, so typing keeps
-// its state through any number of updates.
+// Apply a list of sky-id addressed patches with the input authority
+// filter (I1): value/checked/selected attrs on dirty inputs are
+// dropped so the user's live DOM wins, and innerHTML replacements
+// that would wipe a dirty subtree are re-routed through the morph
+// algorithm (which preserves focused / pending inputs).
 function __skyApplyPatches(patches) {
   for (var i = 0; i < patches.length; i++) {
     var p = patches[i];
     var el = document.querySelector('[sky-id="' + p.id.replace(/"/g, '\\"') + '"]');
     if (!el) continue;
     if (p.text !== undefined && p.text !== null) el.textContent = p.text;
-    if (p.html !== undefined && p.html !== null) el.innerHTML = p.html;
+    if (p.html !== undefined && p.html !== null) {
+      // If any dirty input lives inside this subtree, route the
+      // replacement through __skyMorph — it knows to skip focused /
+      // pending inputs rather than wipe them. Otherwise take the
+      // fast path (native innerHTML assignment).
+      if (__skyContainsDirty(el)) {
+        var tmp = document.createElement("div");
+        tmp.innerHTML = p.html;
+        __skyMorph(el, tmp);
+      } else {
+        el.innerHTML = p.html;
+      }
+    }
     if (p.attrs) {
+      var dirty = __skyIsDirty(el);
       var keys = Object.keys(p.attrs);
       for (var j = 0; j < keys.length; j++) {
         var k = keys[j], v = p.attrs[k];
+        // Authority filter: the user is currently editing this
+        // field, so the server's proposed value/checked/selected
+        // would stomp in-flight keystrokes. Drop them and let the
+        // next event round-trip settle the state.
+        if (dirty && (k === "value" || k === "checked" || k === "selected")) {
+          continue;
+        }
         if (v === "") { el.removeAttribute(k); }
         else {
           el.setAttribute(k, v);
@@ -2631,19 +2721,24 @@ function __skyMorph(oldParent, newParent) {
       continue;
     }
     if (oldNode.nodeType !== newNode.nodeType || oldNode.tagName !== (newNode.tagName || "")) {
-      // Different node type — replace entirely
+      // Different node type — replace entirely UNLESS the old subtree
+      // contains dirty state (focused input, pending debounce, unacked
+      // keystrokes). Stomping it would lose the user's typing; skip
+      // this node and let the next event round-trip reconcile.
+      if (oldNode.nodeType === 1 && __skyContainsDirty(oldNode)) {
+        continue;
+      }
       oldParent.replaceChild(newNode.cloneNode(true), oldNode);
       continue;
     }
-    // Same element type — check if it's a protected input
+    // Same element type — check if it's a protected input. Fold the
+    // __skyIsDirty signals (focus, pending debounce, unacked seq) so
+    // the "don't touch value" skip also fires for inputs the user
+    // edited but hasn't yet blurred.
     var tag = (oldNode.tagName || "").toUpperCase();
     var isInput = tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT";
-    var isFocused = oldNode === document.activeElement;
-    var hid = oldNode.getAttribute ? oldNode.getAttribute("data-sky-hid") : null;
-    var hasPending = hid && __skyInputPending[hid];
-    if (isInput && (isFocused || hasPending)) {
-      // SKIP — user is typing here. Don't touch value or attributes.
-      // Update non-value attributes only (class, style, etc.)
+    if (isInput && __skyIsDirty(oldNode)) {
+      // SKIP — user is typing here. Don't touch value/checked/selected.
       __skyPatchAttrs(oldNode, newNode, true);
       continue;
     }
@@ -2662,18 +2757,23 @@ function __skyMorph(oldParent, newParent) {
 
 function __skyPatchAttrs(oldEl, newEl, skipValue) {
   if (!oldEl.attributes || !newEl.attributes) return;
-  // Remove attrs not in new
+  // Remove attrs not in new. skipValue is the "protected input"
+  // signal — it means don't touch the user-driven attrs on this
+  // element (value, checked, selected all in one bucket).
+  var isUserAuthorityAttr = function(n) {
+    return skipValue && (n === "value" || n === "checked" || n === "selected");
+  };
   var toRemove = [];
   for (var i = 0; i < oldEl.attributes.length; i++) {
     var name = oldEl.attributes[i].name;
-    if (skipValue && name === "value") continue;
+    if (isUserAuthorityAttr(name)) continue;
     if (!newEl.hasAttribute(name)) toRemove.push(name);
   }
   for (var r = 0; r < toRemove.length; r++) oldEl.removeAttribute(toRemove[r]);
   // Set/update attrs from new
   for (var j = 0; j < newEl.attributes.length; j++) {
     var attr = newEl.attributes[j];
-    if (skipValue && attr.name === "value") continue;
+    if (isUserAuthorityAttr(attr.name)) continue;
     if (oldEl.getAttribute(attr.name) !== attr.value) {
       oldEl.setAttribute(attr.name, attr.value);
     }

--- a/runtime-go/rt/live.go
+++ b/runtime-go/rt/live.go
@@ -2479,92 +2479,147 @@ function __skyHandleResponse(seq, ackInputs, applyFn) {
   applyFn();
 }
 
-// ── Focus preservation ───────────────────────────────────────
-// Sky.Live renders whole subtrees via innerHTML replacement (both on
-// JSON patches that carry p.html and on full-HTML navigations). The
-// browser's innerHTML parser is atomic and correct — there's no
-// visibly intermediate state — but it destroys descendants, which
-// loses focus + caret position on any focused input.
+// ── Focus preservation via node identity ────────────────────
+// Sky.Live renders subtrees via innerHTML replacement (both on JSON
+// patches that carry p.html and on full-HTML navigations). Plain
+// innerHTML DESTROYS the focused input element — even though JS is
+// single-threaded, the browser's internal input-method editor (IME),
+// autofill popover, undo stack, composition state, pointer-cursor
+// blink, password manager affordances, and native caret are all
+// tied to the live DOM NODE. Destroying it and recreating a clone
+// with the same .value loses every one of those.
 //
-// Snapshot BEFORE the replacement, restore AFTER: walk back to the
-// same input in the new DOM using its stable identifier (priority:
-// id > sky-id > tag+name), then re-focus and restore selection.
-// When the focused input had in-flight typed text (i.e. is still
-// "dirty" by the authority check), the user's value wins over
-// whatever the server rendered.
+// The correct fix is to preserve node identity through the swap:
+// before the replacement, locate the focused INPUT / TEXTAREA /
+// SELECT, find its placeholder in the new HTML (by sky-id → name),
+// then SPLICE the live node into the new tree in place of the
+// placeholder. Server-side attrs (class, type, placeholder, ...)
+// get copied onto the live node, EXCEPT value/checked/selected —
+// those stay under user authority.
 //
-// This is the same pattern morphdom / Idiomorph use; it's simpler
-// and categorically correct compared to ad-hoc tree walking, which
-// cannot reliably handle structural shifts (e.g. a nav click that
-// changes the whole page) without producing duplicate or orphaned
-// nodes.
-function __skyFocusSnapshot() {
-  var el = document.activeElement;
-  if (!el || el === document.body || el === document.documentElement) return null;
-  var tag = el.tagName;
-  if (tag !== "INPUT" && tag !== "TEXTAREA" && tag !== "SELECT") return null;
-  var snap = {
-    id:             el.id || "",
-    sid:            (el.getAttribute && el.getAttribute("sky-id")) || "",
-    name:           (el.getAttribute && el.getAttribute("name")) || "",
-    tag:            tag,
-    value:          ("value" in el) ? el.value : "",
-    selectionStart: null,
-    selectionEnd:   null,
-    scrollTop:      el.scrollTop || 0,
-  };
+// The live node never gets "destroyed" — it only moves between
+// parents. .value, .selectionStart, IME state, composition buffer,
+// autofill state all survive. Keystrokes in flight land on the
+// same node regardless of where the browser has currently attached
+// it in the DOM tree.
+//
+// Re-focus at the end because replaceChild on a focused element
+// temporarily blurs it (focus isn't a property of the node, it's
+// a property of the document). Selection is lost and must be
+// restored too.
+
+// __skyReplaceHTMLPreservingFocus — the authoritative swap.
+// Drop-in for plain innerHTML assignment that keeps focused input
+// state across the replacement. Used by both __skyPatch (full body)
+// and __skyApplyPatches (p.html patches).
+function __skyReplaceHTMLPreservingFocus(container, newHTML) {
+  // Find the focused input inside this container (if any).
+  var focused = document.activeElement;
+  var focusedInside = focused && focused !== document.body &&
+      container.contains(focused) &&
+      (focused.tagName === "INPUT" ||
+       focused.tagName === "TEXTAREA" ||
+       focused.tagName === "SELECT");
+  if (!focusedInside) {
+    // Fast path — no live input to preserve.
+    container.innerHTML = newHTML;
+    return;
+  }
+
+  // Capture selection + scroll on the LIVE node before any swap
+  // (selection read throws on some input types, so catch it).
+  var selStart = null, selEnd = null;
   try {
-    snap.selectionStart = el.selectionStart;
-    snap.selectionEnd   = el.selectionEnd;
-  } catch (_) { /* some input types (number, email) throw on selection read */ }
-  return snap;
+    selStart = focused.selectionStart;
+    selEnd   = focused.selectionEnd;
+  } catch (_) {}
+  var scrollTop = focused.scrollTop;
+  var focusSid  = focused.getAttribute && focused.getAttribute("sky-id");
+  var focusName = focused.getAttribute && focused.getAttribute("name");
+  var focusTag  = focused.tagName.toLowerCase();
+
+  // Parse the new HTML into a detached element so we can surgery
+  // its tree before attaching it to the DOM.
+  var tmp = document.createElement("div");
+  tmp.innerHTML = newHTML;
+
+  // Locate the placeholder for the live focused input in the new
+  // tree. sky-id first (structural + keyed, uniquely stable), fall
+  // back to tag+name if the structure shifted but the named form
+  // field is still present.
+  var placeholder = null;
+  if (focusSid) {
+    placeholder = tmp.querySelector('[sky-id="' + focusSid.replace(/"/g, '\\"') + '"]');
+  }
+  if (!placeholder && focusName) {
+    placeholder = tmp.querySelector(focusTag + '[name="' + focusName + '"]');
+  }
+
+  if (!placeholder) {
+    // The server's new view unmounts this input. User's typed value
+    // and focus are legitimately gone — honour the server. Fast path.
+    container.innerHTML = newHTML;
+    return;
+  }
+
+  // Copy server-side attrs onto the live input, except the three
+  // the user owns (value / checked / selected). class, type,
+  // placeholder, disabled, aria-*, etc. all propagate.
+  __skyCopyAttrsExceptAuthority(placeholder, focused);
+
+  // Splice: move the live node into the new tree in the placeholder's
+  // slot. replaceChild detaches focused from container (implicit)
+  // and attaches it to tmp.
+  placeholder.parentNode.replaceChild(focused, placeholder);
+
+  // Commit: container's current children (minus the focused input,
+  // which we already moved into tmp) are thrown away; tmp's children
+  // (which include the focused input in its new position) become
+  // container's children.
+  while (container.firstChild) container.removeChild(container.firstChild);
+  while (tmp.firstChild) container.appendChild(tmp.firstChild);
+
+  // Focus was lost during the move (replaceChild + removeChild +
+  // appendChild all drop focus). Restore it on the SAME node — so
+  // .value, IME state, composition buffer, etc. are still the ones
+  // the user was interacting with.
+  try { focused.focus({preventScroll: true}); } catch (_) { focused.focus(); }
+  if (typeof focused.setSelectionRange === "function" &&
+      selStart !== null && selEnd !== null) {
+    try { focused.setSelectionRange(selStart, selEnd); } catch (_) {}
+  }
+  if (scrollTop) focused.scrollTop = scrollTop;
 }
 
-function __skyFocusLocate(snap, scope) {
-  if (!snap) return null;
-  scope = scope || document;
-  var el = null;
-  if (snap.id) {
-    el = document.getElementById(snap.id);
-    if (el) return el;
+// __skyCopyAttrsExceptAuthority — mirror attrs from src onto dst,
+// skipping the three the user drives directly. Removes attrs on
+// dst that aren't in src (same "skip" rule). Used when splicing a
+// live focused input into a server-rendered placeholder.
+function __skyCopyAttrsExceptAuthority(src, dst) {
+  if (!src || !dst || !src.attributes || !dst.attributes) return;
+  var isAuthority = function(n) {
+    return n === "value" || n === "checked" || n === "selected";
+  };
+  // Drop attrs that aren't present in src.
+  var toRemove = [];
+  for (var i = 0; i < dst.attributes.length; i++) {
+    var n = dst.attributes[i].name;
+    if (isAuthority(n)) continue;
+    if (!src.hasAttribute(n)) toRemove.push(n);
   }
-  if (snap.sid) {
-    el = scope.querySelector('[sky-id="' + snap.sid.replace(/"/g, '\\"') + '"]');
-    if (el) return el;
+  for (var r = 0; r < toRemove.length; r++) dst.removeAttribute(toRemove[r]);
+  // Add / update attrs from src.
+  for (var j = 0; j < src.attributes.length; j++) {
+    var a = src.attributes[j];
+    if (isAuthority(a.name)) continue;
+    if (dst.getAttribute(a.name) !== a.value) dst.setAttribute(a.name, a.value);
   }
-  if (snap.name) {
-    el = scope.querySelector(snap.tag.toLowerCase() + '[name="' + snap.name + '"]');
-    if (el) return el;
-  }
-  return null;
 }
 
-function __skyFocusRestore(snap, scope) {
-  if (!snap) return;
-  var el = __skyFocusLocate(snap, scope);
-  if (!el) return;
-  // Preserve the user's in-flight typing: if the snapshot value
-  // differs from what the server just rendered, the user was in
-  // the middle of editing and their DOM wins. Without this, a
-  // concurrent server patch carrying a stale value would clobber
-  // keystrokes the user typed between the patch being generated
-  // and it landing.
-  if (snap.value !== undefined && ("value" in el) && el.value !== snap.value) {
-    el.value = snap.value;
-  }
-  try { el.focus({preventScroll: true}); } catch (_) { el.focus(); }
-  if (typeof el.setSelectionRange === "function" &&
-      snap.selectionStart !== null && snap.selectionEnd !== null) {
-    try { el.setSelectionRange(snap.selectionStart, snap.selectionEnd); } catch (_) {}
-  }
-  if (snap.scrollTop) el.scrollTop = snap.scrollTop;
-}
-
-// __skyPatch: atomic innerHTML replacement for full-body responses
-// (sky-nav click, popstate, full-HTML fallback). The browser's
-// innerHTML parser handles the swap correctly in one step — no
-// intermediate state, no duplicate/orphan nodes from ad-hoc tree
-// walks. Focus + selection are preserved via snapshot/restore.
+// __skyPatch: full-body replacement for sky-nav clicks, popstate,
+// and the server's full-HTML fallback path. Routes through the
+// node-preservation splicer so keystrokes never land on a destroyed
+// DOM node.
 function __skyPatch(t) {
   var root = document.getElementById("sky-root");
   if (!root) return;
@@ -2574,12 +2629,10 @@ function __skyPatch(t) {
   var m = t.match(/<div id="sky-root">([\s\S]*?)<\/div><script>/);
   if (m) t = m[1];
   var scrollX = window.scrollX, scrollY = window.scrollY;
-  var snap = __skyFocusSnapshot();
-  root.innerHTML = t;
+  __skyReplaceHTMLPreservingFocus(root, t);
   window.scrollTo(scrollX, scrollY);
   __skyBindEvents(document);
   __skyRunEvals(root);
-  __skyFocusRestore(snap, root);
 }
 
 // ── Loading indicator ────────────────────────────────────────
@@ -2782,31 +2835,29 @@ function __skySend(msgName, args, handlerId, opts) {
 
 // Apply a list of sky-id addressed patches with input authority (I1):
 // value/checked/selected attrs on dirty inputs are dropped so the
-// user's DOM wins; innerHTML patches use the browser's atomic
-// innerHTML parser (not an ad-hoc tree walk) and focus + selection
-// are preserved via snapshot/restore on either side of the mutation.
-//
-// A single focus snapshot covers the whole batch — if a patch wipes
-// the subtree containing the focused input, the restore locates it
-// by sky-id/name/id in the new DOM and puts the user's typed value
-// back. Between patches the DOM is intermediate but never visibly
-// so (applyPatches runs to completion synchronously before the
-// browser paints).
+// user's DOM wins; innerHTML patches route through
+// __skyReplaceHTMLPreservingFocus which splices the live focused
+// input (same DOM node, same .value, same IME/composition state)
+// through the new HTML so it's never destroyed. Per-attr and
+// textContent updates are fine as-is — they don't regenerate nodes.
 function __skyApplyPatches(patches) {
   if (!patches || patches.length === 0) return;
-  var snap = __skyFocusSnapshot();
   for (var i = 0; i < patches.length; i++) {
     var p = patches[i];
     var el = document.querySelector('[sky-id="' + p.id.replace(/"/g, '\\"') + '"]');
     if (!el) continue;
     if (p.text !== undefined && p.text !== null) {
-      el.textContent = p.text;
+      // textContent on a container that contains the focused input
+      // would also wipe the input (replaces all children with one
+      // text node). Guard the same way as innerHTML.
+      if (__skyContainsFocusedInput(el)) {
+        __skyReplaceHTMLPreservingFocus(el, __skyEscapeHTML(p.text));
+      } else {
+        el.textContent = p.text;
+      }
     }
     if (p.html !== undefined && p.html !== null) {
-      // Atomic innerHTML replacement. Focus/keystroke preservation
-      // handled globally by the surrounding snapshot/restore — no
-      // ad-hoc tree walk required.
-      el.innerHTML = p.html;
+      __skyReplaceHTMLPreservingFocus(el, p.html);
     }
     if (p.attrs) {
       var dirty = __skyIsDirty(el);
@@ -2835,7 +2886,20 @@ function __skyApplyPatches(patches) {
   }
   // Any new sky-* attribute in the patched DOM needs a listener.
   __skyBindEvents(document);
-  __skyFocusRestore(snap);
+}
+
+function __skyContainsFocusedInput(el) {
+  var a = document.activeElement;
+  if (!a || a === document.body) return false;
+  var tag = a.tagName;
+  if (tag !== "INPUT" && tag !== "TEXTAREA" && tag !== "SELECT") return false;
+  return el === a || el.contains(a);
+}
+
+function __skyEscapeHTML(s) {
+  var d = document.createElement("div");
+  d.textContent = s == null ? "" : String(s);
+  return d.innerHTML;
 }
 
 // ── TEA event binding ────────────────────────────────────────

--- a/runtime-go/rt/live.go
+++ b/runtime-go/rt/live.go
@@ -2579,6 +2579,98 @@ document.addEventListener("focusout", function(ev) {
   }
 }, true);
 
+// ── I3: flush on unmount ─────────────────────────────────────
+// Any pending debounce that hasn't fired by the time the user
+// navigates or closes the tab would normally be discarded — the
+// setTimeout is torn down with the page. These handlers flush
+// synchronously so the final keystroke always reaches the server.
+// See docs/skylive/input-authority-protocol.md §I3.
+
+// __skyCollectPendingBatch — snapshot every pending-debounce entry
+// into a batch array, bumping __skyClientSeq per entry so each gets
+// its own order in the batch processed server-side. Clears the
+// pending map as a side effect so the regular debounce callback
+// can't double-fire after a beacon.
+function __skyCollectPendingBatch() {
+  var keys = Object.keys(__skyInputPending);
+  if (keys.length === 0) return null;
+  var batch = [];
+  for (var i = 0; i < keys.length; i++) {
+    var k = keys[i];
+    clearTimeout(__skyInputTimers[k]);
+    var p = __skyInputPending[k];
+    delete __skyInputPending[k];
+    __skyClientSeq++;
+    batch.push({
+      seq: __skyClientSeq,
+      msg: p.msgName || "",
+      args: p.args || [],
+      handlerId: p.hid || ""
+    });
+  }
+  return batch;
+}
+
+// __skyFlushPendingBeacon — POST pending debounces via sendBeacon so
+// the request survives page unload. Single beacon carries the whole
+// batch + the latest inputState snapshot so the server ingests the
+// final DOM values before dispatching. Silent no-op when there's
+// nothing pending or the browser lacks sendBeacon support.
+function __skyFlushPendingBeacon() {
+  if (!navigator || typeof navigator.sendBeacon !== "function") return;
+  var batch = __skyCollectPendingBatch();
+  var snapshot = __skyInputsSnapshot();
+  if (!batch && !snapshot) return;
+  var body = { sessionId: __skySid };
+  if (batch)    body.batch = batch;
+  if (snapshot) body.inputState = snapshot;
+  try {
+    var blob = new Blob([JSON.stringify(body)], {type: "application/json"});
+    navigator.sendBeacon("/_sky/event", blob);
+  } catch (_) {}
+}
+
+// __skyFlushPendingSync — synchronous variant for same-page
+// transitions where sendBeacon is overkill. Calls __skySend for
+// each pending entry; the fetch requests are fire-and-forget and
+// the browser keeps them alive across same-origin navigation.
+function __skyFlushPendingSync() {
+  var batch = __skyCollectPendingBatch();
+  if (!batch) return;
+  for (var i = 0; i < batch.length; i++) {
+    var b = batch[i];
+    __skySend(b.msg, b.args, b.handlerId, {noLoader: true});
+  }
+}
+
+// Capture-phase click listener inside sky-root: before a link click
+// leaves the current page, drain any pending debounce so the final
+// typed value reaches the server in the same origin as the
+// outgoing navigation. Beacon path handles cross-page; sync path
+// handles SPA-style internal routing.
+document.addEventListener("click", function(ev) {
+  var a = ev.target && ev.target.closest && ev.target.closest("a[href]");
+  if (!a) return;
+  var root = document.getElementById("sky-root");
+  if (!root || !root.contains(a)) return;
+  var href = a.getAttribute("href") || "";
+  // External or cross-origin → beacon (browser will tear down the
+  // page, fetch would be cancelled). Same-origin navigation inside
+  // SPA-style routing → sync flush (fetch survives).
+  var isExternal = /^(https?:)?\/\//.test(href) && a.host !== location.host;
+  if (isExternal || href === "") {
+    __skyFlushPendingBeacon();
+  } else {
+    __skyFlushPendingSync();
+  }
+}, true);
+
+// Tab close / navigate away: sendBeacon is the only path that
+// survives the teardown. Listen on both events because iOS Safari
+// + bfcache fire pagehide instead of beforeunload.
+window.addEventListener("beforeunload", __skyFlushPendingBeacon);
+window.addEventListener("pagehide", __skyFlushPendingBeacon);
+
 // ── Core send ────────────────────────────────────────────────
 // Wire format (see docs/skylive/input-authority-protocol.md §Request):
 //   {sessionId, seq, msg, args, handlerId, inputState?}

--- a/runtime-go/rt/live.go
+++ b/runtime-go/rt/live.go
@@ -950,6 +950,28 @@ type Patch struct {
 	Remove bool              `json:"remove,omitempty"`
 }
 
+// inputStateEntry carries the client's current idea of a dirty input.
+// Sent inside eventRequest.InputState so the server can reconcile the
+// rendered tree against the actual DOM before diffing. See
+// docs/skylive/input-authority-protocol.md §Wire format.
+type inputStateEntry struct {
+	Value string `json:"value"`
+	Seq   int64  `json:"seq"`
+}
+
+// batchedEvent is one entry inside eventRequest.Batch (set by
+// navigator.sendBeacon on tab unload). Shape mirrors the top-level
+// single-event fields minus SessionID / InputState, both of which
+// live on the outer envelope so the server ingests them once before
+// processing the batch.
+type batchedEvent struct {
+	Seq       int64             `json:"seq,omitempty"`
+	Msg       string            `json:"msg"`
+	Args      []json.RawMessage `json:"args"`
+	HandlerID string            `json:"handlerId,omitempty"`
+	Value     string            `json:"value,omitempty"`
+}
+
 
 // diffTrees: produce patches to transform `old` into `new_`. If either
 // tree is missing (first render) the caller should fall back to a full
@@ -1195,10 +1217,118 @@ type liveSession struct {
 	prevBody string
 	lastSeen time.Time
 	mu       sync.Mutex
-	// SSE outbound channel: any writer goroutine may push an HTML patch
+	// SSE outbound channel: any writer goroutine may push a frame.
+	// Frame contents are JSON envelopes produced by encodeSSEFrame
+	// (carry seq + ackInputs alongside the body), not raw HTML.
 	sseCh chan string
 	// Cancel function for any active subscription ticker
 	cancelSub chan struct{}
+
+	// Single session-wide monotonic counter for EVERY outgoing frame
+	// (event reply OR SSE patch). Bumped under sess.mu so the value
+	// reflects this session's true mutation order. The client keys its
+	// stale-drop / cross-channel ordering off this number.
+	outSeq int64
+	// Per input sky-id → largest req.InputState[id].Seq observed. Used
+	// to populate response.ackInputs so the client can retire "dirty"
+	// flags once the server has caught up. Stale ids (not present in
+	// prevTree) are evicted on each ack build; see ackInputsForPrevTree.
+	inputSeqs map[string]int64
+}
+
+// nextOutSeq advances and returns the session-wide outgoing seq.
+// MUST be called with sess.mu held.
+func (s *liveSession) nextOutSeq() int64 {
+	s.outSeq++
+	return s.outSeq
+}
+
+// ingestInputState absorbs the client's dirty-input snapshot into
+// sess.inputSeqs, retaining the larger seq per id. No state is lost
+// on concurrent events because every caller holds sess.mu.
+func (s *liveSession) ingestInputState(state map[string]inputStateEntry) {
+	if len(state) == 0 {
+		return
+	}
+	if s.inputSeqs == nil {
+		s.inputSeqs = make(map[string]int64, len(state))
+	}
+	for id, e := range state {
+		if e.Seq > s.inputSeqs[id] {
+			s.inputSeqs[id] = e.Seq
+		}
+	}
+}
+
+// clientStateFromRequest projects inputStateEntry.Value only, for
+// feeding into diffNodes (Step 3 consumer). Step 2 only builds this
+// projection for forward compatibility — no caller uses it yet.
+func clientStateFromRequest(state map[string]inputStateEntry) map[string]string {
+	if len(state) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(state))
+	for id, e := range state {
+		out[id] = e.Value
+	}
+	return out
+}
+
+// ackInputsForPrevTree returns the subset of sess.inputSeqs whose ids
+// still appear in prevTree. Entries whose element has unmounted are
+// evicted as a side effect so the map doesn't accumulate dead ids.
+// Returns nil if nothing to ack (client's __skyInputs map reads nil as
+// "no updates"). MUST be called with sess.mu held.
+func ackInputsForPrevTree(s *liveSession) map[string]int64 {
+	if len(s.inputSeqs) == 0 {
+		return nil
+	}
+	present := map[string]struct{}{}
+	if s.prevTree != nil {
+		var walk func(*VNode)
+		walk = func(n *VNode) {
+			if n.Kind == "element" && n.SkyID != "" {
+				present[n.SkyID] = struct{}{}
+			}
+			for i := range n.Children {
+				walk(&n.Children[i])
+			}
+		}
+		walk(s.prevTree)
+	}
+	out := make(map[string]int64, len(s.inputSeqs))
+	for id, seq := range s.inputSeqs {
+		if _, ok := present[id]; ok {
+			out[id] = seq
+		} else {
+			delete(s.inputSeqs, id)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// encodeSSEFrame serialises a body plus the session-wide seq + ack
+// inputs into a JSON envelope. The consumer-side EventSource listener
+// parses it back out. MUST be called with sess.mu held.
+func encodeSSEFrame(sess *liveSession, body string) string {
+	frame := map[string]any{
+		"seq":  sess.nextOutSeq(),
+		"body": body,
+	}
+	if ack := ackInputsForPrevTree(sess); ack != nil {
+		frame["ackInputs"] = ack
+	}
+	b, err := json.Marshal(frame)
+	if err != nil {
+		// Marshalling a map of primitives can't fail in practice, but
+		// fall back to a bare seq+body frame just in case so the
+		// channel never carries a garbage string.
+		return fmt.Sprintf(`{"seq":%d,"body":%q}`, sess.outSeq, body)
+	}
+	return string(b)
 }
 
 type liveApp struct {
@@ -1706,21 +1836,22 @@ func (app *liveApp) handleConfig(w http.ResponseWriter, r *http.Request) {
 
 
 func (app *liveApp) handleEvent(w http.ResponseWriter, r *http.Request) {
-	// TEA wire format (legacy-compatible):
-	//   * msg       — constructor name (e.g. "Increment", "UpdateEmail")
-	//   * args      — positional args for the constructor (strings, bools,
-	//                 numbers, JSON-encoded record for form submits)
-	//   * handlerId — <sky-id>.<event> fallback used when msg is "" or
-	//                 the constructor can't be found by name
-	//   * sessionId — per-client session key
+	// TEA wire format — see docs/skylive/input-authority-protocol.md
+	// §Wire format. Fields added in the v0.9.3+ protocol upgrade are
+	// all optional: old clients keep working, new clients opt into
+	// sequenced authority by populating seq + inputState + batch.
 	var req struct {
-		SessionID string            `json:"sessionId"`
-		Msg       string            `json:"msg"`
-		Args      []json.RawMessage `json:"args"`
-		HandlerID string            `json:"handlerId"`
-		Value     string            `json:"value"` // legacy fallback
+		SessionID  string                     `json:"sessionId"`
+		Msg        string                     `json:"msg"`
+		Args       []json.RawMessage          `json:"args"`
+		HandlerID  string                     `json:"handlerId"`
+		Value      string                     `json:"value"` // legacy fallback
+		Seq        int64                      `json:"seq,omitempty"`
+		InputState map[string]inputStateEntry `json:"inputState,omitempty"`
+		Batch      []batchedEvent             `json:"batch,omitempty"`
 	}
 	// Bound event payload to 1 MiB — these are tiny JSON envelopes.
+	// Batch events under sendBeacon are equally small (one per input).
 	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
@@ -1741,6 +1872,23 @@ func (app *liveApp) handleEvent(w http.ResponseWriter, r *http.Request) {
 	// Different sessions proceed in parallel.
 	app.locker.Lock(req.SessionID)
 	defer app.locker.Unlock(req.SessionID)
+
+	// Batch path — sendBeacon flushes a sequence of pending-debounce
+	// events on tab unload. Each entry is processed as if it had
+	// arrived on its own, under the single sess.mu held by each
+	// dispatch. The outer InputState is ingested once before the
+	// batch runs so all dispatches see the final DOM values.
+	if len(req.Batch) > 0 {
+		sess.mu.Lock()
+		sess.ingestInputState(req.InputState)
+		sess.mu.Unlock()
+		for _, ev := range req.Batch {
+			app.dispatchBatched(sess, ev)
+		}
+		// sendBeacon can't read the response — 204 just signals OK.
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
 
 	sess.mu.Lock()
 	// Handler maps aren't persisted across encode/decode (closures don't
@@ -1798,10 +1946,21 @@ func (app *liveApp) handleEvent(w http.ResponseWriter, r *http.Request) {
 	if _, isSkyAdt := msg.(SkyADT); !isSkyAdt {
 		msg = applyMsgArgs(msg, req.Args, req.Value)
 	}
+	// Reconcile the client's view of dirty inputs into sess.inputSeqs
+	// before dispatch. Step 3 activates the diff-level client-value
+	// alignment that uses this state; Step 2 only records it so the
+	// ackInputs response field reflects what the server has observed.
+	sess.ingestInputState(req.InputState)
 	// Keep a reference to the previous tree BEFORE dispatch mutates it.
 	prev := sess.prevTree
 	body2 := app.dispatch(sess, msg)
 	newTree := sess.prevTree
+	// Capture outgoing protocol metadata before releasing the lock so
+	// the seq reflects this session's true mutation order. Bumped once
+	// per reply (including no-op replies) so the client's cross-channel
+	// ordering works uniformly.
+	respSeq := sess.nextOutSeq()
+	respAck := ackInputsForPrevTree(sess)
 	sess.mu.Unlock()
 	// Persist the mutated session so DB-backed stores see the new
 	// state. Memory store is a no-op on Set for an already-tracked sid.
@@ -1812,8 +1971,7 @@ func (app *liveApp) handleEvent(w http.ResponseWriter, r *http.Request) {
 	// client acknowledges the event without the server shipping a
 	// redundant HTML frame.
 	if body2 == "" {
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{"patches": []any{}})
+		writeEventJSON(w, respSeq, req.Seq, respAck, nil)
 		return
 	}
 	// When we have a prior tree we can reply with a minimal patch set
@@ -1824,13 +1982,113 @@ func (app *liveApp) handleEvent(w http.ResponseWriter, r *http.Request) {
 	if prev != nil && newTree != nil {
 		patches := diffTrees(prev, newTree)
 		if len(patches) > 0 && !patchesAreFullReplace(patches) {
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]any{"patches": patches})
+			writeEventJSON(w, respSeq, req.Seq, respAck, patches)
 			return
 		}
 	}
-	w.Header().Set("Content-Type", "text/html")
-	w.Write([]byte(body2))
+	writeEventHTML(w, respSeq, respAck, body2)
+}
+
+// writeEventJSON emits the structured /_sky/event response envelope:
+// {seq, respondingTo, ackInputs, patches}. patches may be nil/empty.
+// The three protocol fields survive alongside the legacy `patches` key
+// so pre-upgrade clients continue to deserialise cleanly.
+func writeEventJSON(w http.ResponseWriter, seq, respondingTo int64, ackInputs map[string]int64, patches []Patch) {
+	w.Header().Set("Content-Type", "application/json")
+	payload := map[string]any{
+		"seq":     seq,
+		"patches": patches,
+	}
+	if patches == nil {
+		payload["patches"] = []any{}
+	}
+	if respondingTo > 0 {
+		payload["respondingTo"] = respondingTo
+	}
+	if ackInputs != nil {
+		payload["ackInputs"] = ackInputs
+	}
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+// writeEventHTML emits the full-body fallback. Protocol metadata rides
+// in headers so the client can update its seq bookkeeping without
+// parsing the HTML — X-Sky-Seq (single counter) and X-Sky-Ack-Inputs
+// (JSON-encoded map, absent when empty).
+func writeEventHTML(w http.ResponseWriter, seq int64, ackInputs map[string]int64, body string) {
+	h := w.Header()
+	h.Set("Content-Type", "text/html")
+	h.Set("X-Sky-Seq", strconv.FormatInt(seq, 10))
+	if ackInputs != nil {
+		if b, err := json.Marshal(ackInputs); err == nil {
+			h.Set("X-Sky-Ack-Inputs", string(b))
+		}
+	}
+	_, _ = w.Write([]byte(body))
+}
+
+// dispatchBatched processes one entry from eventRequest.Batch. The
+// locking discipline and handler-lookup rules mirror the single-event
+// path; the only difference is no response is produced (sendBeacon
+// discards it), and any SSE side effects flow through sess.sseCh.
+// Failures are swallowed — a batch arrives on tab-unload so there's
+// no user-visible place to surface them.
+func (app *liveApp) dispatchBatched(sess *liveSession, ev batchedEvent) {
+	sess.mu.Lock()
+	if len(sess.handlers) == 0 && sess.model != nil {
+		sess.handlers = map[string]any{}
+		vn := sky_call(app.view, sess.model).(VNode)
+		assignSkyIDs(&vn, "r")
+		_ = renderVNode(vn, sess.handlers)
+		sess.prevTree = &vn
+	}
+	msg, ok := sess.handlers[ev.HandlerID]
+	if !ok && ev.Msg != "" && ev.HandlerID == "" {
+		tag := -1
+		if t, found := LookupAdtTag(ev.Msg); found {
+			tag = t
+		} else {
+			app.msgTagsMu.Lock()
+			if t2, ok2 := app.msgTags[ev.Msg]; ok2 {
+				tag = t2
+			}
+			app.msgTagsMu.Unlock()
+		}
+		var fields []any
+		for _, raw := range ev.Args {
+			var v any
+			if err := json.Unmarshal(raw, &v); err == nil {
+				fields = append(fields, v)
+			}
+		}
+		msg = SkyADT{Tag: tag, SkyName: ev.Msg, Fields: fields}
+		ok = true
+	}
+	if !ok {
+		sess.mu.Unlock()
+		return
+	}
+	if _, isSkyAdt := msg.(SkyADT); !isSkyAdt {
+		msg = applyMsgArgs(msg, ev.Args, ev.Value)
+	}
+	body2 := app.dispatch(sess, msg)
+	// Bump outSeq once per batched entry so any SSE frame pushed as a
+	// side effect carries a unique seq. Each dispatch that mutates the
+	// view is its own observable event.
+	var frame string
+	if body2 != "" {
+		frame = encodeSSEFrame(sess, body2)
+	}
+	sess.mu.Unlock()
+	// Push to other subscribers (other tabs, SSE listeners). The
+	// originating tab has already unloaded so the frame is for anyone
+	// else observing the session.
+	if frame != "" {
+		select {
+		case sess.sseCh <- frame:
+		default:
+		}
+	}
 }
 
 
@@ -1958,17 +2216,22 @@ func (app *liveApp) runPerform(sess *liveSession, task any, toMsg any) {
 	result := sky_call(task, nil)
 	// toMsg : Result err a -> Msg — convert result to Msg
 	msg := sky_call(toMsg, result)
-	// Push update through locked dispatch
+	// Push update through locked dispatch, then emit an SSE frame
+	// carrying the session-wide seq. Keeping frame construction under
+	// the same lock as dispatch means the seq reflects the actual
+	// mutation order even when other goroutines dispatch concurrently.
 	sess.mu.Lock()
 	body := app.dispatch(sess, msg)
+	var frame string
+	if body != "" {
+		frame = encodeSSEFrame(sess, body)
+	}
 	sess.mu.Unlock()
-	// Empty body = dispatch determined the view is unchanged.
-	if body == "" {
+	if frame == "" {
 		return
 	}
-	// Notify SSE listeners
 	select {
-	case sess.sseCh <- body:
+	case sess.sseCh <- frame:
 	default:
 		// channel full, drop
 	}
@@ -2009,15 +2272,19 @@ func (app *liveApp) setupSubscriptions(sess *liveSession) {
 					msg = sky_call(toMsg, t.UnixMilli())
 				}
 				body := app.dispatch(sess, msg)
+				var frame string
+				if body != "" {
+					frame = encodeSSEFrame(sess, body)
+				}
 				sess.mu.Unlock()
 				// Suppress SSE write when the tick didn't change
 				// the view — prevents Time.every from pushing an
 				// identical HTML frame every interval.
-				if body == "" {
+				if frame == "" {
 					continue
 				}
 				select {
-				case sess.sseCh <- body:
+				case sess.sseCh <- frame:
 				default:
 				}
 			}
@@ -2081,6 +2348,61 @@ func sessionID(r *http.Request, w http.ResponseWriter) string {
 func liveJS(sid string) string {
 	return fmt.Sprintf(`
 var __skySid = %q;
+
+// ── Input authority protocol state ───────────────────────────
+// See docs/skylive/input-authority-protocol.md §Client state.
+// Step 2 populates these counters + per-input table on every send
+// and response; Step 3 activates the patch filter that reads them;
+// Step 4 activates the stale-drop test against __skyLastAppliedSeq.
+var __skyClientSeq = 0;       // monotonic, client-owned; bumped on every __skySend
+var __skyLastAppliedSeq = 0;  // server-owned; largest seq already applied
+var __skyInputs = {};         // sky-id → InputEntry (populated by __skyBindOne)
+
+function __skyInputEntry(sid) {
+  var e = __skyInputs[sid];
+  if (!e) {
+    e = __skyInputs[sid] = {
+      liveValue: "", lastSentSeq: 0, lastAckedSeq: 0,
+      pendingDebounceId: null, pendingSend: null
+    };
+  }
+  return e;
+}
+
+// __skyInputsSnapshot — dirty-input projection bundled into every
+// outgoing event. Only entries whose user-typed value is newer than
+// the server's latest ack are included, so the wire stays compact
+// when the client and server agree.
+function __skyInputsSnapshot() {
+  var out = null;
+  var ids = Object.keys(__skyInputs);
+  for (var i = 0; i < ids.length; i++) {
+    var e = __skyInputs[ids[i]];
+    if (e.lastSentSeq <= e.lastAckedSeq) continue;
+    if (!out) out = {};
+    out[ids[i]] = {value: e.liveValue, seq: e.lastSentSeq};
+  }
+  return out;
+}
+
+// __skyIngestSeq — fold a response or SSE frame's {seq, ackInputs}
+// into client state. seq advances __skyLastAppliedSeq monotonically;
+// ackInputs retires per-input dirty flags so the next snapshot omits
+// caught-up fields.
+function __skyIngestSeq(seq, ackInputs) {
+  if (typeof seq === "number" && seq > __skyLastAppliedSeq) {
+    __skyLastAppliedSeq = seq;
+  }
+  if (ackInputs) {
+    var ids = Object.keys(ackInputs);
+    for (var i = 0; i < ids.length; i++) {
+      var e = __skyInputs[ids[i]];
+      if (!e) continue;
+      var n = ackInputs[ids[i]];
+      if (n > e.lastAckedSeq) e.lastAckedSeq = n;
+    }
+  }
+}
 
 // __skyPatch: replace sky-root's content with the fragment in `+"`"+`t`+"`"+`,
 // preserving the active element (focus + caret/selection) and scroll
@@ -2176,33 +2498,59 @@ document.addEventListener("focusout", function(ev) {
 }, true);
 
 // ── Core send ────────────────────────────────────────────────
-// Wire format: {sid, msg: "MsgName", args: [...], handlerId: "..."}.
-//   * msg + args drive the server's TEA update — the legacy protocol.
-//   * handlerId is a stable-by-render tag used as a fallback when the
-//     server can't locate the Msg constructor by name (anonymous ADTs).
+// Wire format (see docs/skylive/input-authority-protocol.md §Request):
+//   {sessionId, seq, msg, args, handlerId, inputState?}
+//   * seq is client-monotonic — server uses it to match responses to
+//     the inputState snapshot that produced them.
+//   * inputState carries the user's current DOM values for every
+//     dirty input so the server's diff can align against reality
+//     before emitting patches.
 function __skySend(msgName, args, handlerId, opts) {
   opts = opts || {};
   if (!opts.noLoader) __skyLoaderStart();
+  __skyClientSeq++;
+  var mySeq = __skyClientSeq;
+  // Stamp every currently-dirty input with this seq. The server's
+  // ack (for a future response) will clear them back to parity.
+  var dirtyIds = Object.keys(__skyInputs);
+  for (var di = 0; di < dirtyIds.length; di++) {
+    var de = __skyInputs[dirtyIds[di]];
+    if (de.liveValue !== "" || de.pendingDebounceId !== null) {
+      de.lastSentSeq = mySeq;
+    }
+  }
+  var snapshot = __skyInputsSnapshot();
+  var body = {
+    sessionId: __skySid,
+    seq: mySeq,
+    msg: msgName || "",
+    args: args || [],
+    handlerId: handlerId || ""
+  };
+  if (snapshot) body.inputState = snapshot;
   fetch("/_sky/event", {
     method: "POST",
     headers: {"Content-Type":"application/json"},
-    body: JSON.stringify({
-      sessionId: __skySid,
-      msg: msgName || "",
-      args: args || [],
-      handlerId: handlerId || ""
-    }),
+    body: JSON.stringify(body),
     credentials: "same-origin"
   }).then(function(r){
     var ct = r.headers.get("Content-Type") || "";
     if (ct.indexOf("application/json") >= 0) {
       return r.json().then(function(data) {
         __skyLoaderEnd();
-        if (data && data.patches) __skyApplyPatches(data.patches);
+        if (!data) return;
+        __skyIngestSeq(data.seq, data.ackInputs);
+        if (data.patches) __skyApplyPatches(data.patches);
       });
     }
     return r.text().then(function(t) {
       __skyLoaderEnd();
+      var seqStr = r.headers.get("X-Sky-Seq");
+      var seq = seqStr ? parseInt(seqStr, 10) : 0;
+      var ackRaw = r.headers.get("X-Sky-Ack-Inputs");
+      var ack = null;
+      if (ackRaw) { try { ack = JSON.parse(ackRaw); } catch(_) {} }
+      __skyIngestSeq(seq, ack);
       __skyPatch(t);
     });
   }).catch(function() { __skyLoaderEnd(); });
@@ -2362,6 +2710,14 @@ function __skyBindOne(root, eventName) {
       if (ev.type === "submit") ev.preventDefault();
       var args = __skyExtractArgs(ev);
       if (ev.type === "input") {
+        // Track live value against sky-id so the snapshot bundled in
+        // the next __skySend reflects the user's actual DOM state,
+        // and so Step 3's patch filter can recognise dirty inputs.
+        var sid = target.getAttribute("sky-id");
+        if (sid) {
+          var e = __skyInputEntry(sid);
+          e.liveValue = args && args.length > 0 ? String(args[0]) : "";
+        }
         __skyDebouncedSend(msgName, args, hid, 150);
         return;
       }
@@ -2487,11 +2843,20 @@ window.addEventListener("popstate", function() {
     .then(function(r) { return r.text(); })
     .then(__skyPatch);
 });
-// Server-Sent Events: push updates from server (subscriptions, Cmd.perform results)
+// Server-Sent Events: push updates from server (subscriptions, Cmd.perform results).
+// Frame envelope since v0.9.3+: {seq, body, ackInputs?}. Falls back to
+// treating e.data as a raw HTML body when JSON parsing fails, so a
+// mixed-version rollout doesn't break the open-SSE connection.
 var __skySSE = new EventSource("/_sky/sse");
 __skySSE.addEventListener("patch", function(e) {
-  var html = e.data.replace(/\\n/g, "\n");
-  __skyPatch(html);
+  var frame;
+  try { frame = JSON.parse(e.data); } catch (_) {
+    return __skyPatch(e.data.replace(/\\n/g, "\n"));
+  }
+  if (frame && typeof frame === "object") {
+    __skyIngestSeq(frame.seq, frame.ackInputs);
+    if (frame.body) __skyPatch(frame.body.replace(/\\n/g, "\n"));
+  }
 });
 
 // ── Init ─────────────────────────────────────────────────────

--- a/runtime-go/rt/live.go
+++ b/runtime-go/rt/live.go
@@ -2472,6 +2472,20 @@ function __skyIngestSeq(seq, ackInputs) {
   }
 }
 
+// __skyHandleResponse — gate DOM-mutating work behind the monotonic
+// seq check (Step 4 / I2). An out-of-order or replayed frame with
+// seq ≤ __skyLastAppliedSeq is dropped entirely: a newer frame has
+// already landed with a later view, and applying the stale payload
+// would regress the DOM. Legacy frames that omit seq (or report 0)
+// always apply — pre-upgrade servers keep working.
+function __skyHandleResponse(seq, ackInputs, applyFn) {
+  if (typeof seq === "number" && seq > 0 && seq <= __skyLastAppliedSeq) {
+    return; // stale — a newer frame already landed
+  }
+  __skyIngestSeq(seq, ackInputs);
+  applyFn();
+}
+
 // __skyPatch: replace sky-root's content with the fragment in `+"`"+`t`+"`"+`,
 // preserving the active element (focus + caret/selection) and scroll
 // position across the swap. Without this, typing in an input that
@@ -2607,8 +2621,9 @@ function __skySend(msgName, args, handlerId, opts) {
       return r.json().then(function(data) {
         __skyLoaderEnd();
         if (!data) return;
-        __skyIngestSeq(data.seq, data.ackInputs);
-        if (data.patches) __skyApplyPatches(data.patches);
+        __skyHandleResponse(data.seq, data.ackInputs, function() {
+          if (data.patches) __skyApplyPatches(data.patches);
+        });
       });
     }
     return r.text().then(function(t) {
@@ -2618,8 +2633,7 @@ function __skySend(msgName, args, handlerId, opts) {
       var ackRaw = r.headers.get("X-Sky-Ack-Inputs");
       var ack = null;
       if (ackRaw) { try { ack = JSON.parse(ackRaw); } catch(_) {} }
-      __skyIngestSeq(seq, ack);
-      __skyPatch(t);
+      __skyHandleResponse(seq, ack, function() { __skyPatch(t); });
     });
   }).catch(function() { __skyLoaderEnd(); });
 }
@@ -2951,11 +2965,13 @@ var __skySSE = new EventSource("/_sky/sse");
 __skySSE.addEventListener("patch", function(e) {
   var frame;
   try { frame = JSON.parse(e.data); } catch (_) {
+    // Legacy frame (pre-v0.9.3 server) — raw HTML, no seq to gate on.
     return __skyPatch(e.data.replace(/\\n/g, "\n"));
   }
   if (frame && typeof frame === "object") {
-    __skyIngestSeq(frame.seq, frame.ackInputs);
-    if (frame.body) __skyPatch(frame.body.replace(/\\n/g, "\n"));
+    __skyHandleResponse(frame.seq, frame.ackInputs, function() {
+      if (frame.body) __skyPatch(frame.body.replace(/\\n/g, "\n"));
+    });
   }
 });
 

--- a/runtime-go/rt/live_adversarial_test.go
+++ b/runtime-go/rt/live_adversarial_test.go
@@ -1,0 +1,240 @@
+package rt
+
+// Adversarial scenarios beyond the per-step tests. Covers the cross-
+// cutting properties of the input authority protocol that only show
+// up when multiple channels interact: two concurrent events, deep
+// tree alignment, seq ordering across dispatch paths. Browser-driven
+// tests (focus preservation, sendBeacon flush, stale-drop) land in
+// a follow-up; these pin the server invariants they rely on.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestConcurrentEventsSerialise — two /_sky/event requests fired
+// concurrently against the same session MUST produce strictly
+// ordered seq values. sess.mu serialises dispatch, so nextOutSeq
+// runs under the lock per request; any interleaving that produces
+// duplicate or out-of-order seqs would mean the lock is being
+// released too early.
+func TestConcurrentEventsSerialise(t *testing.T) {
+	viewFn := func(model any) any {
+		return velement("button",
+			[]any{eventPair{name: "click", msg: "Click"}},
+			[]any{vtext("go")})
+	}
+	app := &liveApp{
+		update: func(msg, model any) any {
+			// Flip the model slightly so the view body differs from
+			// render to render; otherwise the no-op suppression would
+			// short-circuit and the test would only exercise one path.
+			if s, ok := model.(string); ok {
+				return SkyTuple2{V0: s + ".", V1: cmdT{kind: "none"}}
+			}
+			return SkyTuple2{V0: "x", V1: cmdT{kind: "none"}}
+		},
+		view:    viewFn,
+		store:   newMemoryStore(30 * time.Minute),
+		locker:  newSessionLocker(),
+		msgTags: map[string]int{},
+	}
+	init := sky_call(viewFn, "seed").(VNode)
+	assignSkyIDs(&init, "r")
+	handlers := map[string]any{}
+	_ = renderVNode(init, handlers)
+	sess := &liveSession{
+		model:     "seed",
+		handlers:  handlers,
+		prevTree:  &init,
+		sseCh:     make(chan string, 64),
+		cancelSub: make(chan struct{}),
+	}
+	app.store.Set("sid-conc", sess)
+	clickHid := init.SkyID + ".click"
+
+	const N = 20
+	seqs := make([]int64, N)
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			reqBody := `{"sessionId":"sid-conc","seq":` + itoa(i+1) +
+				`,"msg":"","args":[],"handlerId":"` + clickHid + `"}`
+			req := httptest.NewRequest(http.MethodPost, "/_sky/event",
+				strings.NewReader(reqBody))
+			req.Header.Set("Content-Type", "application/json")
+			rr := httptest.NewRecorder()
+			app.handleEvent(rr, req)
+
+			// Parse the seq out of whichever response format landed.
+			if strings.HasPrefix(rr.Header().Get("Content-Type"), "application/json") {
+				var env map[string]any
+				_ = json.Unmarshal(rr.Body.Bytes(), &env)
+				if v, ok := env["seq"].(float64); ok {
+					seqs[i] = int64(v)
+				}
+			} else {
+				if s := rr.Header().Get("X-Sky-Seq"); s != "" {
+					var n int64
+					_ = json.Unmarshal([]byte(s), &n)
+					seqs[i] = n
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Every seq must be unique and in range [1, N]. Order of arrival
+	// isn't guaranteed — we just assert no collisions and strict
+	// coverage of the range.
+	seen := map[int64]bool{}
+	for _, s := range seqs {
+		if s == 0 {
+			t.Errorf("some requests got zero seq: %v", seqs)
+			continue
+		}
+		if seen[s] {
+			t.Errorf("duplicate seq %d emitted: %v", s, seqs)
+		}
+		seen[s] = true
+	}
+	if len(seen) != N {
+		t.Errorf("got %d distinct seqs, want %d (missing coverage)", len(seen), N)
+	}
+}
+
+// TestSeqCountsCoverEveryOutgoingFrame — encodeSSEFrame (used by
+// subscription ticks and Cmd.perform) and writeEventJSON/HTML (used
+// by event replies) MUST bump the same counter. If a Cmd completes
+// between two events, its SSE frame gets a seq that sits between the
+// two event reply seqs — the client applies in that order and the
+// DOM reflects the server's actual mutation order.
+func TestSeqCountsCoverEveryOutgoingFrame(t *testing.T) {
+	sess := &liveSession{}
+	a := sess.nextOutSeq()  // simulate event reply 1
+	sseFrame := encodeSSEFrame(sess, "<p>sub</p>") // subscription tick
+	b := sess.nextOutSeq()  // simulate event reply 2
+
+	var env map[string]any
+	if err := json.Unmarshal([]byte(sseFrame), &env); err != nil {
+		t.Fatalf("frame invalid: %v", err)
+	}
+	sseSeq := int64(env["seq"].(float64))
+	if a != 1 || sseSeq != 2 || b != 3 {
+		t.Errorf("outgoing seqs not interleaved monotonically: event=%d, sse=%d, event=%d",
+			a, sseSeq, b)
+	}
+}
+
+// TestDiffAlignsInsideNestedForm — the clientState alignment works
+// at arbitrary depth. A deeply-nested form's email input still gets
+// its value patch suppressed when the client's reported value
+// matches the server's intent.
+func TestDiffAlignsInsideNestedForm(t *testing.T) {
+	mk := func(val string) VNode {
+		return elWithAttrs("div", nil,
+			elWithAttrs("main", nil,
+				elWithAttrs("form", nil,
+					elWithAttrs("fieldset", nil,
+						elWithAttrs("input", map[string]string{
+							"name":  "email",
+							"value": val,
+						}),
+					),
+				),
+			),
+		)
+	}
+	old := mk("stale@old.com")
+	new_ := mk("a@b.com")
+	assignSkyIDs(&old, "r")
+	assignSkyIDs(&new_, "r")
+
+	// Dig to the email input inside the nested structure.
+	input := &new_.Children[0].Children[0].Children[0].Children[0]
+	if input.Tag != "input" {
+		t.Fatalf("test tree shape wrong — expected input at deepest leaf, got %q", input.Tag)
+	}
+	emailID := input.SkyID
+
+	patches := diffTrees(&old, &new_, map[string]string{
+		emailID: "a@b.com", // client says DOM already shows this
+	})
+	for _, p := range patches {
+		if p.ID == emailID && p.Attrs != nil {
+			if _, ok := p.Attrs["value"]; ok {
+				t.Errorf("nested form: value patch must be suppressed when client matches, got %+v", p.Attrs)
+			}
+		}
+	}
+}
+
+// TestLegacyFieldsPreserved — request envelope must accept and dispatch
+// old-style events that don't carry seq / inputState / batch. Ensures
+// the protocol bump is backward-compatible for servers running
+// alongside pre-upgrade clients.
+func TestLegacyFieldsPreserved(t *testing.T) {
+	viewFn := func(model any) any {
+		return velement("button",
+			[]any{eventPair{name: "click", msg: "Click"}},
+			[]any{vtext("x")})
+	}
+	app := &liveApp{
+		update: func(msg, model any) any {
+			if s, ok := model.(string); ok {
+				return SkyTuple2{V0: s + "!", V1: cmdT{kind: "none"}}
+			}
+			return SkyTuple2{V0: "x", V1: cmdT{kind: "none"}}
+		},
+		view:    viewFn,
+		store:   newMemoryStore(30 * time.Minute),
+		locker:  newSessionLocker(),
+		msgTags: map[string]int{},
+	}
+	init := sky_call(viewFn, "seed").(VNode)
+	assignSkyIDs(&init, "r")
+	handlers := map[string]any{}
+	_ = renderVNode(init, handlers)
+	sess := &liveSession{
+		model:     "seed",
+		handlers:  handlers,
+		prevTree:  &init,
+		sseCh:     make(chan string, 1),
+		cancelSub: make(chan struct{}),
+	}
+	app.store.Set("sid-legacy", sess)
+	clickHid := init.SkyID + ".click"
+
+	// Pre-upgrade payload — no seq, no inputState, no batch.
+	reqBody := `{"sessionId":"sid-legacy","msg":"","args":[],"handlerId":"` +
+		clickHid + `"}`
+	req := httptest.NewRequest(http.MethodPost, "/_sky/event",
+		strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	app.handleEvent(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("legacy request rejected: status %d, body %s", rr.Code, rr.Body.String())
+	}
+	// The response still carries a seq (server advances outSeq for
+	// every reply), but respondingTo must be omitted since the client
+	// didn't supply one.
+	if strings.HasPrefix(rr.Header().Get("Content-Type"), "application/json") {
+		var env map[string]any
+		_ = json.Unmarshal(rr.Body.Bytes(), &env)
+		if _, present := env["respondingTo"]; present {
+			t.Errorf("respondingTo must be absent for legacy client: %+v", env)
+		}
+		if env["seq"] == nil {
+			t.Errorf("seq still required in response envelope: %+v", env)
+		}
+	}
+}

--- a/runtime-go/rt/live_authority_test.go
+++ b/runtime-go/rt/live_authority_test.go
@@ -1,0 +1,168 @@
+package rt
+
+// Step 3 — I1 client authority for dirty inputs. Server-side tests
+// verify diffNodes honours the clientState hint: when the new model's
+// intended value for a form field matches what the client says the
+// DOM already shows, no value patch is emitted (the server would
+// just round-trip the user's own typing and race against keystrokes).
+// When the new model genuinely disagrees (form reset, admin edit),
+// the patch IS emitted and Step 3's client-side filter decides at
+// apply time whether to take effect.
+
+import (
+	"testing"
+)
+
+// attr on an element via helper — avoids the velement pipeline,
+// which needs more ceremony for attributes.
+func elWithAttrs(tag string, kv map[string]string, children ...VNode) VNode {
+	return VNode{
+		Kind:     "element",
+		Tag:      tag,
+		Attrs:    kv,
+		Events:   map[string]any{},
+		Children: children,
+	}
+}
+
+// TestDiffAlignsToClientValue — server's new intended value matches
+// client's reported DOM value. Diff must NOT emit a value patch.
+func TestDiffAlignsToClientValue(t *testing.T) {
+	old := elWithAttrs("form", nil,
+		elWithAttrs("input", map[string]string{
+			"name":  "email",
+			"value": "stale@old.com",
+		}),
+	)
+	new_ := elWithAttrs("form", nil,
+		elWithAttrs("input", map[string]string{
+			"name":  "email",
+			"value": "a@b.com",
+		}),
+	)
+	assignSkyIDs(&old, "r")
+	assignSkyIDs(&new_, "r")
+	emailID := new_.Children[0].SkyID
+
+	// Client has already typed a@b.com — server's new value agrees.
+	patches := diffTrees(&old, &new_, map[string]string{
+		emailID: "a@b.com",
+	})
+	for _, p := range patches {
+		if p.ID == emailID && p.Attrs != nil {
+			if _, ok := p.Attrs["value"]; ok {
+				t.Errorf("diff emitted a value patch despite client-server agreement: %+v", p.Attrs)
+			}
+		}
+	}
+}
+
+// TestDiffOverridesClientWhenServerDisagrees — update decided the
+// model's email should be "Bob" (e.g. admin edit). Diff MUST emit the
+// patch so the browser hears about the change; the client-side
+// filter in Step 3 decides whether to apply based on focus state.
+func TestDiffOverridesClientWhenServerDisagrees(t *testing.T) {
+	old := elWithAttrs("form", nil,
+		elWithAttrs("input", map[string]string{
+			"name":  "email",
+			"value": "stale@old.com",
+		}),
+	)
+	new_ := elWithAttrs("form", nil,
+		elWithAttrs("input", map[string]string{
+			"name":  "email",
+			"value": "bob@example.com",
+		}),
+	)
+	assignSkyIDs(&old, "r")
+	assignSkyIDs(&new_, "r")
+	emailID := new_.Children[0].SkyID
+
+	// Client says they've typed "draft@typing.com" — server's new
+	// model says "bob@example.com". Disagreement → must patch.
+	patches := diffTrees(&old, &new_, map[string]string{
+		emailID: "draft@typing.com",
+	})
+	found := false
+	for _, p := range patches {
+		if p.ID == emailID && p.Attrs != nil {
+			if v, ok := p.Attrs["value"]; ok && v == "bob@example.com" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Errorf("diff must emit value patch when server disagrees with client; got %+v", patches)
+	}
+}
+
+// TestDiffLegacyCallerNilClientState — no client state is supplied
+// (legacy call path or first render). Must behave like the pre-Step 3
+// diff: every changed value emits a patch.
+func TestDiffLegacyCallerNilClientState(t *testing.T) {
+	old := elWithAttrs("input", map[string]string{"value": "a"})
+	new_ := elWithAttrs("input", map[string]string{"value": "b"})
+	assignSkyIDs(&old, "r")
+	assignSkyIDs(&new_, "r")
+	patches := diffTrees(&old, &new_, nil)
+	found := false
+	for _, p := range patches {
+		if p.Attrs != nil && p.Attrs["value"] == "b" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("nil clientState must preserve legacy diff behaviour; got %+v", patches)
+	}
+}
+
+// TestDiffNonInputTagIgnoresClientState — client state entries for
+// non-input tags must NOT suppress their patches (would hide real
+// server-driven changes like class="error" on a <div>).
+func TestDiffNonInputTagIgnoresClientState(t *testing.T) {
+	old := elWithAttrs("div", map[string]string{"class": "ok"})
+	new_ := elWithAttrs("div", map[string]string{"class": "error"})
+	assignSkyIDs(&old, "r")
+	assignSkyIDs(&new_, "r")
+	// Nonsense clientState entry for a div — should be ignored.
+	patches := diffTrees(&old, &new_, map[string]string{
+		new_.SkyID: "something",
+	})
+	found := false
+	for _, p := range patches {
+		if p.Attrs != nil && p.Attrs["class"] == "error" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("non-input tag must still receive attr patches despite clientState; got %+v", patches)
+	}
+}
+
+// TestDiffAuthorityAttrsChecked — `checked` gets the same alignment
+// treatment as `value`. Client-reported "true" + server-new "true"
+// → no patch. Covers checkbox/radio protection.
+func TestDiffAuthorityAttrsChecked(t *testing.T) {
+	old := elWithAttrs("input", map[string]string{
+		"type":    "checkbox",
+		"checked": "false",
+	})
+	new_ := elWithAttrs("input", map[string]string{
+		"type":    "checkbox",
+		"checked": "true",
+	})
+	assignSkyIDs(&old, "r")
+	assignSkyIDs(&new_, "r")
+
+	// Client says "true" — server's new value agrees.
+	patches := diffTrees(&old, &new_, map[string]string{
+		new_.SkyID: "true",
+	})
+	for _, p := range patches {
+		if p.Attrs != nil {
+			if _, ok := p.Attrs["checked"]; ok {
+				t.Errorf("checked patch should not fire when server matches client; got %+v", p.Attrs)
+			}
+		}
+	}
+}

--- a/runtime-go/rt/live_protocol_test.go
+++ b/runtime-go/rt/live_protocol_test.go
@@ -1,0 +1,327 @@
+package rt
+
+// Step 2 of docs/skylive/input-authority-protocol.md — wire-format
+// scaffolding. These tests pin the new fields end-to-end: parsing
+// req.inputState + req.batch on the server side, monotonic outSeq,
+// ack-inputs eviction for unmounted elements, and the JSON / HTML /
+// SSE envelope shapes. Behaviour remains legacy-compatible: no patch
+// filtering yet (that's step 3), no stale-drop yet (step 4), but the
+// metadata flows on the wire so later steps can activate filters
+// without another protocol change.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestOutSeqMonotonic(t *testing.T) {
+	s := &liveSession{}
+	a := s.nextOutSeq()
+	b := s.nextOutSeq()
+	c := s.nextOutSeq()
+	if a != 1 || b != 2 || c != 3 {
+		t.Errorf("nextOutSeq non-monotonic: got %d,%d,%d, want 1,2,3", a, b, c)
+	}
+}
+
+func TestIngestInputStateKeepsMaxSeq(t *testing.T) {
+	s := &liveSession{}
+	s.ingestInputState(map[string]inputStateEntry{
+		"r.0#input:email": {Value: "a@b.com", Seq: 5},
+		"r.0#input:name":  {Value: "Alice", Seq: 3},
+	})
+	// Older snapshot for email — must NOT regress.
+	s.ingestInputState(map[string]inputStateEntry{
+		"r.0#input:email": {Value: "old", Seq: 2},
+	})
+	// Newer snapshot for email — SHOULD advance.
+	s.ingestInputState(map[string]inputStateEntry{
+		"r.0#input:email": {Value: "a@b.com", Seq: 9},
+	})
+	if s.inputSeqs["r.0#input:email"] != 9 {
+		t.Errorf("email seq = %d, want 9", s.inputSeqs["r.0#input:email"])
+	}
+	if s.inputSeqs["r.0#input:name"] != 3 {
+		t.Errorf("name seq = %d, want 3", s.inputSeqs["r.0#input:name"])
+	}
+}
+
+func TestAckInputsEvictsUnmounted(t *testing.T) {
+	tree := el("form", nil,
+		el("input", map[string]string{"name": "email"}),
+	)
+	assignSkyIDs(&tree, "r")
+	emailID := tree.Children[0].SkyID
+	// Session knows about two inputs, but only one is still rendered.
+	sess := &liveSession{
+		prevTree: &tree,
+		inputSeqs: map[string]int64{
+			emailID:            7,
+			"r.0#input:stale": 3, // unmounted in this render
+		},
+	}
+	ack := ackInputsForPrevTree(sess)
+	if ack[emailID] != 7 {
+		t.Errorf("email ack missing: %+v", ack)
+	}
+	if _, present := ack["r.0#input:stale"]; present {
+		t.Errorf("stale ack not evicted: %+v", ack)
+	}
+	if _, present := sess.inputSeqs["r.0#input:stale"]; present {
+		t.Errorf("stale id not removed from session state: %+v", sess.inputSeqs)
+	}
+}
+
+func TestEncodeSSEFrameShape(t *testing.T) {
+	sess := &liveSession{}
+	raw := encodeSSEFrame(sess, "<div>hi</div>")
+	var frame map[string]any
+	if err := json.Unmarshal([]byte(raw), &frame); err != nil {
+		t.Fatalf("frame is not valid JSON: %v (%s)", err, raw)
+	}
+	seq, ok := frame["seq"].(float64)
+	if !ok || int64(seq) != 1 {
+		t.Errorf("frame.seq = %v, want 1", frame["seq"])
+	}
+	if frame["body"] != "<div>hi</div>" {
+		t.Errorf("frame.body = %v", frame["body"])
+	}
+	if _, present := frame["ackInputs"]; present {
+		t.Errorf("empty ack inputs should be omitted, got %+v", frame)
+	}
+}
+
+func TestWriteEventJSONEnvelope(t *testing.T) {
+	rr := httptest.NewRecorder()
+	text := "new"
+	patches := []Patch{{ID: "r.0#p", Text: &text}}
+	writeEventJSON(rr, 42, 17, map[string]int64{"r.0#input:email": 17}, patches)
+
+	if got := rr.Header().Get("Content-Type"); !strings.HasPrefix(got, "application/json") {
+		t.Errorf("content type = %q, want application/json", got)
+	}
+	var envelope map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("body not JSON: %v (%s)", err, rr.Body.String())
+	}
+	if envelope["seq"].(float64) != 42 {
+		t.Errorf("seq = %v, want 42", envelope["seq"])
+	}
+	if envelope["respondingTo"].(float64) != 17 {
+		t.Errorf("respondingTo = %v, want 17", envelope["respondingTo"])
+	}
+	ack := envelope["ackInputs"].(map[string]any)
+	if ack["r.0#input:email"].(float64) != 17 {
+		t.Errorf("ackInputs = %+v", ack)
+	}
+	if envelope["patches"] == nil {
+		t.Errorf("patches missing")
+	}
+}
+
+func TestWriteEventJSONNoPatchesEmitsEmptyArray(t *testing.T) {
+	rr := httptest.NewRecorder()
+	writeEventJSON(rr, 1, 0, nil, nil)
+	var envelope map[string]any
+	_ = json.Unmarshal(rr.Body.Bytes(), &envelope)
+	arr, ok := envelope["patches"].([]any)
+	if !ok || len(arr) != 0 {
+		t.Errorf("patches = %v, want []", envelope["patches"])
+	}
+	// respondingTo omitted when request seq was 0 (legacy client).
+	if _, present := envelope["respondingTo"]; present {
+		t.Errorf("respondingTo must omit when 0: %+v", envelope)
+	}
+}
+
+func TestWriteEventHTMLSetsProtocolHeaders(t *testing.T) {
+	rr := httptest.NewRecorder()
+	writeEventHTML(rr, 99, map[string]int64{"r.0#input:q": 5}, "<p>ok</p>")
+	if rr.Header().Get("Content-Type") != "text/html" {
+		t.Errorf("content-type = %q", rr.Header().Get("Content-Type"))
+	}
+	if rr.Header().Get("X-Sky-Seq") != "99" {
+		t.Errorf("X-Sky-Seq = %q", rr.Header().Get("X-Sky-Seq"))
+	}
+	var ack map[string]int64
+	if err := json.Unmarshal([]byte(rr.Header().Get("X-Sky-Ack-Inputs")), &ack); err != nil {
+		t.Fatalf("ack header not JSON: %v", err)
+	}
+	if ack["r.0#input:q"] != 5 {
+		t.Errorf("ack header = %+v", ack)
+	}
+	if rr.Body.String() != "<p>ok</p>" {
+		t.Errorf("body = %q", rr.Body.String())
+	}
+}
+
+func TestWriteEventHTMLOmitsEmptyAck(t *testing.T) {
+	rr := httptest.NewRecorder()
+	writeEventHTML(rr, 5, nil, "<p>ok</p>")
+	if got := rr.Header().Get("X-Sky-Ack-Inputs"); got != "" {
+		t.Errorf("ack header should be absent when map is empty, got %q", got)
+	}
+}
+
+// TestHandleEventRoundTripsSeq — a full /_sky/event request with the
+// new protocol fields flows through the handler and the response
+// envelope carries seq + respondingTo. The view renders a form whose
+// email input stays mounted across dispatches so ackInputsForPrevTree
+// keeps the email id and the envelope can echo it back.
+func TestHandleEventRoundTripsSeq(t *testing.T) {
+	// View: a form with an email input that survives every render, so
+	// the input's sky-id stays in prevTree and ackInputs keeps it.
+	viewFn := func(model any) any {
+		return velement("form", nil, []any{
+			velement("input",
+				[]any{attrPair{key: "name", val: "email"}},
+				nil),
+			velement("button",
+				[]any{eventPair{name: "click", msg: "ClickMsg"}},
+				[]any{vtext("Go")}),
+		})
+	}
+	app := &liveApp{
+		update: func(msg, model any) any {
+			// Flip model so dispatch registers a fresh render instead of
+			// the byte-identical-body no-op shortcut.
+			next := model
+			if s, ok := model.(string); ok {
+				next = s + "!"
+			}
+			return SkyTuple2{V0: next, V1: cmdT{kind: "none"}}
+		},
+		view:    viewFn,
+		store:   newMemoryStore(30 * time.Minute),
+		locker:  newSessionLocker(),
+		msgTags: map[string]int{},
+	}
+	// Seed prevTree by rendering once — matches what dispatchRoot does
+	// on the initial page load.
+	init := sky_call(viewFn, "seed").(VNode)
+	assignSkyIDs(&init, "r")
+	handlers := map[string]any{}
+	_ = renderVNode(init, handlers)
+	sess := &liveSession{
+		model:     "seed",
+		handlers:  handlers,
+		prevTree:  &init,
+		sseCh:     make(chan string, 1),
+		cancelSub: make(chan struct{}),
+	}
+	app.store.Set("sid-1", sess)
+
+	// Click handler id is the button's sky-id + ".click". The button
+	// sits at index 1 in the form, and the form at the root position
+	// we fed to assignSkyIDs. Read the actual id off the rendered tree
+	// so the test isn't tied to the internal id grammar.
+	buttonSkyID := init.Children[1].SkyID
+	clickHid := buttonSkyID + ".click"
+	emailSkyID := init.Children[0].SkyID
+
+	reqBody := `{
+		"sessionId": "sid-1",
+		"seq": 42,
+		"msg": "",
+		"args": [],
+		"handlerId": "` + clickHid + `",
+		"inputState": {"` + emailSkyID + `": {"value": "x", "seq": 42}}
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/_sky/event",
+		strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	app.handleEvent(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	if strings.HasPrefix(rr.Header().Get("Content-Type"), "application/json") {
+		var envelope map[string]any
+		if err := json.Unmarshal(rr.Body.Bytes(), &envelope); err != nil {
+			t.Fatalf("body: %v (%s)", err, rr.Body.String())
+		}
+		if envelope["seq"] == nil {
+			t.Errorf("envelope missing seq: %+v", envelope)
+		}
+		if envelope["respondingTo"].(float64) != 42 {
+			t.Errorf("respondingTo = %v, want 42", envelope["respondingTo"])
+		}
+		if ack, ok := envelope["ackInputs"].(map[string]any); !ok {
+			t.Errorf("ackInputs missing from envelope: %+v", envelope)
+		} else if ack[emailSkyID].(float64) != 42 {
+			t.Errorf("ackInputs[email] = %v, want 42", ack[emailSkyID])
+		}
+	} else {
+		if rr.Header().Get("X-Sky-Seq") == "" {
+			t.Errorf("HTML fallback missing X-Sky-Seq header")
+		}
+	}
+}
+
+// TestHandleEventBatch — a sendBeacon-style batch returns 204 and
+// ingests the outer inputState snapshot into the session before
+// processing entries. Each batched entry dispatches under sess.mu
+// and rebuilds the handler map, so only the first entry's handler
+// lookup is guaranteed to succeed — verify the 204 response and the
+// inputState ingest (which happens before the batch runs).
+func TestHandleEventBatch(t *testing.T) {
+	viewFn := func(model any) any {
+		return velement("form", nil, []any{
+			velement("input",
+				[]any{attrPair{key: "name", val: "email"}},
+				nil),
+		})
+	}
+	app := &liveApp{
+		update: func(msg, model any) any {
+			return SkyTuple2{V0: model, V1: cmdT{kind: "none"}}
+		},
+		view:    viewFn,
+		store:   newMemoryStore(30 * time.Minute),
+		locker:  newSessionLocker(),
+		msgTags: map[string]int{},
+	}
+	init := sky_call(viewFn, "seed").(VNode)
+	assignSkyIDs(&init, "r")
+	handlers := map[string]any{}
+	_ = renderVNode(init, handlers)
+	sess := &liveSession{
+		model:     "seed",
+		handlers:  handlers,
+		prevTree:  &init,
+		sseCh:     make(chan string, 16),
+		cancelSub: make(chan struct{}),
+	}
+	app.store.Set("sid-2", sess)
+
+	emailSkyID := init.Children[0].SkyID
+	// A direct-send entry (no handlerId) uses the ADT-lookup fallback
+	// inside dispatchBatched, so the batch path can be exercised even
+	// when the rendered view has no event handlers. The Msg constructor
+	// is resolved via the (empty here) tag registry → SkyADT{Tag:-1}.
+	reqBody := `{
+		"sessionId": "sid-2",
+		"inputState": {"` + emailSkyID + `": {"value": "a@b.com", "seq": 5}},
+		"batch": [
+			{"msg": "NoopMsg", "args": [], "handlerId": ""}
+		]
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/_sky/event",
+		strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	app.handleEvent(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Errorf("status = %d, want 204", rr.Code)
+	}
+	if sess.inputSeqs[emailSkyID] != 5 {
+		t.Errorf("batch inputState not ingested: %+v (want %s=5)",
+			sess.inputSeqs, emailSkyID)
+	}
+}

--- a/runtime-go/rt/live_skyid_test.go
+++ b/runtime-go/rt/live_skyid_test.go
@@ -1,0 +1,220 @@
+package rt
+
+// Regression tests for structural sky-ids (step 1 of the input-authority
+// protocol — docs/skylive/input-authority-protocol.md). The old scheme
+// emitted purely positional ids (`r.2.0.0.3`) which collided between
+// structurally-different subtrees at the same positional depth, letting
+// the diff walker merge e.g. a `<input>` and a `<fieldset>` as if they
+// were the same element. Under the new scheme every segment embeds the
+// tag and (when present) a key, so colliding siblings are impossible.
+
+import (
+	"strings"
+	"testing"
+)
+
+// Element VNode helper — matches the shape assignSkyIDs walks without
+// pulling in the full velement builder (which requires the Sky runtime
+// boot, unnecessary for pure id assignment tests).
+func el(tag string, attrs map[string]string, children ...VNode) VNode {
+	if attrs == nil {
+		attrs = map[string]string{}
+	}
+	return VNode{
+		Kind:     "element",
+		Tag:      tag,
+		Attrs:    attrs,
+		Events:   map[string]any{},
+		Children: children,
+	}
+}
+
+func txt(s string) VNode { return VNode{Kind: "text", Text: s} }
+
+// TestSkyIDCollisionFree — the signIn/signUp duplication repro. Two
+// trees share an outer `<div class="sc-container-sm">` wrapper but the
+// form inside diverges: signIn has a 2-field form, signUp wraps a role
+// `<fieldset>` in front. Under positional-only ids the email input on
+// signIn and the fieldset on signUp would share `r.2.0.0.3`. After the
+// fix, their sky-ids must differ.
+func TestSkyIDCollisionFree(t *testing.T) {
+	signIn := el("div", nil,
+		el("form", nil,
+			el("div", nil,
+				el("label", nil, txt("Email")),
+				el("input", map[string]string{"name": "email", "type": "email"}),
+				el("label", nil, txt("Password")),
+				el("input", map[string]string{"name": "password", "type": "password"}),
+				el("button", map[string]string{"type": "submit"}, txt("Sign in")),
+			),
+		),
+	)
+	signUp := el("div", nil,
+		el("form", nil,
+			el("div", nil,
+				el("fieldset", map[string]string{"name": "role"},
+					el("input", map[string]string{"name": "role", "type": "radio"}),
+					el("input", map[string]string{"name": "role", "type": "radio"}),
+				),
+				el("label", nil, txt("Email")),
+				el("input", map[string]string{"name": "email", "type": "email"}),
+				el("label", nil, txt("Password")),
+				el("input", map[string]string{"name": "password", "type": "password"}),
+				el("button", map[string]string{"type": "submit"}, txt("Sign up")),
+			),
+		),
+	)
+	assignSkyIDs(&signIn, "r")
+	assignSkyIDs(&signUp, "r")
+
+	// Walk to the inner div (r.0#form.0#div) on each side and compare
+	// the child ids. Under the old scheme signIn[1] (email input) and
+	// signUp[1] (label) shared `r.0.0.1`; that must not recur.
+	inCtr := &signIn.Children[0].Children[0]
+	upCtr := &signUp.Children[0].Children[0]
+	if len(inCtr.Children) == 0 || len(upCtr.Children) == 0 {
+		t.Fatalf("container empty: in=%d up=%d", len(inCtr.Children), len(upCtr.Children))
+	}
+	seen := map[string]bool{}
+	for _, c := range inCtr.Children {
+		if c.SkyID != "" {
+			seen[c.SkyID] = true
+		}
+	}
+	for _, c := range upCtr.Children {
+		if c.SkyID == "" {
+			continue
+		}
+		if seen[c.SkyID] {
+			t.Errorf("collision: signIn and signUp share sky-id %q", c.SkyID)
+		}
+	}
+}
+
+// TestSkyIDStableAcrossRenders — two identical renders of the same
+// tree must assign identical sky-ids. Without this the diff can't
+// correlate old→new at all.
+func TestSkyIDStableAcrossRenders(t *testing.T) {
+	mk := func() VNode {
+		return el("div", nil,
+			el("header", nil, txt("hello")),
+			el("main", nil,
+				el("form", nil,
+					el("input", map[string]string{"name": "q"}),
+				),
+			),
+		)
+	}
+	a, b := mk(), mk()
+	assignSkyIDs(&a, "r")
+	assignSkyIDs(&b, "r")
+
+	var collect func(n *VNode, into *[]string)
+	collect = func(n *VNode, into *[]string) {
+		if n.SkyID != "" {
+			*into = append(*into, n.SkyID)
+		}
+		for i := range n.Children {
+			collect(&n.Children[i], into)
+		}
+	}
+	var sa, sb []string
+	collect(&a, &sa)
+	collect(&b, &sb)
+	if strings.Join(sa, "|") != strings.Join(sb, "|") {
+		t.Errorf("identical trees produced different sky-ids:\n  a: %v\n  b: %v", sa, sb)
+	}
+}
+
+// TestSkyIDNameBasedKey — inputs with a `name` attribute get that
+// name appended so the id survives structural shuffling (e.g. rearranged
+// form fields). Without the key, a reordered form confuses the diff.
+func TestSkyIDNameBasedKey(t *testing.T) {
+	f := el("form", nil,
+		el("input", map[string]string{"name": "email"}),
+		el("input", map[string]string{"name": "password"}),
+	)
+	assignSkyIDs(&f, "r")
+
+	if !strings.Contains(f.Children[0].SkyID, ":email") {
+		t.Errorf("email input missing name key: %q", f.Children[0].SkyID)
+	}
+	if !strings.Contains(f.Children[1].SkyID, ":password") {
+		t.Errorf("password input missing name key: %q", f.Children[1].SkyID)
+	}
+	// Swapping order should produce different ids from the original slots
+	// (positional index changes) — identity still tracked via the name.
+	g := el("form", nil,
+		el("input", map[string]string{"name": "password"}),
+		el("input", map[string]string{"name": "email"}),
+	)
+	assignSkyIDs(&g, "r")
+	if f.Children[0].SkyID == g.Children[0].SkyID {
+		t.Errorf("unexpected match after reorder: both %q", f.Children[0].SkyID)
+	}
+	// But the email input is still identifiable in both trees — the diff
+	// can find it by scanning for `:email` when structural position moves.
+	if !strings.HasSuffix(g.Children[1].SkyID, ":email") {
+		t.Errorf("reordered email lost its key: %q", g.Children[1].SkyID)
+	}
+}
+
+// TestSkyIDExplicitKey — an explicit `sky-key` attribute takes
+// precedence over name-based auto-keying. Consumers use this for
+// list items where there's no natural `name` attr.
+func TestSkyIDExplicitKey(t *testing.T) {
+	ul := el("ul", nil,
+		el("li", map[string]string{"sky-key": "todo-42"}, txt("first")),
+		el("li", map[string]string{"sky-key": "todo-17"}, txt("second")),
+	)
+	assignSkyIDs(&ul, "r")
+	if !strings.HasSuffix(ul.Children[0].SkyID, ":todo-42") {
+		t.Errorf("first li missing explicit key: %q", ul.Children[0].SkyID)
+	}
+	if !strings.HasSuffix(ul.Children[1].SkyID, ":todo-17") {
+		t.Errorf("second li missing explicit key: %q", ul.Children[1].SkyID)
+	}
+}
+
+// TestSkyIDKeySanitisation — user-supplied keys with quote/dot/hash
+// characters must be coerced to `[A-Za-z0-9_-]+` so they can't break
+// the sky-id grammar or escape HTML attribute quoting.
+func TestSkyIDKeySanitisation(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"abc", "abc"},
+		{"a.b", "a_b"},
+		{"a#b", "a_b"},
+		{`a"b`, "a_b"},
+		{"a:b", "a_b"},
+		{"user@example.com", "user_example_com"},
+		{"foo-bar_baz", "foo-bar_baz"},
+	}
+	for _, tc := range cases {
+		if got := sanitiseSkyIDKey(tc.in); got != tc.want {
+			t.Errorf("sanitiseSkyIDKey(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestSkyIDTextChildrenDontGetIDs — text/raw nodes must remain unstamped.
+// assignSkyIDs uses positional index, so text children still occupy an
+// index in the parent's Children slice, but their SkyID stays "".
+func TestSkyIDTextChildrenDontGetIDs(t *testing.T) {
+	tree := el("p", nil,
+		txt("before"),
+		el("span", nil, txt("middle")),
+		txt("after"),
+	)
+	assignSkyIDs(&tree, "r")
+	if tree.Children[0].SkyID != "" {
+		t.Errorf("text child got sky-id: %q", tree.Children[0].SkyID)
+	}
+	if tree.Children[2].SkyID != "" {
+		t.Errorf("text child got sky-id: %q", tree.Children[2].SkyID)
+	}
+	// Span sits at index 1 — its id must reflect that index regardless
+	// of the text siblings being unstamped.
+	if !strings.HasPrefix(tree.Children[1].SkyID, "r.1#span") {
+		t.Errorf("span id doesn't reflect position: %q", tree.Children[1].SkyID)
+	}
+}


### PR DESCRIPTION
## Summary

Rewrites Sky.Live's diff/patch pipeline to fix two classes of bug that had been surfacing in real apps (sendcrafts, skyvote, skychess):

1. **Structural duplication / messy DOM on navigation.** `__skyMorph`'s ad-hoc "match by sky-id OR position" walk produced duplicate inputs, orphan nodes, and blank containers whenever the old and new trees diverged structurally.
2. **Lost / reordered keystrokes under latency.** Even after replacing the morph with atomic `innerHTML` + snap/restore, typing `"hello@"` rapidly could come out as `"@ohell"` because the focused DOM node itself was being destroyed — `.value` copying can't reconstruct the browser's IME buffer, undo stack, autofill state, or native caret.

The fix is three layers of defence, all landed in this branch:

- **Server-side diff alignment.** `diffNodes` takes a `clientState` hint (the client's current DOM values for every dirty input) and skips emitting value patches when the server's new view already matches. Stops the server from ever round-tripping the user's own typing back at them.
- **Client-side attr filter.** When a patch carries `value`/`checked`/`selected` for an input that is focused, has a pending debounce, or has unacked typed text, the attr is dropped at apply time. User's DOM wins.
- **Node-identity preservation across innerHTML.** The focused `<input>` / `<textarea>` / `<select>` DOM node is spliced through the new HTML — `parentNode.replaceChild(liveNode, placeholder)` — so it's never destroyed. IME composition, undo stack, autofill state, and caret behaviour all survive; only focus and selection (document-level state) are dropped and explicitly restored.

Plus: structural sky-ids (tag + optional key per path segment so colliding siblings are impossible by construction), monotonic session-wide `outSeq` on every outgoing frame with a client-side stale-drop gate, and `navigator.sendBeacon`-based flush on tab unload so the final keystroke always reaches the server.

Design doc: `docs/skylive/input-authority-protocol.md`.

## Architectural arc

What was tried, what held up, what was abandoned — for the commit log:

1. `3dbaefe` **structural sky-ids** — tag + optional key per path segment (eliminates positional collisions).
2. `3a3c407` **wire protocol v2** — `seq`, `inputState`, `ackInputs`, `batch`, SSE JSON envelope.
3. `63ccd76` **I1 client authority** — server diff alignment + client attr filter.
4. `a8fd9bf` **I2 stale-drop** — monotonic seq gate on every incoming frame.
5. `49bbf12` **I3 flush-on-unmount** — sendBeacon batch on `<a>` click / `beforeunload` / `pagehide`.
6. `9eee5f6` adversarial test matrix + doc update.
7. `1f5b057` scope `__skyIsDirty` to typable form fields (fixed skychess blank view).
8. `51f2525` **retire `__skyMorph`** — atomic innerHTML + focus snap/restore (fixed skyvote structural duplication).
9. `bdebf73` **preserve focused DOM node through innerHTML** (fixed `"@ohell"` typing corruption — the snap/restore from the previous commit was still destroying IME state).

Commit 9 is the key insight: value copying is not a substitute for node preservation when the element carries browser-internal state the user is actively interacting with.

## Test plan

- [x] `cabal test`: 80/80 pass (656s).
- [x] `go test ./rt/`: 25 new tests + existing suite all pass.
- [x] All 18 examples + sendcrafts build clean against the new compiler.
- [x] `/tmp/skylive_e2e.sh`: dispatch smoke passes 6/6 Live examples (09-counter, 10-component, 12-skyvote, 16-skychess, 17-skymon, 18-job-queue).
- [x] **User-confirmed working in browser** (2026-04-22):
  - skyvote top-nav clicks no longer produce duplicate/messy elements.
  - Rapid typing "hello@" preserves order + cursor.
- [ ] CI green on main after merge.
- [ ] Clean-slate sweep of all 18 examples before tag (per CLAUDE.md release gate).

## Files touched

- `runtime-go/rt/live.go` — protocol wire format, diff, client JS (+ new tests).
- `runtime-go/rt/live_skyid_test.go`, `live_protocol_test.go`, `live_authority_test.go`, `live_adversarial_test.go` — 25 protocol invariant tests.
- `docs/skylive/input-authority-protocol.md` — full wire spec (563 lines).
- `.gitignore` — add `sky.zip`.