### PR TITLE
Sky.Live runtime hardening: graceful dispatch errors, structural narrowing, textarea/select rendering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -369,6 +369,42 @@ update msg model =
 
 Concurrency: commands run in goroutines with session locking (same as subscriptions). Model is read fresh from the session store on completion — safe for multi-instance deployments.
 
+### View-event bindings: radio groups + checkboxes
+
+Wire-level events dispatch these args (see `__skyExtractArgs`):
+
+| Event | Element | Args sent |
+|---|---|---|
+| `click`, `focus`, `blur`, `mouseover`/`mouseout`, `mousedown`/`mouseup` | any | `[]` (just the Msg) |
+| `input`, `change` | `<input type="checkbox">` | `[checked : Bool]` |
+| `input`, `change` | `<input type="radio">` | `[checked : Bool]` (always `True` at selection — usually not what you want) |
+| `input`, `change` | `<input type="number">`/`range` | `[value : Float]` |
+| `input`, `change` | text inputs, `<textarea>`, `<select>` | `[value : String]` |
+| `submit` | `<form>` | `[formData : Dict String String]` |
+| `keydown`/`keyup`/`keypress` | any | `[key : String]` |
+
+**Radio convention: use `onClick` on each label/input, not `onInput`.** A radio's `input` event fires on selection but reports `[checked=True]` (a boolean), not the chosen `value`. Binding a typed constructor like `UpdateRole : String -> Msg` to `onInput` would get a `Bool` at runtime and the dispatch drops the event with a `Msg decode error` in the log.
+
+```elm
+-- Preferred: one fully-applied Msg per radio, dispatched on click.
+choiceRow =
+    label [ for "role-guardian", onClick (UpdateRole "guardian") ]
+        [ input [ type "radio", name "role", value "guardian", id "role-guardian" ] []
+        , text "Guardian"
+        ]
+```
+
+The `for`/`id` pairing lets the browser toggle the radio natively on label click; the `onClick` on the label carries the fully-applied Msg (zero wire args) so no type coercion happens server-side. Same pattern works for checkbox groups when you want per-choice Msg variants.
+
+### Dispatch error handling
+
+`dispatch()` is wrapped in `defer/recover`. Two classes are handled cleanly:
+
+1. **Msg decode errors** — client's wire args don't fit the Msg constructor's parameter types (e.g. radio `onInput` bound to `String -> Msg`). `applyMsgArgs` detects the mismatch before `reflect.Call`, logs a targeted message (constructor name, expected type, actual arg), and drops the event. No model mutation.
+2. **User-code panics** — anything inside `update`/`view`/`guard` that panics (typed-FFI boundary mismatches, nil deref in user code, etc.) is caught, stack-traced to stderr, and the event is dropped. Session state stays consistent so the next event dispatches normally.
+
+Both paths return an empty body; the client sees an empty patch list and the DOM is unchanged. Check server logs for `[sky.live] dispatch panic recovered` or `[sky.live] Msg decode error` when debugging an event that "does nothing".
+
 ### Sky.Http.Server
 ```elm
 main =

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,0 +1,85 @@
+# ─────────────────────────────────────────────────────────────
+# Sky Language — LOCAL source build
+#
+# Unlike Dockerfile (which downloads a released binary), this image
+# builds sky from the current source tree. Used when sendcrafts or
+# another consumer needs fixes on an unmerged branch without waiting
+# for a release cut.
+#
+# Usage:
+#   docker build -f Dockerfile.local -t anzel/sky:local .
+#   docker run --rm -v $(pwd):/app -w /app anzel/sky:local build src/Main.sky
+#
+# docker-compose:
+#   services:
+#     app:
+#       image: anzel/sky:local
+#       volumes: [.:/src]
+# ─────────────────────────────────────────────────────────────
+
+# ── Stage 1: build the sky compiler from source ─────────────
+FROM haskell:9.4 AS builder
+
+# Same UTF-8 locale rationale as the release Dockerfile — GHC's
+# text IO honours the system locale when reading the embedded
+# .sky templates + runtime-go files via Template Haskell.
+ENV LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8
+
+WORKDIR /build
+
+# Cache cabal metadata before copying the full tree so edits to
+# runtime/stdlib don't invalidate the 'cabal update' layer.
+RUN cabal update
+
+# Copy cabal descriptor first so dependency resolution caches
+# independently of source edits.
+COPY sky-compiler.cabal ./
+RUN cabal build --dependencies-only exe:sky
+
+# Copy the rest of the source tree (runtime-go, sky-stdlib,
+# templates, app/, src/ — everything the cabal build needs via
+# Template Haskell embedding).
+COPY . ./
+
+# Stamp the version so `sky --version` reports something
+# identifiable inside this image. The release CI normally
+# overwrites app/VERSION with the git tag; for a local build we
+# take the branch + short SHA as --build-args (git is excluded
+# from the build context via .dockerignore so we can't read it
+# in-container). Falls back to a generic "local" when the caller
+# doesn't pass the args.
+ARG SKY_GIT_BRANCH=unknown
+ARG SKY_GIT_SHA=unknown
+RUN printf 'local-%s-%s' "${SKY_GIT_BRANCH}" "${SKY_GIT_SHA}" > app/VERSION; \
+    cat app/VERSION
+
+# Build + install the sky binary. --install-method=copy drops
+# it into /build/bin/sky ready to ship to the runtime stage.
+RUN cabal install --overwrite-policy=always \
+        --installdir=./bin --install-method=copy exe:sky \
+ && ./bin/sky --version
+
+
+# ── Stage 2: runtime image (matches Dockerfile structure) ────
+FROM golang:1.26-bookworm
+
+ENV LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates git \
+ && rm -rf /var/lib/apt/lists/*
+
+# Haskell binaries link against libgmp + libtinfo (ncurses) at
+# runtime. GHC compiles with dynamic linking by default; copy the
+# minimum runtime libs alongside glibc to keep the image lean.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends libgmp10 libtinfo6 libnuma1 \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /build/bin/sky /usr/local/bin/sky
+RUN chmod +x /usr/local/bin/sky && sky --version
+
+WORKDIR /app
+ENTRYPOINT ["sky"]

--- a/build_docker_local.sh
+++ b/build_docker_local.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -e
+
+docker build -f Dockerfile.local \
+    --build-arg SKY_GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD | tr / -)" \
+    --build-arg SKY_GIT_SHA="$(git rev-parse --short HEAD)" \
+    -t anzel/sky:local .

--- a/runtime-go/rt/live.go
+++ b/runtime-go/rt/live.go
@@ -729,7 +729,26 @@ func renderVNode(n VNode, handlers map[string]any) string {
 		sb.WriteString(html.EscapeString(n.SkyID))
 		sb.WriteString(`"`)
 	}
+	// <textarea> has no `value` attribute in the HTML spec — its
+	// displayed value is the TEXT CONTENT between the tags. Emitting
+	// `<textarea value="...">` renders empty in every browser, which
+	// means any server re-render (full-body fallback or innerHTML
+	// patch at an ancestor) wipes the user's text out of the DOM.
+	// Strip the value attr here and splice it in as child content
+	// further down. A redundant `value="..."` kept on <select>
+	// similarly has no effect (selection lives on <option selected>),
+	// so strip there too.
+	textareaValue := ""
+	isTextarea := n.Tag == "textarea"
+	if isTextarea || n.Tag == "select" {
+		if v, ok := n.Attrs["value"]; ok {
+			textareaValue = v
+		}
+	}
 	for k, v := range n.Attrs {
+		if (isTextarea || n.Tag == "select") && k == "value" {
+			continue
+		}
 		sb.WriteString(" ")
 		sb.WriteString(k)
 		sb.WriteString(`="`)
@@ -758,6 +777,13 @@ func renderVNode(n VNode, handlers map[string]any) string {
 		return sb.String()
 	}
 	sb.WriteString(">")
+	// Textarea special-case: write the captured value as text content.
+	// If the VNode already has text children (user wrote `textarea []
+	// [ text "hi" ]`), those take precedence and the attr-derived
+	// value is ignored — preserves existing behaviour.
+	if isTextarea && textareaValue != "" && len(n.Children) == 0 {
+		sb.WriteString(html.EscapeString(textareaValue))
+	}
 	// <script> and <style> bodies are raw text in HTML (CDATA-like):
 	// escaping `'` to `&#39;` breaks the JS at parse time. Sky users
 	// pass the body as a plain string (`script [] "code here"`), which
@@ -766,9 +792,27 @@ func renderVNode(n VNode, handlers map[string]any) string {
 	// <style> @import chains). Matches html/template's behaviour for
 	// JSStr / CSSText contexts.
 	rawBody := n.Tag == "script" || n.Tag == "style"
+	// <select> uses child <option selected> to indicate the chosen
+	// value. Mark the matching option inline — less invasive than
+	// rebuilding the children tree.
+	selectValue := ""
+	if n.Tag == "select" && textareaValue != "" {
+		selectValue = textareaValue
+	}
 	for _, c := range n.Children {
 		if rawBody && c.Kind == "text" {
 			sb.WriteString(c.Text)
+		} else if selectValue != "" && c.Kind == "element" && c.Tag == "option" {
+			// Copy the option, flipping `selected` on the matching value.
+			// Shallow copy of Attrs so we don't mutate the caller's VNode.
+			picked := c
+			picked.Attrs = copyAttrs(c.Attrs)
+			if picked.Attrs["value"] == selectValue {
+				picked.Attrs["selected"] = "selected"
+			} else {
+				delete(picked.Attrs, "selected")
+			}
+			sb.WriteString(renderVNode(picked, handlers))
 		} else {
 			sb.WriteString(renderVNode(c, handlers))
 		}
@@ -777,6 +821,17 @@ func renderVNode(n VNode, handlers map[string]any) string {
 	sb.WriteString(n.Tag)
 	sb.WriteString(">")
 	return sb.String()
+}
+
+func copyAttrs(src map[string]string) map[string]string {
+	if src == nil {
+		return map[string]string{}
+	}
+	dst := make(map[string]string, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
 }
 
 // msgDisplayName extracts a Sky Msg constructor name from its runtime

--- a/runtime-go/rt/live.go
+++ b/runtime-go/rt/live.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"reflect"
 	"runtime"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
@@ -1214,8 +1215,15 @@ func (s *sessionLocker) Unlock(sid string) {
 // applyMsgArgs consumes a resolved Msg-handler value from the handler map
 // and, when it's a curried constructor (onInput: \s -> GotInput s), applies
 // each wire-supplied argument in order to produce a concrete Msg ADT.
-// Falls back to the legacy single-value form (`sky_call(msg, value)`) when
+// Falls back to the legacy single-value form (sky_call(msg, value)) when
 // the client didn't supply structured args — keeps older inputs working.
+//
+// A type-mismatch between the argument the client sent and the constructor's
+// declared parameter type (e.g. a radio's onInput sending [true] into a
+// String -> Msg constructor) used to panic deep inside reflect.Call. The
+// guard below detects the mismatch before the call, logs a useful message
+// with the msg/tag/expected-type/actual-type, and returns (msgDecodeError)
+// so dispatch can drop the event without mutating model state.
 func applyMsgArgs(msg any, args []json.RawMessage, fallbackValue string) any {
 	if msg == nil {
 		return msg
@@ -1226,7 +1234,7 @@ func applyMsgArgs(msg any, args []json.RawMessage, fallbackValue string) any {
 		return msg
 	}
 	if len(args) == 0 {
-		return sky_call(msg, fallbackValue)
+		return safeSkyCall(msg, fallbackValue)
 	}
 	cur := msg
 	for _, raw := range args {
@@ -1234,12 +1242,103 @@ func applyMsgArgs(msg any, args []json.RawMessage, fallbackValue string) any {
 		if err := json.Unmarshal(raw, &v); err != nil {
 			v = string(raw)
 		}
-		cur = sky_call(cur, v)
+		if !argAssignableToFunc(cur, v) {
+			logMsgDecodeError(cur, v, raw)
+			return msgDecodeError{}
+		}
+		cur = safeSkyCall(cur, v)
+		if _, ok := cur.(msgDecodeError); ok {
+			return cur
+		}
 		if reflect.ValueOf(cur).Kind() != reflect.Func {
 			break
 		}
 	}
 	return cur
+}
+
+// msgDecodeError — sentinel value returned from applyMsgArgs when the
+// client's wire-level arguments can't be coerced onto the Msg
+// constructor's parameters. dispatch() recognises it and drops the
+// event cleanly (no model mutation, no view re-render). Not a Go
+// error because it flows through the Msg pipeline and has to be
+// distinguished from legitimate Msg ADT values.
+type msgDecodeError struct{}
+
+// argAssignableToFunc — reports whether the first parameter of `fn`
+// will accept `arg` via reflect.Call. Returns true for interface
+// params (the common Sky case — most curried constructors take
+// `any`) and for exact-type matches. The check is intentionally
+// conservative: we'd rather let a near-miss through to reflect's own
+// error handling than reject legitimate dispatches.
+func argAssignableToFunc(fn any, arg any) bool {
+	rv := reflect.ValueOf(fn)
+	if rv.Kind() != reflect.Func {
+		return true
+	}
+	ft := rv.Type()
+	if ft.NumIn() == 0 {
+		return true
+	}
+	paramT := ft.In(0)
+	if paramT.Kind() == reflect.Interface {
+		// `any` (or any interface type the arg satisfies) — defer to
+		// runtime. Nearly every Sky lambda lands here.
+		if arg == nil {
+			return true
+		}
+		return reflect.TypeOf(arg).Implements(paramT)
+	}
+	if arg == nil {
+		// Typed param can't accept a nil for most kinds; let reflect
+		// surface the specific error if we're wrong.
+		switch paramT.Kind() {
+		case reflect.Ptr, reflect.Interface, reflect.Map, reflect.Slice, reflect.Chan, reflect.Func:
+			return true
+		}
+		return false
+	}
+	argT := reflect.TypeOf(arg)
+	return argT.AssignableTo(paramT)
+}
+
+// safeSkyCall wraps sky_call with a panic recover so a reflect-level
+// type mismatch that slips past argAssignableToFunc (custom func shapes,
+// variadics, etc.) still surfaces as a logged msgDecodeError rather than
+// crashing the dispatch goroutine. The outer panic-recover in /_sky/event
+// would otherwise catch it too, but with less context.
+func safeSkyCall(fn any, arg any) (result any) {
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Fprintf(os.Stderr,
+				"[sky.live] Msg dispatch recovered from panic: %v "+
+					"(fn kind=%s, arg=%T %v)\n",
+				r, reflect.ValueOf(fn).Kind(), arg, arg)
+			result = msgDecodeError{}
+		}
+	}()
+	return sky_call(fn, arg)
+}
+
+// logMsgDecodeError — structured message to stderr when a client-sent
+// argument doesn't fit the Msg constructor's parameter. Gives the
+// developer enough to find the mis-bound handler in their view.
+func logMsgDecodeError(fn any, arg any, raw json.RawMessage) {
+	rv := reflect.ValueOf(fn)
+	expected := "<unknown>"
+	if rv.Kind() == reflect.Func && rv.Type().NumIn() > 0 {
+		expected = rv.Type().In(0).String()
+	}
+	fnName := ""
+	if rv.Kind() == reflect.Func {
+		fnName = runtime.FuncForPC(rv.Pointer()).Name()
+	}
+	fmt.Fprintf(os.Stderr,
+		"[sky.live] Msg decode error: %s expected %s but got %T (%v); "+
+			"raw=%s. Likely fix: check the view binding — e.g. onInput on a "+
+			"radio sends [checked:bool], not the value. Use onClick with a "+
+			"fully-applied Msg per radio instead.\n",
+		fnName, expected, arg, arg, string(raw))
 }
 
 type liveSession struct {
@@ -2143,7 +2242,31 @@ func patchesAreFullReplace(patches []Patch) bool {
 // function, we run it BEFORE update. An `Err reason` short-circuits the
 // update and surfaces `reason` on model.Notification so the user sees
 // why their action was rejected. `Ok ()` proceeds normally.
-func (app *liveApp) dispatch(sess *liveSession, msg any) string {
+//
+// A msgDecodeError value arriving here (from applyMsgArgs rejecting a
+// wire-level type mismatch, e.g. a radio's onInput sending a boolean
+// into a String -> Msg constructor) drops the event: no update runs,
+// no model mutation, no re-render. The error has already been logged
+// with useful context at the dispatch boundary.
+//
+// update/view/guard panics are recovered here as a last-line defence
+// so one malformed handler can't crash the session; the view simply
+// falls back to its last rendered body.
+func (app *liveApp) dispatch(sess *liveSession, msg any) (body string) {
+	if _, bad := msg.(msgDecodeError); bad {
+		// applyMsgArgs already logged the specific mismatch. Return "" so
+		// the client sees an empty patch list (no visible change) and
+		// session state stays consistent.
+		return ""
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Fprintf(os.Stderr,
+				"[sky.live] dispatch panic recovered, dropping event: %v\n%s\n",
+				r, debug.Stack())
+			body = ""
+		}
+	}()
 	if app.guard != nil && isFunc(app.guard) {
 		g := sky_call2(app.guard, msg, sess.model)
 		// guard returns Result: Ok _ (allow) or Err "reason" (reject).
@@ -2171,7 +2294,7 @@ func (app *liveApp) dispatch(sess *liveSession, msg any) string {
 	sess.handlers = map[string]any{}
 	vn := sky_call(app.view, sess.model).(VNode)
 	assignSkyIDs(&vn, "r")
-	body := renderVNode(vn, sess.handlers)
+	body = renderVNode(vn, sess.handlers)
 	sess.prevTree = &vn
 	// Process Cmds (may spawn goroutines)
 	app.runCmd(sess, cmd)

--- a/runtime-go/rt/live_form_rendering_test.go
+++ b/runtime-go/rt/live_form_rendering_test.go
@@ -1,0 +1,168 @@
+package rt
+
+// Regression: renderVNode used to emit <textarea value="X"></textarea>
+// which every browser ignores — the textarea's displayed value is its
+// text content between the tags, not a value attribute. Any innerHTML
+// re-parse (full-HTML fallback, ancestor patch) would then wipe the
+// user's typing out of the DOM even when the server's model was
+// correctly tracking it. Same class of bug for <select> which needs
+// `selected` on the matching <option>, not `value=` on the select.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderTextareaEmitsValueAsContent(t *testing.T) {
+	ta := VNode{
+		Kind:  "element",
+		Tag:   "textarea",
+		Attrs: map[string]string{"name": "bio", "value": "hello world"},
+	}
+	out := renderVNode(ta, map[string]any{})
+
+	// value attribute must NOT appear on textarea (browsers ignore it).
+	if strings.Contains(out, `value="hello world"`) {
+		t.Errorf("textarea must not carry value= attribute; got %q", out)
+	}
+	// Text content between <textarea> and </textarea> must carry the value.
+	if !strings.Contains(out, `>hello world</textarea>`) {
+		t.Errorf("textarea text content missing expected value; got %q", out)
+	}
+	// name attribute stays as normal.
+	if !strings.Contains(out, `name="bio"`) {
+		t.Errorf("non-value attrs must still render; got %q", out)
+	}
+}
+
+func TestRenderTextareaEscapesHTMLInValue(t *testing.T) {
+	ta := VNode{
+		Kind:  "element",
+		Tag:   "textarea",
+		Attrs: map[string]string{"value": `<script>alert("xss")</script>`},
+	}
+	out := renderVNode(ta, map[string]any{})
+	if strings.Contains(out, "<script>") {
+		t.Errorf("textarea content must be HTML-escaped; got %q", out)
+	}
+	if !strings.Contains(out, "&lt;script&gt;") {
+		t.Errorf("textarea content missing escaped form; got %q", out)
+	}
+}
+
+func TestRenderTextareaPrefersChildrenOverValueAttr(t *testing.T) {
+	// If the user wrote `textarea [] [ text "child content" ]`, the
+	// children win — the value attr splice only fires when children
+	// are empty, preserving existing behaviour.
+	ta := VNode{
+		Kind:  "element",
+		Tag:   "textarea",
+		Attrs: map[string]string{"value": "from-attr"},
+		Children: []VNode{
+			{Kind: "text", Text: "from-child"},
+		},
+	}
+	out := renderVNode(ta, map[string]any{})
+	if strings.Contains(out, "from-attr") {
+		t.Errorf("explicit children must override value attr; got %q", out)
+	}
+	if !strings.Contains(out, "from-child") {
+		t.Errorf("child content missing; got %q", out)
+	}
+}
+
+func TestRenderSelectMarksMatchingOption(t *testing.T) {
+	sel := VNode{
+		Kind:  "element",
+		Tag:   "select",
+		Attrs: map[string]string{"name": "role", "value": "artist"},
+		Children: []VNode{
+			{Kind: "element", Tag: "option",
+				Attrs:    map[string]string{"value": "guardian"},
+				Children: []VNode{{Kind: "text", Text: "Guardian"}}},
+			{Kind: "element", Tag: "option",
+				Attrs:    map[string]string{"value": "artist"},
+				Children: []VNode{{Kind: "text", Text: "Artist"}}},
+		},
+	}
+	out := renderVNode(sel, map[string]any{})
+
+	// select itself must NOT carry value= (browsers ignore it).
+	if strings.Contains(out, `<select`) && strings.Contains(out, `value="artist"`) && !strings.Contains(out, `<option`) {
+		// A bit defensive — just check the first attribute block.
+	}
+	selectOpen := strings.Index(out, "<select")
+	selectClose := strings.Index(out, ">")
+	if selectOpen != -1 && selectClose != -1 && selectClose > selectOpen {
+		if strings.Contains(out[selectOpen:selectClose], `value="artist"`) {
+			t.Errorf("select must not carry value= attribute; got %q", out)
+		}
+	}
+	// The matching option must be marked selected.
+	if !strings.Contains(out, `selected="selected"`) {
+		t.Errorf("matching option missing selected attr; got %q", out)
+	}
+	// Only the "artist" option should be selected; "guardian" must not.
+	guardianIdx := strings.Index(out, "Guardian")
+	artistIdx := strings.Index(out, "Artist")
+	guardianOpt := out[:guardianIdx]
+	artistOpt := out[guardianIdx:artistIdx]
+	if strings.Contains(guardianOpt, `selected="selected"`) {
+		t.Errorf("guardian option must not be marked selected; got %q", out)
+	}
+	if !strings.Contains(artistOpt, `selected="selected"`) {
+		t.Errorf("artist option should be marked selected; got %q", out)
+	}
+}
+
+func TestRenderSelectUnselectsStaleSelected(t *testing.T) {
+	// If the user wrote an option with selected= already set but the
+	// select's value points elsewhere, we should flip off the stale
+	// selected so the displayed choice matches the value.
+	sel := VNode{
+		Kind:  "element",
+		Tag:   "select",
+		Attrs: map[string]string{"value": "b"},
+		Children: []VNode{
+			{Kind: "element", Tag: "option",
+				Attrs:    map[string]string{"value": "a", "selected": "selected"},
+				Children: []VNode{{Kind: "text", Text: "A"}}},
+			{Kind: "element", Tag: "option",
+				Attrs:    map[string]string{"value": "b"},
+				Children: []VNode{{Kind: "text", Text: "B"}}},
+		},
+	}
+	out := renderVNode(sel, map[string]any{})
+	// `A` option should no longer carry selected=.
+	aIdx := strings.Index(out, ">A<")
+	bIdx := strings.Index(out, ">B<")
+	if aIdx == -1 || bIdx == -1 {
+		t.Fatalf("both options must be rendered; got %q", out)
+	}
+	// Grab just the <option ...> opening tag for A.
+	aOptStart := strings.LastIndex(out[:aIdx], "<option")
+	aOpt := out[aOptStart:aIdx]
+	if strings.Contains(aOpt, "selected") {
+		t.Errorf("option A must no longer be selected; got %q", aOpt)
+	}
+	bOptStart := strings.LastIndex(out[:bIdx], "<option")
+	bOpt := out[bOptStart:bIdx]
+	if !strings.Contains(bOpt, `selected="selected"`) {
+		t.Errorf("option B should be marked selected; got %q", bOpt)
+	}
+}
+
+func TestRenderInputValueStillAttr(t *testing.T) {
+	// Regular inputs: value lives as an attribute — that's the correct
+	// HTML semantics for <input>. The fix must not accidentally strip
+	// it there.
+	in := VNode{
+		Kind:  "element",
+		Tag:   "input",
+		Attrs: map[string]string{"type": "text", "value": "hello"},
+	}
+	out := renderVNode(in, map[string]any{})
+	if !strings.Contains(out, `value="hello"`) {
+		t.Errorf("input must keep value= attribute; got %q", out)
+	}
+}

--- a/runtime-go/rt/live_msg_decode_test.go
+++ b/runtime-go/rt/live_msg_decode_test.go
@@ -1,0 +1,180 @@
+package rt
+
+// Regression tests for the Msg decode error handling. Before this
+// layer, a type-mismatched wire arg (e.g. a radio's onInput sending
+// a bool into a String -> Msg constructor) would panic deep in
+// reflect.Call. The outer panic-recover around /_sky/event caught
+// the crash but gave no useful diagnostic and silently dropped the
+// event. Now applyMsgArgs inspects the first parameter type up front
+// and returns a msgDecodeError sentinel when the types don't match,
+// with a targeted log line. dispatch() recognises the sentinel and
+// returns "" (no model mutation, no re-render).
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// A Msg constructor with a String parameter — the common
+// UpdateAuthRole-style shape from the sendcrafts bug report.
+func stringMsg(v string) any {
+	return SkyADT{Tag: 1, SkyName: "GotString", Fields: []any{v}}
+}
+
+// TestApplyMsgArgs_MismatchReturnsSentinel — bool arg into a String
+// constructor must return msgDecodeError, not panic.
+func TestApplyMsgArgs_MismatchReturnsSentinel(t *testing.T) {
+	// Wire arg: [true] — boolean, as radio onInput sends.
+	raw := json.RawMessage("true")
+	result := applyMsgArgs(any(stringMsg), []json.RawMessage{raw}, "")
+	if _, ok := result.(msgDecodeError); !ok {
+		t.Errorf("expected msgDecodeError sentinel, got %T %v", result, result)
+	}
+}
+
+// TestApplyMsgArgs_StringArgSucceeds — the happy path. A String arg
+// into a String -> Msg constructor dispatches cleanly.
+func TestApplyMsgArgs_StringArgSucceeds(t *testing.T) {
+	raw := json.RawMessage(`"guardian"`)
+	result := applyMsgArgs(any(stringMsg), []json.RawMessage{raw}, "")
+	adt, ok := result.(SkyADT)
+	if !ok {
+		t.Fatalf("expected SkyADT, got %T %v", result, result)
+	}
+	if adt.SkyName != "GotString" || len(adt.Fields) != 1 || adt.Fields[0] != "guardian" {
+		t.Errorf("bad ADT payload: %+v", adt)
+	}
+}
+
+// TestApplyMsgArgs_AnyParamAccepts — most Sky curried lambdas take
+// `any` at the reflect level (that's what the lowerer emits). The
+// type check must NOT reject those; it's only real Go-typed params
+// (e.g. `func(s string) Msg`) where a wrong-type arg causes panic.
+func TestApplyMsgArgs_AnyParamAccepts(t *testing.T) {
+	anyFn := func(v any) any {
+		return SkyADT{Tag: 0, SkyName: "GotAny", Fields: []any{v}}
+	}
+	raw := json.RawMessage("42")
+	result := applyMsgArgs(any(anyFn), []json.RawMessage{raw}, "")
+	if _, bad := result.(msgDecodeError); bad {
+		t.Errorf("any-param fn should accept any wire arg, got msgDecodeError")
+	}
+	adt, ok := result.(SkyADT)
+	if !ok || adt.SkyName != "GotAny" {
+		t.Errorf("expected ADT, got %T %v", result, result)
+	}
+}
+
+// TestDispatch_DropsMsgDecodeError — dispatch() receiving the sentinel
+// must return "" and NOT touch model state.
+func TestDispatch_DropsMsgDecodeError(t *testing.T) {
+	viewFn := func(model any) any {
+		return velement("p", nil, []any{vtext("v=" + fmt_sprint(model))})
+	}
+	originalModel := "initial"
+	updateCalls := 0
+	app := &liveApp{
+		update: func(msg, model any) any {
+			updateCalls++
+			return SkyTuple2{V0: "MUTATED", V1: cmdT{kind: "none"}}
+		},
+		view:    viewFn,
+		store:   newMemoryStore(30 * time.Minute),
+		locker:  newSessionLocker(),
+		msgTags: map[string]int{},
+	}
+	sess := &liveSession{
+		model:     originalModel,
+		handlers:  map[string]any{},
+		sseCh:     make(chan string, 1),
+		cancelSub: make(chan struct{}),
+	}
+	body := app.dispatch(sess, msgDecodeError{})
+	if body != "" {
+		t.Errorf("decode error must return empty body, got %q", body)
+	}
+	if updateCalls != 0 {
+		t.Errorf("update must not be called on decode error; called %d times", updateCalls)
+	}
+	if sess.model != originalModel {
+		t.Errorf("model mutated on decode error: %v -> %v", originalModel, sess.model)
+	}
+}
+
+// TestDispatch_RecoversFromPanic — a user-code panic inside update
+// must be caught, logged, and not propagate. Session state stays
+// consistent; body returns "" so the client sees no change.
+func TestDispatch_RecoversFromPanic(t *testing.T) {
+	originalModel := "initial"
+	app := &liveApp{
+		update: func(msg, model any) any {
+			panic("deliberate panic from update()")
+		},
+		view: func(model any) any {
+			return velement("p", nil, []any{vtext("x")})
+		},
+		store:   newMemoryStore(30 * time.Minute),
+		locker:  newSessionLocker(),
+		msgTags: map[string]int{},
+	}
+	sess := &liveSession{
+		model:     originalModel,
+		handlers:  map[string]any{},
+		sseCh:     make(chan string, 1),
+		cancelSub: make(chan struct{}),
+	}
+	// Pick any Msg — the update() panic fires regardless.
+	body := app.dispatch(sess, SkyADT{Tag: 0, SkyName: "Anything"})
+	if body != "" {
+		t.Errorf("panic must yield empty body, got %q", body)
+	}
+	if sess.model != originalModel {
+		t.Errorf("model mutated on panic: %v -> %v", originalModel, sess.model)
+	}
+}
+
+// TestArgAssignable_Coverage — the type-check helper must accept:
+// - assignable types (string → string, int → int)
+// - any arg into an interface{} param
+// - nil into pointer/slice/interface params
+// and reject clear mismatches (bool → string).
+func TestArgAssignable_Coverage(t *testing.T) {
+	stringFn := func(s string) any { return s }
+	intFn := func(n int) any { return n }
+	anyFn := func(v any) any { return v }
+	ptrFn := func(p *int) any { return p }
+
+	cases := []struct {
+		name string
+		fn   any
+		arg  any
+		want bool
+	}{
+		{"string->string OK", stringFn, "hi", true},
+		{"bool->string FAIL", stringFn, true, false},
+		{"int->string FAIL", stringFn, 42, false},
+		{"int->int OK", intFn, 42, true},
+		{"float->int FAIL", intFn, 3.14, false},
+		{"any accepts string", anyFn, "hi", true},
+		{"any accepts bool", anyFn, true, true},
+		{"any accepts nil", anyFn, nil, true},
+		{"nil into *int OK", ptrFn, nil, true},
+		{"nil into string FAIL", stringFn, nil, false},
+	}
+	for _, tc := range cases {
+		if got := argAssignableToFunc(tc.fn, tc.arg); got != tc.want {
+			t.Errorf("%s: got %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// fmt_sprint — small helper so the view fn can stringify whatever
+// model value we throw at it without depending on the Sky runtime's
+// kernel `fmt` wiring.
+func fmt_sprint(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return "???"
+}

--- a/runtime-go/rt/rt.go
+++ b/runtime-go/rt/rt.go
@@ -6020,6 +6020,30 @@ func SkyCall(f any, args ...any) any {
 	return result
 }
 
+// isStructuralNarrowCandidate — whitelist for the skyCallDirect
+// fallback. Restricts narrowReflectValue-backed conversion to the
+// kinds where the typed codegen's AsListT / AsMapT / Coerce helpers
+// already do the same walk, so kernels dispatching through
+// reflection stay consistent with direct call sites. Excludes the
+// "primitive → string" fmt.Sprintf path — we want that to remain
+// a panic so a radio onInput bug surfaces cleanly rather than
+// silently becoming the string "true".
+func isStructuralNarrowCandidate(src, target reflect.Kind) bool {
+	if target == reflect.Map && src == reflect.Map {
+		return true
+	}
+	if target == reflect.Slice && src == reflect.Slice {
+		return true
+	}
+	if target == reflect.Struct && src == reflect.Struct {
+		return true
+	}
+	if target == reflect.Ptr || src == reflect.Ptr {
+		return true
+	}
+	return false
+}
+
 func skyCallDirect(rv reflect.Value, args []any) any {
 	vals := make([]reflect.Value, len(args))
 	fnType := rv.Type()
@@ -6044,6 +6068,29 @@ func skyCallDirect(rv reflect.Value, args []any) any {
 			// (See rt.Coerce for the same rule.)
 			vals[i] = av.Convert(pt)
 		default:
+			// Structural narrowing ONLY: the typed codegen inserts
+			// rt.AsListT / rt.AsMapT coercions at direct call sites, but
+			// List_foldlAnyT (and any other reflection-based higher-order
+			// kernel) routes elements through here without that
+			// narrowing. When the param is a concrete map[K]V / []V / *T
+			// / named-struct and the arg is the corresponding any-shaped
+			// runtime value, walk the recursive narrower the boundary
+			// helpers already use.
+			//
+			// Gated on matching-kind containers + pointer (de)ref — we
+			// deliberately do NOT use narrowReflectValue's
+			// any-to-string fmt.Sprintf fallback here, because that
+			// would silently coerce a radio's Bool into a "true" string
+			// when the Msg expected a real chosen value. Silent
+			// primitive-kind coercion is a worse bug than a panic; keep
+			// it a panic so the Msg decode layer or the outer
+			// dispatch recover can surface it as a clean diagnostic.
+			if isStructuralNarrowCandidate(av.Kind(), pt.Kind()) {
+				if narrowed := narrowReflectValue(av, pt); narrowed.IsValid() {
+					vals[i] = narrowed
+					break
+				}
+			}
 			// Audit P0-6: pre-fix this branch silently passed `av` into
 			// reflect.Call with a wrong type, which then panicked inside
 			// reflect with a cryptic "reflect: Call using X as Y" message.

--- a/runtime-go/rt/rt_narrow_dispatch_test.go
+++ b/runtime-go/rt/rt_narrow_dispatch_test.go
@@ -1,0 +1,79 @@
+package rt
+
+// Regression: List_foldlAnyT (and any other reflection-based
+// higher-order kernel) invokes user reducers via reflect.Call. When
+// the reducer is annotated with a concrete Go-typed param like
+// map[string]string or []string and the list element runtime value
+// is the any-shaped equivalent (map[string]interface{} / []interface{}),
+// reflect panics with "Call using X as Y". Typed codegen inserts
+// rt.AsListT/rt.AsMapT coercions at direct call sites, but the
+// reflection kernel path didn't — so List.foldl over an annotated
+// DB row slice blew up before this fix.
+//
+// skyCallDirect now falls back to narrowReflectValue when the exact
+// type / interface / convertible cases all miss, letting reflection
+// dispatch absorb the same structural narrowing the direct path
+// already does.
+
+import (
+	"testing"
+)
+
+func TestSkyCallDirect_NarrowsMapAnyToMapString(t *testing.T) {
+	// Reducer-like shape: takes a typed map, returns anything.
+	fn := func(row map[string]string) string {
+		return row["name"]
+	}
+	// Wire-runtime value is map[string]interface{} (what Db.query
+	// actually returns) — each value stringify-compatible.
+	arg := map[string]interface{}{"name": "Alice", "role": "guardian"}
+	got := SkyCall(fn, arg)
+	if s, ok := got.(string); !ok || s != "Alice" {
+		t.Errorf("expected \"Alice\", got %T %v", got, got)
+	}
+}
+
+func TestSkyCallDirect_NarrowsSliceAnyToSliceString(t *testing.T) {
+	fn := func(items []string) int {
+		return len(items)
+	}
+	arg := []interface{}{"a", "b", "c"}
+	got := SkyCall(fn, arg)
+	if n, ok := got.(int); !ok || n != 3 {
+		t.Errorf("expected 3, got %T %v", got, got)
+	}
+}
+
+func TestSkyCallDirect_NarrowsNestedSliceOfMaps(t *testing.T) {
+	// The sendcrafts / 08-notes-app shape: DB returns []any where
+	// each element is map[string]any, but the reducer wants
+	// []map[string]string (each row narrowed). Whole-value narrow
+	// walks nested containers.
+	fn := func(rows []map[string]string) string {
+		if len(rows) == 0 {
+			return "empty"
+		}
+		return rows[0]["status"]
+	}
+	arg := []interface{}{
+		map[string]interface{}{"status": "pending", "user": "alice"},
+		map[string]interface{}{"status": "verified", "user": "bob"},
+	}
+	got := SkyCall(fn, arg)
+	if s, ok := got.(string); !ok || s != "pending" {
+		t.Errorf("expected \"pending\", got %T %v", got, got)
+	}
+}
+
+func TestSkyCallDirect_StillPanicsOnGenuineMismatch(t *testing.T) {
+	// When the types genuinely can't be narrowed (e.g. bool → string,
+	// the radio-onInput case), skyCallDirect still panics. The dispatch
+	// layer's defer/recover catches it and drops the event.
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic for bool → string mismatch; none occurred")
+		}
+	}()
+	fn := func(s string) string { return s }
+	_ = SkyCall(fn, true)
+}

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -1318,6 +1318,27 @@ main =
 **Navigation**: `a [ href "/about", attribute "sky-nav" "" ] [ text "About" ]`
 **Styling**: Use `Std.Css` with `stylesheet`/`rule` — not inline style strings.
 
+### Event binding — radio groups
+
+Sky.Live's `input`/`change` event on a `<input type="radio">` reports the radio's `checked` state (always `True` at selection), NOT its `value`. Binding a typed constructor like `UpdateRole : String -> Msg` to `onInput` gets a `Bool` at runtime, which the server drops as a Msg decode error.
+
+**Use `onClick` with a fully-applied Msg per radio** (same pattern for per-choice checkboxes):
+
+```elm
+-- One <label> per choice, each carrying a zero-arg Msg.
+choiceRow =
+    label [ for "role-guardian", onClick (UpdateRole "guardian") ]
+        [ input [ type "radio", name "role", value "guardian", id "role-guardian" ] []
+        , text "Guardian"
+        ]
+```
+
+The browser toggles the radio natively via the `for`/`id` pairing; the Msg ADT arrives on the server already applied (no wire-level type coercion). This is the recommended TEA pattern for radio groups.
+
+### Dispatch error handling
+
+Sky.Live's dispatcher is wrapped in `defer/recover`. If your `update`/`view`/`guard` panics — or a wire-level Msg decode mismatches a constructor type — the event is dropped cleanly, the session model is NOT mutated, and a diagnostic is written to stderr (`[sky.live] dispatch panic recovered …` or `[sky.live] Msg decode error …`). The client sees an empty patch list and the DOM stays as-is. Check server logs when an event appears to "do nothing".
+
 ### Sky.Live Component Protocol
 
 Components are separate modules with their own `Model`/`Msg`/`update`/`view`. The compiler auto-wires message routing.


### PR DESCRIPTION
## Summary

Three interconnected runtime-reliability fixes surfaced while testing the v0.9.4 Input Authority work on sendcrafts. Each was a real panic or data-loss class; together they make Sky.Live's dispatch pipeline survive wire-level type mismatches, user-code panics, and the HTML re-parse path without losing state.

### 1. Msg decode errors — no more reflect panics on wire type mismatch

A view binding like `onInput UpdateRole` on `<input type="radio">` sends `[checked:Bool]` (from `t.checked`) instead of `[value:String]`. When `UpdateRole : String -> Msg`, the server panics deep inside `reflect.Call` with `reflect: Call using bool as type string`.

`applyMsgArgs` now pre-flight-checks the constructor's first parameter type via `argAssignableToFunc` BEFORE invoking `reflect.Call`. Mismatches return a `msgDecodeError` sentinel which `dispatch()` short-circuits: no update runs, no model mutation, no re-render. A targeted diagnostic is logged with constructor name, expected type, actual arg type, and raw wire value.

### 2. Dispatch-level panic recover — belt-and-braces for user-code panics

A `defer/recover` at the top of `dispatch()` now catches any panic inside `update`/`view`/`guard` (nil deref, typed-FFI boundary checks, etc.), logs with full `debug.Stack()` context, and drops the event. Session state stays consistent. The existing HTTP middleware recover is unchanged but now serves as a backstop, not the front line.

### 3. Structural narrowing in `skyCallDirect` — typed-codegen gap closed for reflection kernels

`List.foldl` (and any other `List_*AnyT` / reflection-based higher-order) dispatches its reducer via `reflect.Call`. When the reducer's declared param is `map[string]string` (e.g. narrowing a `Db.query` row) and the runtime value is the any-shaped `map[string]any`, the typed-codegen `rt.AsListT` / `rt.AsMapT` coercions at direct call sites don't run — reflection sees the mismatch and panics.

`skyCallDirect` now tries `narrowReflectValue` when the exact-match / convertible / interface-impl cases all miss. Gated via `isStructuralNarrowCandidate` so **only** container shapes narrow (`map[K]any → map[K]V`, `[]any → []V`, `*T` auto-deref, Sky generic container reinstantiation). Primitive-kind coercions (`bool → string`, `int → string`) still panic — silently stringifying a radio's Bool would be a worse bug than the panic.

### 4. Textarea / select rendering — displayed value survives HTML re-parse

`renderVNode` used to emit `<textarea value="X"></textarea>`. Per HTML spec, textarea's displayed value is its **text content** between the tags, not a `value=` attribute — browsers ignore the attribute. The moment any server response caused an HTML re-parse (full-body fallback or innerHTML patch at an ancestor), textareas came back empty even though the server's model tracked the text correctly.

Fix:
- `<textarea>`: strip `value` from attribute emission, splice it in as HTML-escaped text content between the tags. User-authored children (`textarea [] [text "x"]`) still win.
- `<select>`: strip `value` from attribute emission, walk children flipping `selected=` on the matching `<option>`, clearing stale `selected=` on non-matching ones.
- `<input type="text">` unchanged — `value` IS a real attribute there.

## Architectural arc (commits squashed here)

1. `4a9fd57` graceful dispatch errors + structural narrowing (Msg decode, panic recover, `skyCallDirect` narrowing).
2. `8dde2d4` textarea value as text content; select marks matching option.

## Docs updates

`CLAUDE.md` + `templates/CLAUDE.md` now document:

- Full event/arg dispatch table (what `onInput`/`onChange` etc. actually wire up per input type).
- The `onClick`-per-radio convention with a worked example (no more bool-vs-string pitfall on radio groups).
- Dispatch error handling behaviour so devs know to check `[sky.live] dispatch panic recovered` or `[sky.live] Msg decode error` in logs when an event "does nothing".

## Tests

15 new cases across 3 files + all pre-existing tests still green.

- `live_msg_decode_test.go` — 5 cases: mismatch-returns-sentinel, string-arg-succeeds, any-param-accepts-anything, dispatch-drops-sentinel, dispatch-recovers-from-panic, `argAssignableToFunc` coverage.
- `rt_narrow_dispatch_test.go` — 4 cases: map-any-to-map-string, slice-any-to-slice-string, nested-slice-of-maps (the sendcrafts shape), genuine-mismatch-still-panics.
- `live_form_rendering_test.go` — 6 cases: textarea content emission + XSS escape, user-children override, select marks matching option, select clears stale selected, input keeps value attr.
- `skycall_strict_test.go` (pre-existing) — confirms the P0-6 boundary check still rejects primitive-kind mismatches.

## Test plan

- [x] `go test ./rt/`: ok, full suite green.
- [x] `/tmp/skylive_e2e.sh`: 6/6 Live examples pass dispatch smoke.
- [x] All 18 examples rebuild clean against the new compiler.
- [x] User-confirmed working in browser against sendcrafts: signup form (previously panicked on radio group), textarea values survive navigation.
- [ ] CI green on main after squash-merge.
- [ ] Clean-slate sweep of all 18 examples before tag.

## Files touched

- `runtime-go/rt/live.go` — applyMsgArgs type check + sentinel, dispatch() defer/recover, renderVNode textarea/select.
- `runtime-go/rt/rt.go` — skyCallDirect structural narrowing + `isStructuralNarrowCandidate` whitelist.
- `runtime-go/rt/live_msg_decode_test.go` (new), `rt_narrow_dispatch_test.go` (new), `live_form_rendering_test.go` (new) — 15 new cases.
- `CLAUDE.md`, `templates/CLAUDE.md` — event table + radio convention + error handling docs.
- `Dockerfile.local`, `build_docker_local.sh` — source-build variant for local testing (image tag `anzel/sky:local`, not pushed).