### PR TITLE
Print message to user when instalaling go deps

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -529,7 +529,6 @@ appendGoDependency pkg = do
 -- inspector failures — user can still run `sky add <pkg>` manually.
 regenMissingBindings :: [(String, String)] -> IO ()
 regenMissingBindings deps = do
-    putStrLn $ "-- Installing " ++ show (length deps) ++ " Go dependency(ies)"
     createDirectoryIfMissing True ".skycache/ffi"
     mapM_ regenOne deps
   where
@@ -1104,6 +1103,7 @@ runCommand cmd = case cmd of
         -- the old workflow where bindings were checked-in under ffi/.
         let goDeps = Toml._goDeps config
         when (not (null goDeps)) $ do
+            putStrLn $ "Installing " ++ show (length deps) ++ " Go dependency(ies)"
             createDirectoryIfMissing True "sky-out"
             hasGoMod <- doesFileExist "sky-out/go.mod"
             when (not hasGoMod) $ do
@@ -1112,6 +1112,7 @@ runCommand cmd = case cmd of
                     then callProcess "cp" ["runtime-go/go.mod", "sky-out/go.mod"]
                     else writeFile "sky-out/go.mod" $ unlines ["module sky-app", "", "go 1.21"]
             regenMissingBindings goDeps
+            putStrLn $ "Go dependencies installed."
         case Toml._skyDeps config of
             [] -> return ()
             _  -> putStrLn "Sky dependencies installed."

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -529,6 +529,7 @@ appendGoDependency pkg = do
 -- inspector failures — user can still run `sky add <pkg>` manually.
 regenMissingBindings :: [(String, String)] -> IO ()
 regenMissingBindings deps = do
+    putStrLn $ "-- Installing " ++ show (length deps) ++ " Go dependency(ies)"
     createDirectoryIfMissing True ".skycache/ffi"
     mapM_ regenOne deps
   where

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1103,7 +1103,7 @@ runCommand cmd = case cmd of
         -- the old workflow where bindings were checked-in under ffi/.
         let goDeps = Toml._goDeps config
         when (not (null goDeps)) $ do
-            putStrLn $ "Installing " ++ show (length deps) ++ " Go dependency(ies)"
+            putStrLn $ "Installing " ++ show (length goDeps) ++ " Go dependency(ies)"
             createDirectoryIfMissing True "sky-out"
             hasGoMod <- doesFileExist "sky-out/go.mod"
             when (not hasGoMod) $ do


### PR DESCRIPTION
Running `sky install` at `examples` folder on an old machine like mine only prints a blank line. The user may be confused if the installation has stalled or is still running. 

I added simple messages when installing Go dependencies, but I think it would be much better if Sky printed the output of the `go get` process when installing dependencies one by one (see [`here`](https://github.com/anzellai/sky/blob/094c9b711f76f256e21904ba6a1ee27ac8ddad82/app/Main.hs#L542)). Maybe a progress bar or terminal spinner?


Before this patch:

```bash
sky/examples/07-todo-cli/ $ sky install


```

After:

```bash
sky/examples/07-todo-cli/ $ sky install
Installing 2 Go dependency(ies)
Go dependencies installed.
``` 