### PR TITLE
Added screenshots/screen casts to examples

### DIFF
--- a/examples/01-hello-world/README.md
+++ b/examples/01-hello-world/README.md
@@ -8,3 +8,5 @@ The simplest Sky programme -- prints a greeting to stdout.
 sky build src/Main.sky
 ./sky-out/app
 ```
+
+<img width="829" height="206" alt="01-hello-world" src="https://github.com/user-attachments/assets/6ba24bf8-ff71-44ce-8bb2-79525a70ba59" />

--- a/examples/02-go-stdlib/README.md
+++ b/examples/02-go-stdlib/README.md
@@ -11,3 +11,5 @@ sky build src/Main.sky
 ```
 
 Requires `sky install` first to generate FFI bindings for Go stdlib packages.
+
+<img width="828" height="318" alt="02-go-stdlib" src="https://github.com/user-attachments/assets/3054cd4a-6d8e-4db0-9694-3f5753af697d" />

--- a/examples/03-tea-external/README.md
+++ b/examples/03-tea-external/README.md
@@ -11,3 +11,5 @@ sky build src/Main.sky
 ```
 
 Requires `sky install` first to fetch Go dependencies and generate FFI bindings.
+
+<img width="830" height="227" alt="03-tea-external" src="https://github.com/user-attachments/assets/66871b17-a026-4e24-92b2-6a483729d931" />

--- a/examples/04-local-pkg/README.md
+++ b/examples/04-local-pkg/README.md
@@ -8,3 +8,5 @@ Multi-module project showing how to import and use local Sky modules (`Lib.Utils
 sky build src/Main.sky
 ./sky-out/app
 ```
+
+<img width="828" height="205" alt="04-local-pkg" src="https://github.com/user-attachments/assets/54695b62-2629-465c-a0bd-ef4d53af8da1" />

--- a/examples/05-mux-server/README.md
+++ b/examples/05-mux-server/README.md
@@ -11,3 +11,8 @@ sky build src/Main.sky
 ```
 
 Requires `sky install` first to fetch Go dependencies. The server listens on port 8000.
+
+<img width="830" height="256" alt="05-mux-server" src="https://github.com/user-attachments/assets/6d5ecc32-267f-494b-9f9c-ce8d826ae357" />
+
+<img width="800" height="734" alt="05-mux-server mp4" src="https://github.com/user-attachments/assets/fa51951f-68c8-4605-9ddc-fb4096baf288" />
+

--- a/examples/06-json/README.md
+++ b/examples/06-json/README.md
@@ -27,3 +27,5 @@ sky build src/Main.sky
 Sections 10–12 demonstrate the **applicative combinators** added in v0.7.25 — useful for form validation, multi-field parsing, and any case where you have several Results to combine without writing nested case expressions.
 
 Section 10 also showcases v0.7.26's **auto record constructors**: every `type alias Foo = { ... }` automatically generates a positional constructor function `Foo : ... -> Foo` (matches the convention Elm uses for the same construct), so you can pass the type alias name directly into `Result.map3` instead of writing a `makeFoo` helper.
+
+<img width="463" height="907" alt="06-json" src="https://github.com/user-attachments/assets/bfb18d80-d23d-4ae4-88a8-e7c22aaf9f15" />

--- a/examples/07-todo-cli/README.md
+++ b/examples/07-todo-cli/README.md
@@ -19,3 +19,5 @@ Requires `sky install` first. Usage:
 ./sky-out/app remove 1
 ./sky-out/app clear
 ```
+
+<img width="790" height="912" alt="07-todo-cli" src="https://github.com/user-attachments/assets/82708b12-2ead-4d96-bbaf-f21935a2259b" />

--- a/examples/08-notes-app/README.md
+++ b/examples/08-notes-app/README.md
@@ -11,3 +11,7 @@ sky build src/Main.sky
 ```
 
 Requires `sky install` first. The server listens on port 8000.
+
+<img width="820" height="740" alt="08-notes-app" src="https://github.com/user-attachments/assets/12feec58-352d-4ed5-8f3c-2990fb0e7a4d" />
+
+<img width="1024" height="557" alt="08-note-taking-app mp4" src="https://github.com/user-attachments/assets/33f80127-a7ec-456c-8b49-699e34a293b4" />

--- a/examples/09-live-counter/README.md
+++ b/examples/09-live-counter/README.md
@@ -10,3 +10,5 @@ sky build src/Main.sky
 ```
 
 The server listens on port 8000. Open `http://localhost:8000` in a browser.
+
+<img width="1024" height="441" alt="09-live-counter mp4" src="https://github.com/user-attachments/assets/5a48c182-2bb6-4bd2-a786-a2daab8a5000" />

--- a/examples/10-live-component/README.md
+++ b/examples/10-live-component/README.md
@@ -10,3 +10,5 @@ sky build src/Main.sky
 ```
 
 Open `http://localhost:8000` in your browser.
+
+<img width="1024" height="441" alt="10-live-component mp4" src="https://github.com/user-attachments/assets/afa58864-0210-4eb8-9fd2-0d64843ab505" />

--- a/examples/12-skyvote/README.md
+++ b/examples/12-skyvote/README.md
@@ -11,3 +11,5 @@ sky build src/Main.sky
 ```
 
 Open `http://localhost:8000` in your browser. Data is stored in a local SQLite database.
+
+<img width="1024" height="666" alt="12-skyvote mp4" src="https://github.com/user-attachments/assets/9093f6e7-7bb4-49b5-8dee-66b4bd71a0a3" />

--- a/examples/14-task-demo/README.md
+++ b/examples/14-task-demo/README.md
@@ -10,3 +10,5 @@ sky build src/Main.sky
 ```
 
 Shows how `Task.andThen`, `Task.map`, `Task.sequence`, and `Task.parallel` compose effectful computations.
+
+<img width="671" height="416" alt="14-task-demo" src="https://github.com/user-attachments/assets/783c5d0d-6ecb-421e-9779-5f2738005f8b" />

--- a/examples/15-http-server/README.md
+++ b/examples/15-http-server/README.md
@@ -10,3 +10,5 @@ sky build src/Main.sky
 ```
 
 Open `http://localhost:8000` in your browser. Includes GET/POST routes, cookie handling, and static file serving.
+
+<img width="1024" height="659" alt="15-http-server mp4" src="https://github.com/user-attachments/assets/c64e0feb-51d2-4537-bf67-19eb4f2ad686" />

--- a/examples/16-skychess/README.md
+++ b/examples/16-skychess/README.md
@@ -11,3 +11,5 @@ sky build src/Main.sky
 ```
 
 Open `http://localhost:8000` in your browser. Play as white against the AI.
+
+<img width="1024" height="666" alt="16-skychess mp4" src="https://github.com/user-attachments/assets/5843c911-cb7b-4d68-8ae4-7b7c4ace7b19" />

--- a/examples/17-skymon/README.md
+++ b/examples/17-skymon/README.md
@@ -11,3 +11,5 @@ sky build src/Main.sky
 ```
 
 Open `http://localhost:8000` in your browser. Configure monitors and alert thresholds from the dashboard.
+
+<img width="1024" height="666" alt="17-skymon mp4" src="https://github.com/user-attachments/assets/add828cf-e94a-4582-9570-57a1f811c53f" />

--- a/examples/18-job-queue/README.md
+++ b/examples/18-job-queue/README.md
@@ -12,3 +12,4 @@ sky build src/Main.sky
 
 Open `http://localhost:8000` in your browser. Simulate different jobs and snapshots.
 
+<img width="1024" height="666" alt="18-job-queue mp4" src="https://github.com/user-attachments/assets/ee8e88d9-5899-4a57-a466-25b7493a8391" />

--- a/examples/18-job-queue/README.md
+++ b/examples/18-job-queue/README.md
@@ -1,0 +1,14 @@
+# Job queue
+
+Simulate a job queue composed of tasks with different timings. 
+
+
+## Build & Run
+
+```bash
+sky build src/Main.sky
+./sky-out/app
+```
+
+Open `http://localhost:8000` in your browser. Simulate different jobs and snapshots.
+

--- a/examples/19-skyforum/README.md
+++ b/examples/19-skyforum/README.md
@@ -1,0 +1,13 @@
+# SkyForum
+
+A Reddit/HackerNews-style demo built with Sky.Live and Std.Ui. The view layer is split across multiple modules (State / Update / View.Common / View.Posts / View.Detail / View.Compose / View.Login) so each per-module type-check stays well below the heap-exhaustion limit (CLAUDE.md Limitation #17).
+A single monolithic Main with the same surface OOMs the type-checker and locked the Mac that birthed scripts/mem-guard.sh — the split form gives us the full feature surface at zero ergonomics cost pending compiler fix.
+
+## Build & Run
+
+```bash
+sky build src/Main.sky
+./sky-out/app
+```
+
+Open `http://localhost:8000` in your browser.

--- a/examples/19-skyforum/README.md
+++ b/examples/19-skyforum/README.md
@@ -1,7 +1,6 @@
 # SkyForum
 
-A Reddit/HackerNews-style demo built with Sky.Live and Std.Ui. The view layer is split across multiple modules (State / Update / View.Common / View.Posts / View.Detail / View.Compose / View.Login) so each per-module type-check stays well below the heap-exhaustion limit (CLAUDE.md Limitation #17).
-A single monolithic Main with the same surface OOMs the type-checker and locked the Mac that birthed scripts/mem-guard.sh — the split form gives us the full feature surface at zero ergonomics cost pending compiler fix.
+A Reddit/HackerNews-style demo built with Sky.Live and Std.Ui. The view layer is split across multiple modules (State / Update / View.Common / View.Posts / View.Detail / View.Compose / View.Login).
 
 ## Build & Run
 
@@ -11,3 +10,5 @@ sky build src/Main.sky
 ```
 
 Open `http://localhost:8000` in your browser.
+
+<img width="1024" height="636" alt="19-skyforum mp4" src="https://github.com/user-attachments/assets/df2c75dc-6e4e-407e-817b-4503c03d01da" />


### PR DESCRIPTION
A simple set of screenshots/screen casts to demonstrate the result of compiling and running the examples.

I have accidentally closed the [other PR](#39 ) when syncing fork through Github. This one handles all modifications needed, including the addition of `README.md` to examples 18 and 19.

I have not added images to:

- [11-fyne-stopwatch](https://github.com/anzellai/sky/tree/main/examples/11-fyne-stopwatch): the example doesn't work as expected. I won't be able to check it ATM.

- [13-skyshop](https://github.com/anzellai/sky/tree/main/examples/13-skyshop): I don't have a Firestore key so I moved to other examples.