### PR TITLE
Modify LSP configuration and add grammar setup instructions

### DIFF
--- a/docs/tooling/lsp.md
+++ b/docs/tooling/lsp.md
@@ -50,12 +50,33 @@ scope = "source.sky"
 file-types = ["sky"]
 indent = { tab-width = 4, unit = "    " }
 auto-format = true
-formatter = { command = "sky", args = ["fmt"] }
+formatter = { command = "sky", args = ["fmt", "--stdin" ] }
 language-servers = ["sky-lsp"]
 
 [language-server.sky-lsp]
 command = "sky"
 args = ["lsp"]
+
+[[grammar]]
+name = "sky"
+source = { git = "https://github.com/anzellai/tree-sitter-sky", rev = "main" }
+```
+
+Then fetch and build:
+
+```bash
+hx --grammar fetch
+hx --grammar build
+```
+
+Finally copy some needed files:
+
+```bash
+curl --create-dirs --output-dir ~/.config/helix/runtime/queries/sky \
+  -O https://raw.githubusercontent.com/anzellai/tree-sitter-sky/refs/heads/main/queries/highlights.scm \
+  -O https://raw.githubusercontent.com/anzellai/tree-sitter-sky/refs/heads/main/queries/locals.scm \
+  -O https://raw.githubusercontent.com/anzellai/tree-sitter-sky/refs/heads/main/queries/tags.scm
+
 ```
 
 ### Zed


### PR DESCRIPTION
Updated formater command to include `--stdin` argument, otherwise the file content was replaced by `sky fmt` output (e.g. "Formatted src/Main.sky").

Also added proper instructions for fetching and building tree-sitter grammar files.