### PR TITLE
hotfix: gate unix dep + Posix.Signals to non-Windows (v0.11.8)

### DIFF
--- a/sky-compiler.cabal
+++ b/sky-compiler.cabal
@@ -62,8 +62,16 @@ executable sky
     ansi-terminal >= 0.11,
     file-embed >= 0.0.15,
     template-haskell >= 2.18,
-    temporary >= 1.3,
-    unix >= 2.7
+    temporary >= 1.3
+
+  -- POSIX signals are POSIX-only. Used by Sky.Cli.Watch to forward
+  -- SIGTERM into the same UserInterrupt-based clean-exit path that
+  -- Ctrl-C goes through. Windows has no SIGTERM in the POSIX sense
+  -- (terminateProcess on Windows is unconditional already), so we
+  -- conditionally skip the dependency + the corresponding handler
+  -- via CPP guards inside Sky.Cli.Watch.
+  if !os(windows)
+    build-depends: unix >= 2.7
 
   autogen-modules: Paths_sky_compiler
   other-modules:

--- a/src/Sky/Cli/Watch.hs
+++ b/src/Sky/Cli/Watch.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -42,7 +43,9 @@ import System.FilePath ((</>), takeDirectory, takeExtension, takeFileName)
 import System.IO (hFlush, hPutStrLn, stderr, stdout)
 import qualified System.Process as P
 import System.Process (ProcessHandle, getProcessExitCode, terminateProcess)
+#ifndef mingw32_HOST_OS
 import qualified System.Posix.Signals as Sig
+#endif
 import qualified Data.Time.Clock as Clock
 import qualified Data.Time.Clock.POSIX as POSIX
 
@@ -194,9 +197,12 @@ killChildGraceful timeoutMs ph = do
         | steps <= 0 = do
             -- Escalate. There's no portable Haskell SIGKILL helper so go
             -- through System.Posix.Signals directly. On Windows the
-            -- terminateProcess call above already wins.
+            -- terminateProcess call above is unconditional already
+            -- (TerminateProcess), so there is nothing to escalate to.
+#ifndef mingw32_HOST_OS
             mPid <- P.getPid ph
             forM_ mPid $ \pid -> Sig.signalProcess Sig.sigKILL pid
+#endif
             -- Reap so the handle releases its zombie slot.
             _ <- P.waitForProcess ph
             pure ()
@@ -293,11 +299,15 @@ runWatch opts = do
     childRef <- newIORef (Nothing :: Maybe ProcessHandle)
 
     -- Forward SIGTERM to the main thread as UserInterrupt, joining the
-    -- same clean-exit path Ctrl-C uses.
+    -- same clean-exit path Ctrl-C uses. POSIX-only — Windows has no
+    -- SIGTERM in this sense; Ctrl-C / Ctrl-Break still raise
+    -- UserInterrupt via the GHC RTS on every platform.
+#ifndef mingw32_HOST_OS
     mainTid <- Control.Concurrent.myThreadId
     _ <- Sig.installHandler Sig.sigTERM
             (Sig.CatchOnce (E.throwTo mainTid E.UserInterrupt))
             Nothing
+#endif
 
     let cleanup = do
             mch <- readIORef childRef


### PR DESCRIPTION
## Summary
- v0.11.8 Release run [25515137058](https://github.com/anzellai/sky/actions/runs/25515137058) failed on `build (windows-latest, sky-windows-x64, .exe)` because PR #46 added an unconditional `unix >= 2.7` cabal dep + a `System.Posix.Signals` import in `Sky.Cli.Watch`. The `unix` package is POSIX-only.
- This hotfix wraps the dep + handler in cross-platform guards so Windows skips them entirely. POSIX still gets the SIGTERM forwarder; Windows still has the same Ctrl-C / Ctrl-Break clean-exit path via the GHC RTS.

## Root cause
PR #46 added (in `sky-compiler.cabal`):
\`\`\`
unix >= 2.7
\`\`\`
and (in `src/Sky/Cli/Watch.hs`):
\`\`\`hs
import qualified System.Posix.Signals as Sig
...
Sig.installHandler Sig.sigTERM (Sig.CatchOnce (E.throwTo mainTid E.UserInterrupt)) Nothing
...
forM_ mPid $ \pid -> Sig.signalProcess Sig.sigKILL pid
\`\`\`
On Windows, cabal-install backjumps through every base version trying to satisfy unix's `base >= 4.5 && < 4.9` constraint:
\`\`\`
rejecting: base-4.17.2.1/installed-4.17.2.1
    (conflict: unix => base>=4.5 && <4.9)
\`\`\`
… and bails.

## Fix
- `sky-compiler.cabal`: `if !os(windows): build-depends: unix >= 2.7`.
- `src/Sky/Cli/Watch.hs`: added `{-# LANGUAGE CPP #-}` and gated the import + the SIGTERM-forwarder install + the SIGKILL escalation with `#ifndef mingw32_HOST_OS`. On Windows, `terminateProcess` maps to `TerminateProcess()` which is unconditional, so the escalation is a no-op there.

## Verification
- POSIX `cabal build exe:sky` → clean.
- POSIX `cabal test` → 155/155 (lone flake was a stale skyforum server holding port 8000 from a prior test run; rerunning the spec passes).
- `ghc -E -cpp -Dmingw32_HOST_OS Sky/Cli/Watch.hs` confirms the Windows preprocess emits zero `Sig.` references.

## Re-tag plan (after merge)
1. Delete `v0.11.8` tag locally + on origin (no Release artefact was published, so no consumers).
2. Re-tag the merge commit on main as `v0.11.8`.
3. Push the new tag → Release workflow re-runs across Linux/macOS/Windows.

## Test plan
- [x] POSIX cabal build green
- [x] POSIX cabal test 155/155 (modulo port-8000 flake)
- [x] Windows preprocess removes Posix.Signals references
- [ ] Release workflow green on linux + macos + windows after merge + retag