### PR TITLE
FFI Result-type enforcement at HM level + e2e verification harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,8 @@ legacy-ts-compiler/node_modules/
 /.direnv/
 /.envrc.local
 sky.zip
+
+# Local-only example verification — playwright recordings,
+# screenshots, traces. Not source; per-developer; regenerated
+# whenever scripts/verify-examples.sh is run.
+_verify/

--- a/examples/02-go-stdlib/src/Main.sky
+++ b/examples/02-go-stdlib/src/Main.sky
@@ -13,9 +13,7 @@ import Std.Log exposing (println)
 main =
     let
         nowStr =
-            Time.now ()
-                |> Task.run
-                |> Result.map Time.timeString
+            Time.now () |> Task.run |> Result.map Time.timeString
                 |> Result.withDefault "unknown"
         _ = println ("Current time: " ++ nowStr)
         data = "Hello, Sky!"
@@ -30,7 +28,7 @@ main =
                 Ok resp ->
                     println
                         ("HTTP response received, body length: "
-                             ++ String.fromInt (String.length resp.body))
+                            ++ String.fromInt (String.length resp.body))
 
                 Err e ->
                     println ("HTTP error: " ++ errorToString e)

--- a/examples/03-tea-external/src/Main.sky
+++ b/examples/03-tea-external/src/Main.sky
@@ -13,4 +13,4 @@ main =
             println ("Generated UUID: " ++ uuid)
 
         Err e ->
-            println ("Failed to generate UUID: " ++ e)
+            println ("Failed to generate UUID: " ++ errorToString e)

--- a/examples/04-local-pkg/src/Main.sky
+++ b/examples/04-local-pkg/src/Main.sky
@@ -12,6 +12,6 @@ main =
         sum = Utils.add a b
         message = Utils.formatMessage "Current" sum
     in
-        -- println takes a single String; concat the prefix and the
-        -- formatted message before passing.
+    -- println takes a single String; concat the prefix and the
+    -- formatted message before passing.
         println ("Calculation result: " ++ message)

--- a/examples/05-mux-server/src/Main.sky
+++ b/examples/05-mux-server/src/Main.sky
@@ -56,6 +56,6 @@ main =
 
         Err e ->
             let
-                _ = println ("Failed to create router: " ++ e)
+                _ = println ("Failed to create router: " ++ errorToString e)
             in
                 ()

--- a/examples/06-json/src/Main.sky
+++ b/examples/06-json/src/Main.sky
@@ -92,7 +92,7 @@ decodeSimpleExample =
 userDecoder =
     Decode.succeed
         (\name email age verified ->
-             { name = name, email = email, age = age, verified = verified })
+            { name = name, email = email, age = age, verified = verified })
         |> Pipeline.required "name" Decode.string
         |> Pipeline.required "email" Decode.string
         |> Pipeline.required "age" Decode.int
@@ -132,10 +132,10 @@ optionalExample =
         Result.withDefault
             "profile error"
             (Result.map
-                 (\p ->
-                      "@" ++ p.username ++ ", bio: " ++ p.bio ++ ", followers: "
-                          ++ String.fromInt p.followers)
-                 result)
+                (\p ->
+                    "@" ++ p.username ++ ", bio: " ++ p.bio ++ ", followers: "
+                        ++ String.fromInt p.followers)
+                result)
 
 
 -- 6. Nested field access
@@ -150,8 +150,8 @@ nestedExample =
     Result.withDefault
         "nested error"
         (Decode.decodeString
-             nestedDecoder
-             "{\"user\":{\"profile\":{\"name\":\"Eve\",\"city\":\"London\"}}}")
+            nestedDecoder
+            "{\"user\":{\"profile\":{\"name\":\"Eve\",\"city\":\"London\"}}}")
 
 
 -- 7. Decoding a list of objects
@@ -176,8 +176,8 @@ listExample =
         Result.withDefault
             "list error"
             (Result.map
-                 (\todos -> String.join ", " (List.map (\t -> t.title) todos))
-                 result)
+                (\todos -> String.join ", " (List.map (\t -> t.title) todos))
+                result)
 
 
 -- 8. Roundtrip: Encode -> JSON String -> Decode
@@ -196,12 +196,12 @@ roundtrip =
         decoder =
             Decode.map2
                 (\c ns ->
-                     "Count: " ++ String.fromInt c ++ ", Names: "
-                         ++ String.join ", " ns)
+                    "Count: " ++ String.fromInt c ++ ", Names: "
+                        ++ String.join ", " ns)
                 (Decode.field "count" Decode.int)
                 (Decode.field
-                     "items"
-                     (Decode.list (Decode.field "name" Decode.string)))
+                    "items"
+                    (Decode.list (Decode.field "name" Decode.string)))
         result = Decode.decodeString decoder jsonStr
     in
         Result.withDefault "roundtrip error" result

--- a/examples/07-todo-cli/src/Main.sky
+++ b/examples/07-todo-cli/src/Main.sky
@@ -17,7 +17,6 @@ module Main exposing (main)
 -- which prints to stderr and `System.exit 1`s. No silent `let _ = …`
 -- discard pattern — every effect either runs to completion via the
 -- chain or surfaces its error through the reporter.
-
 import Sky.Core.Prelude exposing (..)
 import Sky.Core.List as List
 import Sky.Core.Maybe as Maybe
@@ -41,10 +40,11 @@ import Std.Log exposing (println)
 -- CLI entry points.
 main =
     let
+    -- System.args is Task Error (List String) after the
+    -- v1.0 Task-everywhere migration. Force at the
+    -- read site for ergonomic let-binding access.
         pipeline =
-            Db.connect ()
-                |> Task.andThen runApp
-                |> Task.onError reportError
+            Db.connect () |> Task.andThen runApp |> Task.onError reportError
         _ = Task.run pipeline
     in
         ()
@@ -56,13 +56,8 @@ runApp conn =
         |> Task.andThen
                (\_ ->
                    let
-                       -- System.args is Task Error (List String) after the
-                       -- v1.0 Task-everywhere migration. Force at the
-                       -- read site for ergonomic let-binding access.
                        userArgs =
-                           System.args ()
-                               |> Task.run
-                               |> Result.withDefault []
+                           System.args () |> Task.run |> Result.withDefault []
                        cmd = getArg userArgs
                        cmdArg = getArg (List.drop 1 userArgs)
                    in
@@ -118,6 +113,7 @@ listTodos conn =
                                    "No todos yet. Add one with: ./app add \"My task\""
                        in
                            ()
+
                    else
                        let
                            _ = println "Your TODOs:"
@@ -141,6 +137,7 @@ formatTodo row =
         status =
             if todoDone == "1" then
                 "[x]"
+
             else
                 "[ ]"
     in
@@ -152,8 +149,10 @@ markDone conn idStr =
     Db.exec conn "UPDATE todos SET done = 1 WHERE id = ?" [idStr]
         |> Task.map
                (\_ ->
-                   let _ = println ("Marked as done: " ++ idStr) in
-                   ())
+                   let
+                       _ = println ("Marked as done: " ++ idStr)
+                   in
+                       ())
 
 
 markUndone : Db -> String -> Task Error ()
@@ -161,8 +160,10 @@ markUndone conn idStr =
     Db.exec conn "UPDATE todos SET done = 0 WHERE id = ?" [idStr]
         |> Task.map
                (\_ ->
-                   let _ = println ("Marked as not done: " ++ idStr) in
-                   ())
+                   let
+                       _ = println ("Marked as not done: " ++ idStr)
+                   in
+                       ())
 
 
 removeTodo : Db -> String -> Task Error ()
@@ -170,8 +171,10 @@ removeTodo conn idStr =
     Db.exec conn "DELETE FROM todos WHERE id = ?" [idStr]
         |> Task.map
                (\_ ->
-                   let _ = println ("Removed todo: " ++ idStr) in
-                   ())
+                   let
+                       _ = println ("Removed todo: " ++ idStr)
+                   in
+                       ())
 
 
 clearDone : Db -> Task Error ()
@@ -179,8 +182,10 @@ clearDone conn =
     Db.exec conn "DELETE FROM todos WHERE done = 1" []
         |> Task.map
                (\_ ->
-                   let _ = println "Cleared completed todos" in
-                   ())
+                   let
+                       _ = println "Cleared completed todos"
+                   in
+                       ())
 
 
 showUsage : Task Error ()
@@ -210,8 +215,11 @@ runCommand conn cmd cmdArg =
 
         "add" ->
             if cmdArg == "" then
-                let _ = println "Usage: ./app add <title>" in
-                Task.succeed ()
+                let
+                    _ = println "Usage: ./app add <title>"
+                in
+                    Task.succeed ()
+
             else
                 addTodo conn cmdArg
 
@@ -220,22 +228,31 @@ runCommand conn cmd cmdArg =
 
         "done" ->
             if cmdArg == "" then
-                let _ = println "Usage: ./app done <id>" in
-                Task.succeed ()
+                let
+                    _ = println "Usage: ./app done <id>"
+                in
+                    Task.succeed ()
+
             else
                 markDone conn cmdArg
 
         "undone" ->
             if cmdArg == "" then
-                let _ = println "Usage: ./app undone <id>" in
-                Task.succeed ()
+                let
+                    _ = println "Usage: ./app undone <id>"
+                in
+                    Task.succeed ()
+
             else
                 markUndone conn cmdArg
 
         "remove" ->
             if cmdArg == "" then
-                let _ = println "Usage: ./app remove <id>" in
-                Task.succeed ()
+                let
+                    _ = println "Usage: ./app remove <id>"
+                in
+                    Task.succeed ()
+
             else
                 removeTodo conn cmdArg
 

--- a/examples/08-notes-app/src/Lib/Auth.sky
+++ b/examples/08-notes-app/src/Lib/Auth.sky
@@ -1,4 +1,13 @@
-module Lib.Auth exposing (hashPassword, verifyPassword, generateToken, createUser, authenticateUser, createSession, getSessionUser, verifyEmail)
+module Lib.Auth exposing
+    ( hashPassword
+    , verifyPassword
+    , generateToken
+    , createUser
+    , authenticateUser
+    , createSession
+    , getSessionUser
+    , verifyEmail
+    )
 
 import Sky.Core.Prelude exposing (..)
 import Sky.Core.Maybe exposing (..)
@@ -25,8 +34,8 @@ hashPassword password =
 
 verifyPassword : String -> String -> Bool
 verifyPassword password storedHash =
-    -- Auth.verifyPassword returns Result Error Bool — collapse with
-    -- withDefault False (auth-deny on internal error, not auth-grant).
+-- Auth.verifyPassword returns Result Error Bool — collapse with
+-- withDefault False (auth-deny on internal error, not auth-grant).
     Result.withDefault False (Auth.verifyPassword password storedHash)
 
 
@@ -63,7 +72,7 @@ createUser email password =
             Err _ ->
                 Err
                     (Error.invalidInput
-                         "That email is already registered, or a server error occurred.")
+                        "That email is already registered, or a server error occurred.")
 
 
 checkUserCredentials password user =
@@ -78,13 +87,13 @@ checkUserCredentials password user =
             else
                 Err
                     (Error.permissionDenied
-                         |> Error.withMessage
-                                "Email not verified yet. Please check the server console for your verification link.")
+                        |> Error.withMessage
+                               "Email not verified yet. Please check the server console for your verification link.")
 
         else
             Err
                 (Error.permissionDenied
-                     |> Error.withMessage "Invalid email or password.")
+                    |> Error.withMessage "Invalid email or password.")
 
 
 -- authenticateUser : Result Error User. DB errors surface upstream so
@@ -105,7 +114,7 @@ authenticateUser email password =
                 Nothing ->
                     Err
                         (Error.permissionDenied
-                             |> Error.withMessage "Invalid email or password.")
+                            |> Error.withMessage "Invalid email or password.")
 
                 Just user ->
                     checkUserCredentials password user

--- a/examples/08-notes-app/src/Lib/Db.sky
+++ b/examples/08-notes-app/src/Lib/Db.sky
@@ -29,8 +29,7 @@ conn =
             let
                 _ =
                     println
-                        ("[FATAL] Cannot open skynotes.db: "
-                             ++ Error.toString e)
+                        ("[FATAL] Cannot open skynotes.db: " ++ Error.toString e)
             in
                 System.exit 1
 

--- a/examples/08-notes-app/src/Lib/View.sky
+++ b/examples/08-notes-app/src/Lib/View.sky
@@ -1,4 +1,16 @@
-module Lib.View exposing (landingPage, signInPage, signUpPage, signUpSuccessPage, forgotPasswordPage, forgotPasswordSentPage, verifyResultPage, notesListPage, noteViewPage, noteFormPage, errorPage)
+module Lib.View exposing
+    ( landingPage
+    , signInPage
+    , signUpPage
+    , signUpSuccessPage
+    , forgotPasswordPage
+    , forgotPasswordSentPage
+    , verifyResultPage
+    , notesListPage
+    , noteViewPage
+    , noteFormPage
+    , errorPage
+    )
 
 import Sky.Core.Prelude exposing (..)
 import Sky.Core.Maybe as Maybe
@@ -505,20 +517,20 @@ layout title navEl content =
     doctype ()
         ++ render
                (htmlNode
-                    [Attr.lang "en"]
-                    [ headNode
-                          []
-                          [ meta [Attr.charset "UTF-8"]
-                          , meta
-                                [ Attr.name "viewport"
-                                , Attr.content
-                                      "width=device-width,initial-scale=1.0"
-                                ]
-                          , titleNode (title ++ " - SkyNotes")
-                          , styleNode [] (appStyles ())
-                          ]
-                    , body [] [ navEl, div [Attr.class "container"] [content] ]
-                    ])
+                   [Attr.lang "en"]
+                   [ headNode
+                         []
+                         [ meta [Attr.charset "UTF-8"]
+                         , meta
+                               [ Attr.name "viewport"
+                               , Attr.content
+                                     "width=device-width,initial-scale=1.0"
+                               ]
+                         , titleNode (title ++ " - SkyNotes")
+                         , styleNode [] (appStyles ())
+                         ]
+                   , body [] [ navEl, div [Attr.class "container"] [content] ]
+                   ])
 
 
 -- ============================================================
@@ -549,10 +561,10 @@ navAuth email =
                   [ span
                         [Attr.style
                             (Css.styles
-                                 [ Css.color (Css.rgba 255 255 255 0.7)
-                                 , Css.fontSize (Css.px 14)
-                                 , Css.marginRight (sp 2)
-                                 ])]
+                                [ Css.color (Css.rgba 255 255 255 0.7)
+                                , Css.fontSize (Css.px 14)
+                                , Css.marginRight (sp 2)
+                                ])]
                         [text email]
                   , a [Attr.href "/auth/sign-out"] [text "Sign Out"]
                   ]
@@ -583,52 +595,52 @@ landingPage _ =
         heroBtnStyle =
             Attr.style
                 (Css.styles
-                     [ Css.padding2 (Css.px 14) (sp 8)
-                     , Css.fontSize (Css.px 16)
-                     ])
+                    [ Css.padding2 (Css.px 14) (sp 8)
+                    , Css.fontSize (Css.px 16)
+                    ])
     in
         layout
             "Welcome"
             (navGuest ())
             (div
-                 [Attr.class "hero"]
-                 [ h1 [] [text "SkyNotes"]
-                 , p
-                       []
-                       [text
-                           "A markdown note-taking app built with the Sky language"]
-                 , div
-                       []
-                       [ a
-                             [ Attr.href "/auth/sign-up"
-                             , Attr.class "btn"
-                             , heroBtnStyle
-                             , Attr.style (Css.styles [Css.marginRight (sp 3)])
-                             ]
-                             [text "Get Started"]
-                       , a
-                             [ Attr.href "/auth/sign-in"
-                             , Attr.class "btn btn-outline"
-                             , heroBtnStyle
-                             ]
-                             [text "Sign In"]
-                       ]
-                 , div
-                       [Attr.class "features"]
-                       [ featureCard
-                             "M"
-                             "Markdown"
-                             "Write in Markdown with live preview. Supports headings, code blocks, lists, and more."
-                       , featureCard
-                             "S"
-                             "Secure"
-                             "SHA-256 password hashing with email verification to protect your account."
-                       , featureCard
-                             "F"
-                             "Fast"
-                             "Built with Sky, compiled to native Go. Backed by SQLite for reliable storage."
-                       ]
-                 ])
+                [Attr.class "hero"]
+                [ h1 [] [text "SkyNotes"]
+                , p
+                      []
+                      [text
+                          "A markdown note-taking app built with the Sky language"]
+                , div
+                      []
+                      [ a
+                            [ Attr.href "/auth/sign-up"
+                            , Attr.class "btn"
+                            , heroBtnStyle
+                            , Attr.style (Css.styles [Css.marginRight (sp 3)])
+                            ]
+                            [text "Get Started"]
+                      , a
+                            [ Attr.href "/auth/sign-in"
+                            , Attr.class "btn btn-outline"
+                            , heroBtnStyle
+                            ]
+                            [text "Sign In"]
+                      ]
+                , div
+                      [Attr.class "features"]
+                      [ featureCard
+                            "M"
+                            "Markdown"
+                            "Write in Markdown with live preview. Supports headings, code blocks, lists, and more."
+                      , featureCard
+                            "S"
+                            "Secure"
+                            "SHA-256 password hashing with email verification to protect your account."
+                      , featureCard
+                            "F"
+                            "Fast"
+                            "Built with Sky, compiled to native Go. Backed by SQLite for reliable storage."
+                      ]
+                ])
 
 
 signInPage errorMsg =
@@ -636,40 +648,40 @@ signInPage errorMsg =
         "Sign In"
         (navGuest ())
         (div
-             [Attr.class "card auth-card"]
-             [ h2 [] [text "Sign In"]
-             , errorBanner errorMsg
-             , form
-                   [ Attr.method "POST", Attr.action "/auth/sign-in" ]
-                   [ formGroup
-                         "Email"
-                         (input
-                              [ Attr.type_ "email"
-                              , Attr.name "email"
-                              , Attr.placeholder "you@example.com"
-                              , Attr.required ()
-                              ])
-                   , formGroup
-                         "Password"
-                         (input
-                              [ Attr.type_ "password"
-                              , Attr.name "password"
-                              , Attr.placeholder "Your password"
-                              , Attr.required ()
-                              ])
-                   , button
-                         [ Attr.type_ "submit", Attr.class "btn", fullWidth () ]
-                         [text "Sign In"]
-                   ]
-             , div
-                   [Attr.class "auth-footer"]
-                   [ a
-                         [Attr.href "/auth/forgot-password"]
-                         [text "Forgot password?"]
-                   , span [] [text " | "]
-                   , a [Attr.href "/auth/sign-up"] [text "Create account"]
-                   ]
-             ])
+            [Attr.class "card auth-card"]
+            [ h2 [] [text "Sign In"]
+            , errorBanner errorMsg
+            , form
+                  [ Attr.method "POST", Attr.action "/auth/sign-in" ]
+                  [ formGroup
+                        "Email"
+                        (input
+                            [ Attr.type_ "email"
+                            , Attr.name "email"
+                            , Attr.placeholder "you@example.com"
+                            , Attr.required ()
+                            ])
+                  , formGroup
+                        "Password"
+                        (input
+                            [ Attr.type_ "password"
+                            , Attr.name "password"
+                            , Attr.placeholder "Your password"
+                            , Attr.required ()
+                            ])
+                  , button
+                        [ Attr.type_ "submit", Attr.class "btn", fullWidth () ]
+                        [text "Sign In"]
+                  ]
+            , div
+                  [Attr.class "auth-footer"]
+                  [ a
+                        [Attr.href "/auth/forgot-password"]
+                        [text "Forgot password?"]
+                  , span [] [text " | "]
+                  , a [Attr.href "/auth/sign-up"] [text "Create account"]
+                  ]
+            ])
 
 
 signUpPage errorMsg =
@@ -677,46 +689,46 @@ signUpPage errorMsg =
         "Sign Up"
         (navGuest ())
         (div
-             [Attr.class "card auth-card"]
-             [ h2 [] [text "Create Account"]
-             , errorBanner errorMsg
-             , form
-                   [ Attr.method "POST", Attr.action "/auth/sign-up" ]
-                   [ formGroup
-                         "Email"
-                         (input
-                              [ Attr.type_ "email"
-                              , Attr.name "email"
-                              , Attr.placeholder "you@example.com"
-                              , Attr.required ()
-                              ])
-                   , formGroup
-                         "Password"
-                         (input
-                              [ Attr.type_ "password"
-                              , Attr.name "password"
-                              , Attr.placeholder "Min 8 characters"
-                              , Attr.minlength 8
-                              , Attr.required ()
-                              ])
-                   , formGroup
-                         "Confirm Password"
-                         (input
-                              [ Attr.type_ "password"
-                              , Attr.name "confirm_password"
-                              , Attr.placeholder "Repeat your password"
-                              , Attr.required ()
-                              ])
-                   , button
-                         [ Attr.type_ "submit", Attr.class "btn", fullWidth () ]
-                         [text "Create Account"]
-                   ]
-             , div
-                   [Attr.class "auth-footer"]
-                   [ text "Already have an account? "
-                   , a [Attr.href "/auth/sign-in"] [text "Sign in"]
-                   ]
-             ])
+            [Attr.class "card auth-card"]
+            [ h2 [] [text "Create Account"]
+            , errorBanner errorMsg
+            , form
+                  [ Attr.method "POST", Attr.action "/auth/sign-up" ]
+                  [ formGroup
+                        "Email"
+                        (input
+                            [ Attr.type_ "email"
+                            , Attr.name "email"
+                            , Attr.placeholder "you@example.com"
+                            , Attr.required ()
+                            ])
+                  , formGroup
+                        "Password"
+                        (input
+                            [ Attr.type_ "password"
+                            , Attr.name "password"
+                            , Attr.placeholder "Min 8 characters"
+                            , Attr.minlength 8
+                            , Attr.required ()
+                            ])
+                  , formGroup
+                        "Confirm Password"
+                        (input
+                            [ Attr.type_ "password"
+                            , Attr.name "confirm_password"
+                            , Attr.placeholder "Repeat your password"
+                            , Attr.required ()
+                            ])
+                  , button
+                        [ Attr.type_ "submit", Attr.class "btn", fullWidth () ]
+                        [text "Create Account"]
+                  ]
+            , div
+                  [Attr.class "auth-footer"]
+                  [ text "Already have an account? "
+                  , a [Attr.href "/auth/sign-in"] [text "Sign in"]
+                  ]
+            ])
 
 
 signUpSuccessPage _ =
@@ -724,27 +736,27 @@ signUpSuccessPage _ =
         "Account Created"
         (navGuest ())
         (div
-             [Attr.class "card auth-card"]
-             [ h2 [] [text "Account Created!"]
-             , div
-                   [Attr.class "success"]
-                   [text
-                       "Your account has been created. Check the server console for your email verification link."]
-             , p
-                   [Attr.style
-                       (Css.styles
-                            [ Css.marginTop (sp 4)
-                            , Css.color (textMuted ())
-                            , Css.fontSize (Css.px 14)
-                            ])]
-                   [text "Once verified, you can sign in to start taking notes."]
-             , a
-                   [ Attr.href "/auth/sign-in"
-                   , Attr.class "btn"
-                   , fullWidthBlock ()
-                   ]
-                   [text "Go to Sign In"]
-             ])
+            [Attr.class "card auth-card"]
+            [ h2 [] [text "Account Created!"]
+            , div
+                  [Attr.class "success"]
+                  [text
+                      "Your account has been created. Check the server console for your email verification link."]
+            , p
+                  [Attr.style
+                      (Css.styles
+                          [ Css.marginTop (sp 4)
+                          , Css.color (textMuted ())
+                          , Css.fontSize (Css.px 14)
+                          ])]
+                  [text "Once verified, you can sign in to start taking notes."]
+            , a
+                  [ Attr.href "/auth/sign-in"
+                  , Attr.class "btn"
+                  , fullWidthBlock ()
+                  ]
+                  [text "Go to Sign In"]
+            ])
 
 
 forgotPasswordPage errorMsg =
@@ -752,34 +764,32 @@ forgotPasswordPage errorMsg =
         "Forgot Password"
         (navGuest ())
         (div
-             [Attr.class "card auth-card"]
-             [ h2 [] [text "Forgot Password"]
-             , p
-                   [Attr.style
-                       (Css.styles
-                            [ Css.color (textMuted ())
-                            , Css.marginBottom (sp 5)
-                            ])]
-                   [text "Enter your email and we'll send you a reset link."]
-             , errorBanner errorMsg
-             , form
-                   [ Attr.method "POST", Attr.action "/auth/forgot-password" ]
-                   [ formGroup
-                         "Email"
-                         (input
-                              [ Attr.type_ "email"
-                              , Attr.name "email"
-                              , Attr.placeholder "you@example.com"
-                              , Attr.required ()
-                              ])
-                   , button
-                         [ Attr.type_ "submit", Attr.class "btn", fullWidth () ]
-                         [text "Send Reset Link"]
-                   ]
-             , div
-                   [Attr.class "auth-footer"]
-                   [a [Attr.href "/auth/sign-in"] [text "Back to Sign In"]]
-             ])
+            [Attr.class "card auth-card"]
+            [ h2 [] [text "Forgot Password"]
+            , p
+                  [Attr.style
+                      (Css.styles
+                          [ Css.color (textMuted ()), Css.marginBottom (sp 5) ])]
+                  [text "Enter your email and we'll send you a reset link."]
+            , errorBanner errorMsg
+            , form
+                  [ Attr.method "POST", Attr.action "/auth/forgot-password" ]
+                  [ formGroup
+                        "Email"
+                        (input
+                            [ Attr.type_ "email"
+                            , Attr.name "email"
+                            , Attr.placeholder "you@example.com"
+                            , Attr.required ()
+                            ])
+                  , button
+                        [ Attr.type_ "submit", Attr.class "btn", fullWidth () ]
+                        [text "Send Reset Link"]
+                  ]
+            , div
+                  [Attr.class "auth-footer"]
+                  [a [Attr.href "/auth/sign-in"] [text "Back to Sign In"]]
+            ])
 
 
 forgotPasswordSentPage _ =
@@ -787,28 +797,28 @@ forgotPasswordSentPage _ =
         "Reset Link Sent"
         (navGuest ())
         (div
-             [Attr.class "card auth-card"]
-             [ h2 [] [text "Check Your Console"]
-             , div
-                   [Attr.class "success"]
-                   [text
-                       "If an account exists with that email, a password reset link has been logged to the server console."]
-             , p
-                   [Attr.style
-                       (Css.styles
-                            [ Css.marginTop (sp 4)
-                            , Css.color (textMuted ())
-                            , Css.fontSize (Css.px 14)
-                            ])]
-                   [text
-                       "This is a demo app -- in production, an email would be sent instead."]
-             , a
-                   [ Attr.href "/auth/sign-in"
-                   , Attr.class "btn"
-                   , fullWidthBlock ()
-                   ]
-                   [text "Back to Sign In"]
-             ])
+            [Attr.class "card auth-card"]
+            [ h2 [] [text "Check Your Console"]
+            , div
+                  [Attr.class "success"]
+                  [text
+                      "If an account exists with that email, a password reset link has been logged to the server console."]
+            , p
+                  [Attr.style
+                      (Css.styles
+                          [ Css.marginTop (sp 4)
+                          , Css.color (textMuted ())
+                          , Css.fontSize (Css.px 14)
+                          ])]
+                  [text
+                      "This is a demo app -- in production, an email would be sent instead."]
+            , a
+                  [ Attr.href "/auth/sign-in"
+                  , Attr.class "btn"
+                  , fullWidthBlock ()
+                  ]
+                  [text "Back to Sign In"]
+            ])
 
 
 verifyResultPage isSuccess message =
@@ -824,16 +834,16 @@ verifyResultPage isSuccess message =
             "Email Verification"
             (navGuest ())
             (div
-                 [Attr.class "card auth-card"]
-                 [ h2 [] [text "Email Verification"]
-                 , div [Attr.class msgClass] [text message]
-                 , a
-                       [ Attr.href "/auth/sign-in"
-                       , Attr.class "btn"
-                       , fullWidthBlock ()
-                       ]
-                       [text "Go to Sign In"]
-                 ])
+                [Attr.class "card auth-card"]
+                [ h2 [] [text "Email Verification"]
+                , div [Attr.class msgClass] [text message]
+                , a
+                      [ Attr.href "/auth/sign-in"
+                      , Attr.class "btn"
+                      , fullWidthBlock ()
+                      ]
+                      [text "Go to Sign In"]
+                ])
 
 
 -- ============================================================
@@ -854,15 +864,15 @@ noteCard note =
     in
         render
             (div
-                 [Attr.class "card note-card"]
-                 [a
-                     [Attr.href ("/notes/view?id=" ++ noteId)]
-                     [ h3
-                           [Attr.style (Css.styles [Css.marginBottom (Css.px 4)])]
-                           [text noteTitle]
-                     , p [Attr.class "note-meta"] [text ("Created " ++ date)]
-                     , p [Attr.class "note-preview"] [text preview]
-                     ]])
+                [Attr.class "card note-card"]
+                [a
+                    [Attr.href ("/notes/view?id=" ++ noteId)]
+                    [ h3
+                          [Attr.style (Css.styles [Css.marginBottom (Css.px 4)])]
+                          [text noteTitle]
+                    , p [Attr.class "note-meta"] [text ("Created " ++ date)]
+                    , p [Attr.class "note-preview"] [text preview]
+                    ]])
 
 
 notesListPage email notes =
@@ -871,36 +881,36 @@ notesListPage email notes =
         headerRow =
             render
                 (div
-                     [Attr.class "header-row"]
-                     [ h1 [] [text "My Notes"]
-                     , a
-                           [ Attr.href "/notes/new", Attr.class "btn" ]
-                           [text "+ New Note"]
-                     ])
+                    [Attr.class "header-row"]
+                    [ h1 [] [text "My Notes"]
+                    , a
+                          [ Attr.href "/notes/new", Attr.class "btn" ]
+                          [text "+ New Note"]
+                    ])
         content =
             if List.isEmpty notes then
                 headerRow
                     ++ render
                            (div
-                                [Attr.class "card empty-state"]
-                                [ p
-                                      [Attr.style
-                                          (Css.styles
-                                               [ Css.fontSize (Css.em 1.2)
-                                               , Css.marginBottom (sp 2)
-                                               ])]
-                                      [text "No notes yet"]
-                                , p
-                                      [Attr.style
-                                          (Css.styles [Css.marginBottom (sp 5)])]
-                                      [text
-                                          "Create your first markdown note to get started."]
-                                , a
-                                      [ Attr.href "/notes/new"
-                                      , Attr.class "btn"
-                                      ]
-                                      [text "Create Your First Note"]
-                                ])
+                               [Attr.class "card empty-state"]
+                               [ p
+                                     [Attr.style
+                                         (Css.styles
+                                             [ Css.fontSize (Css.em 1.2)
+                                             , Css.marginBottom (sp 2)
+                                             ])]
+                                     [text "No notes yet"]
+                               , p
+                                     [Attr.style
+                                         (Css.styles [Css.marginBottom (sp 5)])]
+                                     [text
+                                         "Create your first markdown note to get started."]
+                               , a
+                                     [ Attr.href "/notes/new"
+                                     , Attr.class "btn"
+                                     ]
+                                     [text "Create Your First Note"]
+                               ])
 
             else
                 headerRow ++ noteCards
@@ -926,59 +936,59 @@ noteViewPage email note =
             noteTitle
             (navAuth email)
             (div
-                 [Attr.class "card"]
-                 [ div
-                       [Attr.class "header-row"]
-                       [ div
-                             []
-                             [ h1 [] [text noteTitle]
-                             , p [Attr.class "note-meta"] [text dateDisplay]
-                             ]
-                       , div
-                             []
-                             [ a
-                                   [ Attr.href ("/notes/edit?id=" ++ noteId)
-                                   , Attr.class "btn btn-sm"
-                                   , Attr.style
-                                         (Css.styles [Css.marginRight (sp 2)])
-                                   ]
-                                   [text "Edit"]
-                             , form
-                                   [ Attr.method "POST"
-                                   , Attr.action ("/notes/delete?id=" ++ noteId)
-                                   , Attr.style
-                                         (Css.styles [Css.display "inline"])
-                                   , Events.onSubmit
-                                         "return confirm('Delete this note?')"
-                                   ]
-                                   [button
-                                       [ Attr.type_ "submit"
-                                       , Attr.class "btn btn-sm btn-danger"
-                                       ]
-                                       [text "Delete"]]
-                             ]
-                       ]
-                 , hr
-                       [Attr.style
-                           (Css.styles
-                                [ Css.border (Css.none ())
-                                , Css.borderTop ("1px solid " ++ borderColor ())
-                                , Css.margin2 (sp 5) (Css.zero ())
-                                ])]
-                 , textarea
-                       [ Attr.id "raw-md"
-                       , Attr.style (Css.styles [Css.display "none"])
-                       ]
-                       [text content]
-                 , div [ Attr.id "rendered", Attr.class "md" ] []
-                 , script
-                       [Attr.src
-                           "https://cdn.jsdelivr.net/npm/marked/marked.min.js"]
-                       ""
-                 , script
-                       []
-                       "window.addEventListener('DOMContentLoaded',function(){document.getElementById('rendered').innerHTML=marked.parse(document.getElementById('raw-md').value);});"
-                 ])
+                [Attr.class "card"]
+                [ div
+                      [Attr.class "header-row"]
+                      [ div
+                            []
+                            [ h1 [] [text noteTitle]
+                            , p [Attr.class "note-meta"] [text dateDisplay]
+                            ]
+                      , div
+                            []
+                            [ a
+                                  [ Attr.href ("/notes/edit?id=" ++ noteId)
+                                  , Attr.class "btn btn-sm"
+                                  , Attr.style
+                                        (Css.styles [Css.marginRight (sp 2)])
+                                  ]
+                                  [text "Edit"]
+                            , form
+                                  [ Attr.method "POST"
+                                  , Attr.action ("/notes/delete?id=" ++ noteId)
+                                  , Attr.style
+                                        (Css.styles [Css.display "inline"])
+                                  , Events.onSubmit
+                                        "return confirm('Delete this note?')"
+                                  ]
+                                  [button
+                                      [ Attr.type_ "submit"
+                                      , Attr.class "btn btn-sm btn-danger"
+                                      ]
+                                      [text "Delete"]]
+                            ]
+                      ]
+                , hr
+                      [Attr.style
+                          (Css.styles
+                              [ Css.border (Css.none ())
+                              , Css.borderTop ("1px solid " ++ borderColor ())
+                              , Css.margin2 (sp 5) (Css.zero ())
+                              ])]
+                , textarea
+                      [ Attr.id "raw-md"
+                      , Attr.style (Css.styles [Css.display "none"])
+                      ]
+                      [text content]
+                , div [ Attr.id "rendered", Attr.class "md" ] []
+                , script
+                      [Attr.src
+                          "https://cdn.jsdelivr.net/npm/marked/marked.min.js"]
+                      ""
+                , script
+                      []
+                      "window.addEventListener('DOMContentLoaded',function(){document.getElementById('rendered').innerHTML=marked.parse(document.getElementById('raw-md').value);});"
+                ])
 
 
 noteFormPage email noteTitle content noteId isEdit =
@@ -1002,72 +1012,72 @@ noteFormPage email noteTitle content noteId isEdit =
             pageTitle
             (navAuth email)
             (div
-                 [Attr.class "card"]
-                 [ h1
-                       [Attr.style (Css.styles [Css.marginBottom (sp 6)])]
-                       [text pageTitle]
-                 , form
-                       [ Attr.method "POST", Attr.action formAction ]
-                       [ formGroup
-                             "Title"
-                             (input
-                                  [ Attr.type_ "text"
-                                  , Attr.name "title"
-                                  , Attr.value noteTitle
-                                  , Attr.placeholder "Note title"
-                                  , Attr.required ()
-                                  ])
-                       , div
-                             [Attr.class "form-group"]
-                             [ label [] [text "Content (Markdown)"]
-                             , div
-                                   [Attr.class "split-view"]
-                                   [ div
-                                         []
-                                         [textarea
-                                             [ Attr.id "editor"
-                                             , Attr.name "content"
-                                             , Attr.placeholder placeholderText
-                                             , Attr.required ()
-                                             ]
-                                             [text content]]
-                                   , div
-                                         []
-                                         [ div
-                                               [Attr.class "preview-label"]
-                                               [text "Preview"]
-                                         , div
-                                               [ Attr.id "preview"
-                                               , Attr.class "preview-pane md"
-                                               ]
-                                               []
-                                         ]
-                                   ]
-                             ]
-                       , div
-                             [Attr.style (Css.styles [Css.marginTop (sp 5)])]
-                             [ button
-                                   [ Attr.type_ "submit", Attr.class "btn" ]
-                                   [text "Save Note"]
-                             , a
-                                   [ Attr.href "/notes"
-                                   , Attr.style
-                                         (Css.styles
-                                              [ Css.marginLeft (sp 4)
-                                              , Css.color (textMuted ())
-                                              ])
-                                   ]
-                                   [text "Cancel"]
-                             ]
-                       ]
-                 , script
-                       [Attr.src
-                           "https://cdn.jsdelivr.net/npm/marked/marked.min.js"]
-                       ""
-                 , script
-                       []
-                       "window.addEventListener('DOMContentLoaded',function(){var e=document.getElementById('editor'),p=document.getElementById('preview');function u(){p.innerHTML=marked.parse(e.value)}e.addEventListener('input',u);u();});"
-                 ])
+                [Attr.class "card"]
+                [ h1
+                      [Attr.style (Css.styles [Css.marginBottom (sp 6)])]
+                      [text pageTitle]
+                , form
+                      [ Attr.method "POST", Attr.action formAction ]
+                      [ formGroup
+                            "Title"
+                            (input
+                                [ Attr.type_ "text"
+                                , Attr.name "title"
+                                , Attr.value noteTitle
+                                , Attr.placeholder "Note title"
+                                , Attr.required ()
+                                ])
+                      , div
+                            [Attr.class "form-group"]
+                            [ label [] [text "Content (Markdown)"]
+                            , div
+                                  [Attr.class "split-view"]
+                                  [ div
+                                        []
+                                        [textarea
+                                            [ Attr.id "editor"
+                                            , Attr.name "content"
+                                            , Attr.placeholder placeholderText
+                                            , Attr.required ()
+                                            ]
+                                            [text content]]
+                                  , div
+                                        []
+                                        [ div
+                                              [Attr.class "preview-label"]
+                                              [text "Preview"]
+                                        , div
+                                              [ Attr.id "preview"
+                                              , Attr.class "preview-pane md"
+                                              ]
+                                              []
+                                        ]
+                                  ]
+                            ]
+                      , div
+                            [Attr.style (Css.styles [Css.marginTop (sp 5)])]
+                            [ button
+                                  [ Attr.type_ "submit", Attr.class "btn" ]
+                                  [text "Save Note"]
+                            , a
+                                  [ Attr.href "/notes"
+                                  , Attr.style
+                                        (Css.styles
+                                            [ Css.marginLeft (sp 4)
+                                            , Css.color (textMuted ())
+                                            ])
+                                  ]
+                                  [text "Cancel"]
+                            ]
+                      ]
+                , script
+                      [Attr.src
+                          "https://cdn.jsdelivr.net/npm/marked/marked.min.js"]
+                      ""
+                , script
+                      []
+                      "window.addEventListener('DOMContentLoaded',function(){var e=document.getElementById('editor'),p=document.getElementById('preview');function u(){p.innerHTML=marked.parse(e.value)}e.addEventListener('input',u);u();});"
+                ])
 
 
 errorPage message =
@@ -1075,13 +1085,13 @@ errorPage message =
         "Error"
         (navGuest ())
         (div
-             [Attr.class "card auth-card"]
-             [ h2 [] [text "Something Went Wrong"]
-             , div [Attr.class "error"] [text message]
-             , a
-                   [ Attr.href "/"
-                   , Attr.class "btn"
-                   , Attr.style (Css.styles [Css.marginTop (sp 3)])
-                   ]
-                   [text "Go Home"]
-             ])
+            [Attr.class "card auth-card"]
+            [ h2 [] [text "Something Went Wrong"]
+            , div [Attr.class "error"] [text message]
+            , a
+                  [ Attr.href "/"
+                  , Attr.class "btn"
+                  , Attr.style (Css.styles [Css.marginTop (sp 3)])
+                  ]
+                  [text "Go Home"]
+            ])

--- a/examples/08-notes-app/src/Main.sky
+++ b/examples/08-notes-app/src/Main.sky
@@ -29,7 +29,7 @@ runInit label result =
                 _ =
                     println
                         ("[NOTES ERROR] initDb " ++ label ++ ": "
-                             ++ Error.toString e)
+                            ++ Error.toString e)
             in
                 ()
 
@@ -40,7 +40,7 @@ initDb _ =
             runInit
                 "users"
                 (Db.exec
-                     """CREATE TABLE IF NOT EXISTS users (
+                    """CREATE TABLE IF NOT EXISTS users (
                         id INTEGER PRIMARY KEY AUTOINCREMENT,
                         email TEXT NOT NULL UNIQUE,
                         password_hash TEXT NOT NULL,
@@ -48,23 +48,23 @@ initDb _ =
                         verification_token TEXT,
                         created_at TEXT DEFAULT (datetime('now'))
                     )"""
-                     [])
+                    [])
         _ =
             runInit
                 "sessions"
                 (Db.exec
-                     """CREATE TABLE IF NOT EXISTS sessions (
+                    """CREATE TABLE IF NOT EXISTS sessions (
                         id INTEGER PRIMARY KEY AUTOINCREMENT,
                         user_id TEXT NOT NULL,
                         token TEXT NOT NULL UNIQUE,
                         created_at TEXT DEFAULT (datetime('now'))
                     )"""
-                     [])
+                    [])
         _ =
             runInit
                 "notes"
                 (Db.exec
-                     """CREATE TABLE IF NOT EXISTS notes (
+                    """CREATE TABLE IF NOT EXISTS notes (
                         id INTEGER PRIMARY KEY AUTOINCREMENT,
                         user_id TEXT NOT NULL,
                         title TEXT NOT NULL,
@@ -72,7 +72,7 @@ initDb _ =
                         created_at TEXT DEFAULT (datetime('now')),
                         updated_at TEXT DEFAULT ''
                     )"""
-                     [])
+                    [])
     in
         ()
 
@@ -103,7 +103,7 @@ requireAuth req onUser =
                         _ =
                             println
                                 ("[NOTES ERROR] session lookup: "
-                                     ++ Error.toString e)
+                                    ++ Error.toString e)
                     in
                         Server.redirect "/auth/sign-in"
 
@@ -157,17 +157,17 @@ handleSignIn req =
                             Ok sessionToken ->
                                 Task.succeed
                                     (Server.redirect "/notes"
-                                         |> Server.withCookie
-                                                "session"
-                                                sessionToken
-                                                "Path=/; HttpOnly; SameSite=Lax")
+                                        |> Server.withCookie
+                                               "session"
+                                               sessionToken
+                                               "Path=/; HttpOnly; SameSite=Lax")
 
                             Err e ->
                                 let
                                     _ =
                                         println
                                             ("[NOTES ERROR] sign-in createSession: "
-                                                 ++ Error.toString e)
+                                                ++ Error.toString e)
                                     userMsg =
                                         "Sign-in temporarily unavailable. Please try again."
                                 in
@@ -214,8 +214,8 @@ handleSignUp req =
             else if String.length password < 8 then
                 Task.succeed
                     (Server.html
-                         (View.signUpPage
-                              "Password must be at least 8 characters."))
+                        (View.signUpPage
+                            "Password must be at least 8 characters."))
 
             else
                 case Auth.createUser email password of
@@ -228,7 +228,7 @@ handleSignUp req =
                             _ =
                                 println
                                     ("[NOTES ERROR] sign-up: "
-                                         ++ Error.toString e)
+                                        ++ Error.toString e)
                             userMsg = Error.toString e
                         in
                             Task.succeed (Server.html (View.signUpPage userMsg))
@@ -246,7 +246,7 @@ handleForgotPassword req =
             _ =
                 println
                     ("[Email Service] Password reset for: " ++ email ++ " "
-                         ++ resetToken)
+                        ++ resetToken)
         in
             Task.succeed (Server.html (View.forgotPasswordSentPage ()))
 
@@ -264,7 +264,7 @@ handleVerify req =
         if token == "" then
             Task.succeed
                 (Server.html
-                     (View.verifyResultPage False "Missing verification token."))
+                    (View.verifyResultPage False "Missing verification token."))
 
         else
             case Auth.verifyEmail token of
@@ -280,10 +280,9 @@ handleVerify req =
                     in
                         Task.succeed
                             (Server.html
-                                 (View.verifyResultPage
-                                      False
-                                      ("Verification failed: "
-                                           ++ Error.toString e)))
+                                (View.verifyResultPage
+                                    False
+                                    ("Verification failed: " ++ Error.toString e)))
 
 
 handleSignOut : Request -> Task Error Response
@@ -306,7 +305,7 @@ handleSignOut req =
     in
         Task.succeed
             (Server.redirect "/"
-                 |> Server.withCookie "session" "" "Path=/; HttpOnly; Max-Age=0")
+                |> Server.withCookie "session" "" "Path=/; HttpOnly; Max-Age=0")
 
 
 -- ============================================================
@@ -319,189 +318,189 @@ handleNotesList : Request -> Task Error Response
 handleNotesList req =
     Task.succeed
         (requireAuth
-             req
-             (\user email ->
-                  let
-                      userId = Db.getField "id" user
-                  in
-                      case Notes.getNotes userId of
+            req
+            (\user email ->
+                let
+                    userId = Db.getField "id" user
+                in
+                    case Notes.getNotes userId of
 
-                          Ok notes ->
-                              Server.html (View.notesListPage email notes)
+                        Ok notes ->
+                            Server.html (View.notesListPage email notes)
 
-                          Err e ->
-                              let
-                                  _ =
-                                      println
-                                          ("[NOTES ERROR] list: "
-                                               ++ Error.toString e)
-                              in
-                                  Server.html
-                                      (View.errorPage
-                                           ("Failed to load notes: "
-                                                ++ Error.toString e))))
+                        Err e ->
+                            let
+                                _ =
+                                    println
+                                        ("[NOTES ERROR] list: "
+                                            ++ Error.toString e)
+                            in
+                                Server.html
+                                    (View.errorPage
+                                        ("Failed to load notes: "
+                                            ++ Error.toString e))))
 
 
 handleNewNote : Request -> Task Error Response
 handleNewNote req =
     Task.succeed
         (requireAuth
-             req
-             (\user email ->
-                  let
-                      userId = Db.getField "id" user
-                  in
-                      if Server.method req == "POST" then
-                          let
-                              title = Server.formValue "title" req
-                              content = Server.formValue "content" req
-                          in
-                              case Notes.createNote userId title content of
+            req
+            (\user email ->
+                let
+                    userId = Db.getField "id" user
+                in
+                    if Server.method req == "POST" then
+                        let
+                            title = Server.formValue "title" req
+                            content = Server.formValue "content" req
+                        in
+                            case Notes.createNote userId title content of
 
-                                  Ok _ ->
-                                      Server.redirect "/notes"
+                                Ok _ ->
+                                    Server.redirect "/notes"
 
-                                  Err e ->
-                                      let
-                                          _ =
-                                              println
-                                                  ("[NOTES ERROR] createNote: "
-                                                       ++ Error.toString e)
-                                      in
-                                          Server.html
-                                              (View.errorPage
-                                                   ("Failed to save note: "
-                                                        ++ Error.toString e))
+                                Err e ->
+                                    let
+                                        _ =
+                                            println
+                                                ("[NOTES ERROR] createNote: "
+                                                    ++ Error.toString e)
+                                    in
+                                        Server.html
+                                            (View.errorPage
+                                                ("Failed to save note: "
+                                                    ++ Error.toString e))
 
-                      else
-                          Server.html (View.noteFormPage email "" "" "" False)))
+                    else
+                        Server.html (View.noteFormPage email "" "" "" False)))
 
 
 handleViewNote : Request -> Task Error Response
 handleViewNote req =
     Task.succeed
         (requireAuth
-             req
-             (\user email ->
-                  let
-                      userId = Db.getField "id" user
-                      noteId =
-                          Maybe.withDefault "" (Server.queryParam "id" req)
-                  in
-                      case Notes.getNote noteId userId of
+            req
+            (\user email ->
+                let
+                    userId = Db.getField "id" user
+                    noteId =
+                        Maybe.withDefault "" (Server.queryParam "id" req)
+                in
+                    case Notes.getNote noteId userId of
 
-                          Ok (Just note) ->
-                              Server.html (View.noteViewPage email note)
+                        Ok (Just note) ->
+                            Server.html (View.noteViewPage email note)
 
-                          Ok Nothing ->
-                              Server.html (View.errorPage "Note not found.")
+                        Ok Nothing ->
+                            Server.html (View.errorPage "Note not found.")
 
-                          Err e ->
-                              let
-                                  _ =
-                                      println
-                                          ("[NOTES ERROR] getNote: "
-                                               ++ Error.toString e)
-                              in
-                                  Server.html
-                                      (View.errorPage
-                                           ("Failed to load note: "
-                                                ++ Error.toString e))))
+                        Err e ->
+                            let
+                                _ =
+                                    println
+                                        ("[NOTES ERROR] getNote: "
+                                            ++ Error.toString e)
+                            in
+                                Server.html
+                                    (View.errorPage
+                                        ("Failed to load note: "
+                                            ++ Error.toString e))))
 
 
 handleEditNote : Request -> Task Error Response
 handleEditNote req =
     Task.succeed
         (requireAuth
-             req
-             (\user email ->
-                  let
-                      userId = Db.getField "id" user
-                      noteId =
-                          Maybe.withDefault "" (Server.queryParam "id" req)
-                  in
-                      if Server.method req == "POST" then
-                          let
-                              title = Server.formValue "title" req
-                              content = Server.formValue "content" req
-                          in
-                              case Notes.updateNote noteId userId title content of
+            req
+            (\user email ->
+                let
+                    userId = Db.getField "id" user
+                    noteId =
+                        Maybe.withDefault "" (Server.queryParam "id" req)
+                in
+                    if Server.method req == "POST" then
+                        let
+                            title = Server.formValue "title" req
+                            content = Server.formValue "content" req
+                        in
+                            case Notes.updateNote noteId userId title content of
 
-                                  Ok _ ->
-                                      Server.redirect
-                                          ("/notes/view?id=" ++ noteId)
+                                Ok _ ->
+                                    Server.redirect
+                                        ("/notes/view?id=" ++ noteId)
 
-                                  Err e ->
-                                      let
-                                          _ =
-                                              println
-                                                  ("[NOTES ERROR] updateNote: "
-                                                       ++ Error.toString e)
-                                      in
-                                          Server.html
-                                              (View.errorPage
-                                                   ("Failed to update note: "
-                                                        ++ Error.toString e))
+                                Err e ->
+                                    let
+                                        _ =
+                                            println
+                                                ("[NOTES ERROR] updateNote: "
+                                                    ++ Error.toString e)
+                                    in
+                                        Server.html
+                                            (View.errorPage
+                                                ("Failed to update note: "
+                                                    ++ Error.toString e))
 
-                      else
-                          case Notes.getNote noteId userId of
+                    else
+                        case Notes.getNote noteId userId of
 
-                              Ok (Just note) ->
-                                  let
-                                      title = Db.getField "title" note
-                                      content = Db.getField "content" note
-                                  in
-                                      Server.html
-                                          (View.noteFormPage
-                                               email
-                                               title
-                                               content
-                                               noteId
-                                               True)
+                            Ok (Just note) ->
+                                let
+                                    title = Db.getField "title" note
+                                    content = Db.getField "content" note
+                                in
+                                    Server.html
+                                        (View.noteFormPage
+                                            email
+                                            title
+                                            content
+                                            noteId
+                                            True)
 
-                              Ok Nothing ->
-                                  Server.html (View.errorPage "Note not found.")
+                            Ok Nothing ->
+                                Server.html (View.errorPage "Note not found.")
 
-                              Err e ->
-                                  let
-                                      _ =
-                                          println
-                                              ("[NOTES ERROR] getNote (edit): "
-                                                   ++ Error.toString e)
-                                  in
-                                      Server.html
-                                          (View.errorPage
-                                               ("Failed to load note: "
-                                                    ++ Error.toString e))))
+                            Err e ->
+                                let
+                                    _ =
+                                        println
+                                            ("[NOTES ERROR] getNote (edit): "
+                                                ++ Error.toString e)
+                                in
+                                    Server.html
+                                        (View.errorPage
+                                            ("Failed to load note: "
+                                                ++ Error.toString e))))
 
 
 handleDeleteNote : Request -> Task Error Response
 handleDeleteNote req =
     Task.succeed
         (requireAuth
-             req
-             (\user email ->
-                  let
-                      userId = Db.getField "id" user
-                      noteId =
-                          Maybe.withDefault "" (Server.queryParam "id" req)
-                  in
-                      case Notes.deleteNote noteId userId of
+            req
+            (\user email ->
+                let
+                    userId = Db.getField "id" user
+                    noteId =
+                        Maybe.withDefault "" (Server.queryParam "id" req)
+                in
+                    case Notes.deleteNote noteId userId of
 
-                          Ok _ ->
-                              Server.redirect "/notes"
+                        Ok _ ->
+                            Server.redirect "/notes"
 
-                          Err e ->
-                              let
-                                  _ =
-                                      println
-                                          ("[NOTES ERROR] deleteNote: "
-                                               ++ Error.toString e)
-                              in
-                                  Server.html
-                                      (View.errorPage
-                                           ("Failed to delete note: "
-                                                ++ Error.toString e))))
+                        Err e ->
+                            let
+                                _ =
+                                    println
+                                        ("[NOTES ERROR] deleteNote: "
+                                            ++ Error.toString e)
+                            in
+                                Server.html
+                                    (View.errorPage
+                                        ("Failed to delete note: "
+                                            ++ Error.toString e))))
 
 
 -- ============================================================

--- a/examples/10-live-component/src/Main.sky
+++ b/examples/10-live-component/src/Main.sky
@@ -103,8 +103,7 @@ view model =
                     [class "total"]
                     [text
                         ("Total: "
-                             ++ String.fromInt
-                                    (Counter.getCount model.myCounter))]
+                            ++ String.fromInt (Counter.getCount model.myCounter))]
               ]
         ]
 

--- a/examples/11-fyne-stopwatch/src/Main.sky
+++ b/examples/11-fyne-stopwatch/src/Main.sky
@@ -16,7 +16,7 @@ setupWindow myApp =
 
         Err e ->
             let
-                _ = println ("Failed to create window: " ++ e)
+                _ = println ("Failed to create window: " ++ errorToString e)
             in
                 ()
 
@@ -31,7 +31,10 @@ showWindow window =
                     case Fyne.newSize 400.0 200.0 of
 
                         Ok size ->
-                            Fyne.windowResize window size
+                            let
+                                _ = Fyne.windowResize window size
+                            in
+                                ()
 
                         Err _ ->
                             ()
@@ -41,7 +44,7 @@ showWindow window =
 
         Err e ->
             let
-                _ = println ("Failed to create label: " ++ e)
+                _ = println ("Failed to create label: " ++ errorToString e)
             in
                 ()
 
@@ -54,6 +57,6 @@ main =
 
         Err e ->
             let
-                _ = println ("Failed to create Fyne app: " ++ e)
+                _ = println ("Failed to create Fyne app: " ++ errorToString e)
             in
                 ()

--- a/examples/12-skyvote/src/Lib/Auth.sky
+++ b/examples/12-skyvote/src/Lib/Auth.sky
@@ -25,8 +25,8 @@ hashPassword password =
 
 verifyPassword : String -> String -> Bool
 verifyPassword password storedHash =
-    -- Auth.verifyPassword returns Result Error Bool — collapse with
-    -- withDefault False (auth-deny on internal error, not auth-grant).
+-- Auth.verifyPassword returns Result Error Bool — collapse with
+-- withDefault False (auth-deny on internal error, not auth-grant).
     Result.withDefault False (Auth.verifyPassword password storedHash)
 
 
@@ -47,9 +47,8 @@ createUser username email password =
                 let
                     _ =
                         println
-                            ("[AUTH] User created: " ++ username ++ " ("
-                                 ++ email
-                                 ++ ")")
+                            ("[AUTH] User created: " ++ username ++ " (" ++ email
+                                ++ ")")
                 in
                     Ok id
 
@@ -81,8 +80,8 @@ authenticateUser email password =
                     in
                         Err
                             (Error.permissionDenied
-                                 |> Error.withMessage
-                                        "Invalid email or password.")
+                                |> Error.withMessage
+                                       "Invalid email or password.")
 
                 Just user ->
                     let
@@ -101,12 +100,12 @@ authenticateUser email password =
                                 _ =
                                     println
                                         ("[AUTH] Sign-in failed (bad password): "
-                                             ++ email)
+                                            ++ email)
                             in
                                 Err
                                     (Error.permissionDenied
-                                         |> Error.withMessage
-                                                "Invalid email or password.")
+                                        |> Error.withMessage
+                                               "Invalid email or password.")
 
 
 -- getUserById : Result Error (Maybe User). The outer Result is for

--- a/examples/12-skyvote/src/Lib/AuthHandlers.sky
+++ b/examples/12-skyvote/src/Lib/AuthHandlers.sky
@@ -1,4 +1,11 @@
-module Lib.AuthHandlers exposing (handleSignInSuccess, handleSignIn, handleSignUpSuccess, handleSignUpValidated, handleSignUp, handleSignOut)
+module Lib.AuthHandlers exposing
+    ( handleSignInSuccess
+    , handleSignIn
+    , handleSignUpSuccess
+    , handleSignUpValidated
+    , handleSignUp
+    , handleSignOut
+    )
 
 import Sky.Core.Prelude exposing (..)
 import Sky.Core.Result as Result

--- a/examples/12-skyvote/src/Lib/Comments.sky
+++ b/examples/12-skyvote/src/Lib/Comments.sky
@@ -25,8 +25,8 @@ createComment ideaId authorId content =
                 0
                 12
                 (Crypto.sha256
-                     (ideaId ++ ":" ++ authorId ++ ":" ++ content ++ ":"
-                          ++ String.fromInt nowMs))
+                    (ideaId ++ ":" ++ authorId ++ ":" ++ content ++ ":"
+                        ++ String.fromInt nowMs))
     in
         case Db.exec
                  "INSERT INTO comments (id, idea_id, author_id, content) VALUES (?, ?, ?, ?)"
@@ -40,7 +40,7 @@ createComment ideaId authorId content =
                     _ =
                         println
                             ("[COMMENT] Added on " ++ ideaId ++ " by "
-                                 ++ authorId)
+                                ++ authorId)
                 in
                     Ok ()
 

--- a/examples/12-skyvote/src/Lib/Db.sky
+++ b/examples/12-skyvote/src/Lib/Db.sky
@@ -27,8 +27,7 @@ dbConn =
             let
                 _ =
                     println
-                        ("[FATAL] Cannot open skyvote.db: "
-                             ++ Error.toString e)
+                        ("[FATAL] Cannot open skyvote.db: " ++ Error.toString e)
             in
                 System.exit 1
 

--- a/examples/12-skyvote/src/Lib/Ideas.sky
+++ b/examples/12-skyvote/src/Lib/Ideas.sky
@@ -1,4 +1,13 @@
-module Lib.Ideas exposing (createIdea, getIdeas, getIdea, getIdeasByStatus, toggleVote, hasVoted, getVoteCount, updateStatus)
+module Lib.Ideas exposing
+    ( createIdea
+    , getIdeas
+    , getIdea
+    , getIdeasByStatus
+    , toggleVote
+    , hasVoted
+    , getVoteCount
+    , updateStatus
+    )
 
 import Sky.Core.Prelude exposing (..)
 import Sky.Core.Maybe exposing (..)
@@ -117,7 +126,7 @@ toggleVote ideaId userId =
                                 _ =
                                     println
                                         ("[VOTE] Removed: " ++ userId ++ " on "
-                                             ++ ideaId)
+                                            ++ ideaId)
                             in
                                 Ok ()
 
@@ -140,9 +149,8 @@ toggleVote ideaId userId =
                                 let
                                     _ =
                                         println
-                                            ("[VOTE] Added: " ++ userId
-                                                 ++ " on "
-                                                 ++ ideaId)
+                                            ("[VOTE] Added: " ++ userId ++ " on "
+                                                ++ ideaId)
                                 in
                                     Ok ()
 
@@ -210,6 +218,6 @@ updateStatus ideaId newStatus =
                 _ =
                     println
                         ("[IDEA] Status changed: " ++ ideaId ++ " -> "
-                             ++ newStatus)
+                            ++ newStatus)
             in
                 Ok ()

--- a/examples/12-skyvote/src/Main.sky
+++ b/examples/12-skyvote/src/Main.sky
@@ -227,7 +227,7 @@ logActivity event targetId userId =
                     _ =
                         println
                             ("[ACTIVITY ERROR] " ++ event ++ ": "
-                                 ++ Error.toString e)
+                                ++ Error.toString e)
                 in
                     ()
 
@@ -242,9 +242,9 @@ refreshCurrentView model =
                     Result.withDefault
                         []
                         (Ideas.getIdeas
-                             model.sortBy
-                             model.filterCategory
-                             model.searchQuery)
+                            model.sortBy
+                            model.filterCategory
+                            model.searchQuery)
             in
                 ( { model | ideas = ideas }, Cmd.none )
 
@@ -424,9 +424,9 @@ handleBackToBoard model =
             Result.withDefault
                 []
                 (Ideas.getIdeas
-                     model.sortBy
-                     model.filterCategory
-                     model.searchQuery)
+                    model.sortBy
+                    model.filterCategory
+                    model.searchQuery)
     in
         ( { model | page = BoardPage
           , ideas = ideas
@@ -471,9 +471,9 @@ doCreateIdea user model =
                         Result.withDefault
                             []
                             (Ideas.getIdeas
-                                 model.sortBy
-                                 model.filterCategory
-                                 model.searchQuery)
+                                model.sortBy
+                                model.filterCategory
+                                model.searchQuery)
                 in
                     ( { model | page = BoardPage
                       , ideas = ideas

--- a/examples/12-skyvote/src/Page/About.sky
+++ b/examples/12-skyvote/src/Page/About.sky
@@ -11,118 +11,118 @@ viewAbout model =
     Layout.page
         model
         (div
-             [class "content-page"]
-             [ h1 [] [text "About SkyVote"]
-             , p
-                   []
-                   [text
-                       "SkyVote is a feature voting board where users can submit ideas, vote on the ones they care about, and discuss with the community. The best ideas rise to the top."]
-             , p
-                   []
-                   [ text
-                         "This application is a production-grade example built with "
-                   , strong [] [text "Sky"]
-                   , text
-                         " -- a pure-functional, ML-family programming language that compiles to Go."
-                   ]
-             , h2 [] [text "Built with Sky"]
-             , p
-                   []
-                   [text
-                       "Sky combines the safety of Hindley-Milner type inference with Go's performance and ecosystem. This app demonstrates:"]
-             , ul
-                   []
-                   [ li
-                         []
-                         [ strong [] [text "Sky.Live"]
-                         , text
-                               " -- Server-driven real-time UI. No client-side JavaScript framework needed. The server holds all state and sends minimal HTML patches over SSE."
-                         ]
-                   , li
-                         []
-                         [ strong [] [text "Type-safe HTML & CSS"]
-                         , text
-                               " -- All markup and styles are generated with Sky's type-safe builders. No templates, no CSS files."
-                         ]
-                   , li
-                         []
-                         [ strong [] [text "SQLite database"]
-                         , text
-                               " -- Persistent data storage via Go's database/sql with the modernc SQLite driver. Zero external dependencies."
-                         ]
-                   , li
-                         []
-                         [ strong [] [text "TEA — model / update / view / subscriptions"]
-                         , text
-                               " -- Predictable state management with Model, Msg, init, update, and view."
-                         ]
-                   , li
-                         []
-                         [ strong [] [text "Go interop"]
-                         , text
-                               " -- Seamless access to Go's standard library and third-party packages through auto-generated bindings."
-                         ]
-                   ]
-             , h2 [] [text "Architecture"]
-             , p
-                   []
-                   [text "SkyVote is structured as a multi-module Sky project:"]
-             , ul
-                   []
-                   [ li
-                         []
-                         [ codeNode [] [text "Main.sky"]
-                         , text " -- App entry point, routing, state management"
-                         ]
-                   , li
-                         []
-                         [ codeNode [] [text "Page/*"]
-                         , text " -- View modules for each page"
-                         ]
-                   , li
-                         []
-                         [ codeNode [] [text "Lib/*"]
-                         , text " -- Database, auth, and business logic"
-                         ]
-                   , li
-                         []
-                         [ codeNode [] [text "Ui/*"]
-                         , text " -- Shared layout, styles, and components"
-                         ]
-                   ]
-             , p
-                   []
-                   [text
-                       "The entire application compiles to a single Go binary with an embedded SQLite database. Deploy it anywhere -- it is just one file."]
-             , h2 [] [text "How Voting Works"]
-             , ul
-                   []
-                   [ li
-                         []
-                         [text "Sign up for an account to submit ideas and vote"]
-                   , li
-                         []
-                         [text
-                             "Each user gets one vote per idea -- click to vote, click again to unvote"]
-                   , li
-                         []
-                         [text
-                             "Ideas are sorted by vote count so the most popular ones rise to the top"]
-                   , li
-                         []
-                         [text "Add comments to discuss ideas with the community"]
-                   , li
-                         []
-                         [ text "The "
-                         , a
-                               [ href "/roadmap", attribute "sky-nav" "" ]
-                               [text "Roadmap"]
-                         , text " page shows ideas grouped by their status"
-                         ]
-                   ]
-             , h2 [] [text "Learn More"]
-             , p
-                   []
-                   [text
-                       "Sky is open source and under active development. Visit the project repository to learn more about the language, read the documentation, or contribute."]
-             ])
+            [class "content-page"]
+            [ h1 [] [text "About SkyVote"]
+            , p
+                  []
+                  [text
+                      "SkyVote is a feature voting board where users can submit ideas, vote on the ones they care about, and discuss with the community. The best ideas rise to the top."]
+            , p
+                  []
+                  [ text
+                        "This application is a production-grade example built with "
+                  , strong [] [text "Sky"]
+                  , text
+                        " -- a pure-functional, ML-family programming language that compiles to Go."
+                  ]
+            , h2 [] [text "Built with Sky"]
+            , p
+                  []
+                  [text
+                      "Sky combines the safety of Hindley-Milner type inference with Go's performance and ecosystem. This app demonstrates:"]
+            , ul
+                  []
+                  [ li
+                        []
+                        [ strong [] [text "Sky.Live"]
+                        , text
+                              " -- Server-driven real-time UI. No client-side JavaScript framework needed. The server holds all state and sends minimal HTML patches over SSE."
+                        ]
+                  , li
+                        []
+                        [ strong [] [text "Type-safe HTML & CSS"]
+                        , text
+                              " -- All markup and styles are generated with Sky's type-safe builders. No templates, no CSS files."
+                        ]
+                  , li
+                        []
+                        [ strong [] [text "SQLite database"]
+                        , text
+                              " -- Persistent data storage via Go's database/sql with the modernc SQLite driver. Zero external dependencies."
+                        ]
+                  , li
+                        []
+                        [ strong
+                              []
+                              [text "TEA — model / update / view / subscriptions"]
+                        , text
+                              " -- Predictable state management with Model, Msg, init, update, and view."
+                        ]
+                  , li
+                        []
+                        [ strong [] [text "Go interop"]
+                        , text
+                              " -- Seamless access to Go's standard library and third-party packages through auto-generated bindings."
+                        ]
+                  ]
+            , h2 [] [text "Architecture"]
+            , p [] [text "SkyVote is structured as a multi-module Sky project:"]
+            , ul
+                  []
+                  [ li
+                        []
+                        [ codeNode [] [text "Main.sky"]
+                        , text " -- App entry point, routing, state management"
+                        ]
+                  , li
+                        []
+                        [ codeNode [] [text "Page/*"]
+                        , text " -- View modules for each page"
+                        ]
+                  , li
+                        []
+                        [ codeNode [] [text "Lib/*"]
+                        , text " -- Database, auth, and business logic"
+                        ]
+                  , li
+                        []
+                        [ codeNode [] [text "Ui/*"]
+                        , text " -- Shared layout, styles, and components"
+                        ]
+                  ]
+            , p
+                  []
+                  [text
+                      "The entire application compiles to a single Go binary with an embedded SQLite database. Deploy it anywhere -- it is just one file."]
+            , h2 [] [text "How Voting Works"]
+            , ul
+                  []
+                  [ li
+                        []
+                        [text "Sign up for an account to submit ideas and vote"]
+                  , li
+                        []
+                        [text
+                            "Each user gets one vote per idea -- click to vote, click again to unvote"]
+                  , li
+                        []
+                        [text
+                            "Ideas are sorted by vote count so the most popular ones rise to the top"]
+                  , li
+                        []
+                        [text "Add comments to discuss ideas with the community"]
+                  , li
+                        []
+                        [ text "The "
+                        , a
+                              [ href "/roadmap", attribute "sky-nav" "" ]
+                              [text "Roadmap"]
+                        , text " page shows ideas grouped by their status"
+                        ]
+                  ]
+            , h2 [] [text "Learn More"]
+            , p
+                  []
+                  [text
+                      "Sky is open source and under active development. Visit the project repository to learn more about the language, read the documentation, or contribute."]
+            ])

--- a/examples/12-skyvote/src/Page/Board.sky
+++ b/examples/12-skyvote/src/Page/Board.sky
@@ -50,32 +50,32 @@ viewBoard model =
         Layout.page
             model
             (div
-                 []
-                 [ div
-                       [class "board-header"]
-                       [ div
-                             []
-                             [ h1 [class "page-title"] [text "Feature Board"]
-                             , p
-                                   [class "page-subtitle"]
-                                   [text
-                                       "Vote on ideas you care about. The best ones rise to the top."]
-                             ]
-                       , viewSubmitButton model
-                       ]
-                 , viewToolbar model
-                 , viewIdeaList model userId
-                 ])
+                []
+                [ div
+                      [class "board-header"]
+                      [ div
+                            []
+                            [ h1 [class "page-title"] [text "Feature Board"]
+                            , p
+                                  [class "page-subtitle"]
+                                  [text
+                                      "Vote on ideas you care about. The best ones rise to the top."]
+                            ]
+                      , viewSubmitButton model
+                      ]
+                , viewToolbar model
+                , viewIdeaList model userId
+                ])
 
 
 viewIdeaList model userId =
     div
         [class "idea-list"]
         (if List.isEmpty model.ideas then
-             [emptyState "No ideas yet. Be the first to submit one!"]
+            [emptyState "No ideas yet. Be the first to submit one!"]
 
-         else
-             List.map (\idea -> ideaCard idea userId) model.ideas)
+        else
+            List.map (\idea -> ideaCard idea userId) model.ideas)
 
 
 viewToolbar model =
@@ -109,10 +109,10 @@ filterBtn filterValue label activeFilter =
         [ onClick (SetFilter filterValue)
         , class
               (if activeFilter == filterValue then
-                   "filter-btn active"
+                  "filter-btn active"
 
-               else
-                   "filter-btn")
+              else
+                  "filter-btn")
         ]
         [text label]
 
@@ -122,9 +122,9 @@ sortBtn sortValue label activeSort =
         [ onClick (SetSort sortValue)
         , class
               (if activeSort == sortValue then
-                   "filter-btn active"
+                  "filter-btn active"
 
-               else
-                   "filter-btn")
+              else
+                  "filter-btn")
         ]
         [text label]

--- a/examples/12-skyvote/src/Page/Detail.sky
+++ b/examples/12-skyvote/src/Page/Detail.sky
@@ -104,8 +104,8 @@ viewComments model =
               [class "comments-title"]
               [text
                   ("Comments ("
-                       ++ String.fromInt (List.length model.ideaComments)
-                       ++ ")")]
+                      ++ String.fromInt (List.length model.ideaComments)
+                      ++ ")")]
         , viewCommentForm model
         , viewCommentList model
         ]
@@ -115,12 +115,12 @@ viewCommentList model =
     div
         []
         (if List.isEmpty model.ideaComments then
-             [p
-                 [class "text-muted-sm"]
-                 [text "No comments yet. Be the first to share your thoughts!"]]
+            [p
+                [class "text-muted-sm"]
+                [text "No comments yet. Be the first to share your thoughts!"]]
 
-         else
-             List.map viewComment model.ideaComments)
+        else
+            List.map viewComment model.ideaComments)
 
 
 viewComment comment =

--- a/examples/12-skyvote/src/Page/Roadmap.sky
+++ b/examples/12-skyvote/src/Page/Roadmap.sky
@@ -26,23 +26,23 @@ viewRoadmap model =
         Layout.page
             model
             (div
-                 [class "mt-32"]
-                 [ h1 [class "page-title"] [text "Roadmap"]
-                 , p
-                       [class "page-subtitle"]
-                       [text
-                           "Track the progress of community ideas from submission to completion."]
-                 , div
-                       [class "roadmap-grid"]
-                       [ roadmapColumn "Open" "Awaiting review" open_
-                       , roadmapColumn "Planned" "On the roadmap" planned
-                       , roadmapColumn
-                             "In Progress"
-                             "Currently being built"
-                             inProgress
-                       , roadmapColumn "Done" "Shipped!" done
-                       ]
-                 ])
+                [class "mt-32"]
+                [ h1 [class "page-title"] [text "Roadmap"]
+                , p
+                      [class "page-subtitle"]
+                      [text
+                          "Track the progress of community ideas from submission to completion."]
+                , div
+                      [class "roadmap-grid"]
+                      [ roadmapColumn "Open" "Awaiting review" open_
+                      , roadmapColumn "Planned" "On the roadmap" planned
+                      , roadmapColumn
+                            "In Progress"
+                            "Currently being built"
+                            inProgress
+                      , roadmapColumn "Done" "Shipped!" done
+                      ]
+                ])
 
 
 roadmapColumn title subtitle items =
@@ -59,10 +59,10 @@ roadmapColumn title subtitle items =
         , div
               []
               (if List.isEmpty items then
-                   [p [class "roadmap-empty"] [text "Nothing here yet"]]
+                  [p [class "roadmap-empty"] [text "Nothing here yet"]]
 
-               else
-                   List.map roadmapItem items)
+              else
+                  List.map roadmapItem items)
         ]
 
 

--- a/examples/12-skyvote/src/Page/Submit.sky
+++ b/examples/12-skyvote/src/Page/Submit.sky
@@ -12,68 +12,68 @@ viewSubmit model =
     Layout.pageWithAuth
         model
         (div
-             [class "submit-container"]
-             [ h1 [class "page-title"] [text "Submit an Idea"]
-             , p
-                   [class "page-subtitle"]
-                   [text
-                       "Have a feature request, bug report, or improvement? Share it with the community."]
-             , div
-                   [class "card"]
-                   [form
-                       [onSubmit SubmitIdea]
-                       [ div
-                             [class "form-group"]
-                             [ label [class "form-label"] [text "Title"]
-                             , input
-                                   [ type_ "text"
-                                   , class "form-input"
-                                   , placeholder "A short, descriptive title"
-                                   , value model.submitTitle
-                                   , onInput UpdateTitle
-                                   ]
-                             ]
-                       , div
-                             [class "form-group"]
-                             [ label [class "form-label"] [text "Description"]
-                             , textarea
-                                   [ class "form-input"
-                                   , placeholder
-                                         "Describe your idea in detail. What problem does it solve? How should it work?"
-                                   , value model.submitDescription
-                                   , onInput UpdateDescription
-                                   , rows 6
-                                   ]
-                                   []
-                             ]
-                       , div
-                             [class "form-group"]
-                             [ label [class "form-label"] [text "Category"]
-                             , select
-                                   [ class "form-input"
-                                   , value model.submitCategory
-                                   , onChange UpdateCategory
-                                   ]
-                                   [ option
-                                         [value "feature"]
-                                         [text "Feature Request"]
-                                   , option [value "bug"] [text "Bug Report"]
-                                   , option
-                                         [value "improvement"]
-                                         [text "Improvement"]
-                                   ]
-                             ]
-                       , div
-                             [class "form-actions"]
-                             [ button
-                                   [ onClick BackToBoard
-                                   , type_ "button"
-                                   , class "btn btn-secondary"
-                                   ]
-                                   [text "Cancel"]
-                             , button
-                                   [ type_ "submit", class "btn btn-primary" ]
-                                   [text "Submit Idea"]
-                             ]
-                       ]]
-             ])
+            [class "submit-container"]
+            [ h1 [class "page-title"] [text "Submit an Idea"]
+            , p
+                  [class "page-subtitle"]
+                  [text
+                      "Have a feature request, bug report, or improvement? Share it with the community."]
+            , div
+                  [class "card"]
+                  [form
+                      [onSubmit SubmitIdea]
+                      [ div
+                            [class "form-group"]
+                            [ label [class "form-label"] [text "Title"]
+                            , input
+                                  [ type_ "text"
+                                  , class "form-input"
+                                  , placeholder "A short, descriptive title"
+                                  , value model.submitTitle
+                                  , onInput UpdateTitle
+                                  ]
+                            ]
+                      , div
+                            [class "form-group"]
+                            [ label [class "form-label"] [text "Description"]
+                            , textarea
+                                  [ class "form-input"
+                                  , placeholder
+                                        "Describe your idea in detail. What problem does it solve? How should it work?"
+                                  , value model.submitDescription
+                                  , onInput UpdateDescription
+                                  , rows 6
+                                  ]
+                                  []
+                            ]
+                      , div
+                            [class "form-group"]
+                            [ label [class "form-label"] [text "Category"]
+                            , select
+                                  [ class "form-input"
+                                  , value model.submitCategory
+                                  , onChange UpdateCategory
+                                  ]
+                                  [ option
+                                        [value "feature"]
+                                        [text "Feature Request"]
+                                  , option [value "bug"] [text "Bug Report"]
+                                  , option
+                                        [value "improvement"]
+                                        [text "Improvement"]
+                                  ]
+                            ]
+                      , div
+                            [class "form-actions"]
+                            [ button
+                                  [ onClick BackToBoard
+                                  , type_ "button"
+                                  , class "btn btn-secondary"
+                                  ]
+                                  [text "Cancel"]
+                            , button
+                                  [ type_ "submit", class "btn btn-primary" ]
+                                  [text "Submit Idea"]
+                            ]
+                      ]]
+            ])

--- a/examples/12-skyvote/src/Ui/Layout.sky
+++ b/examples/12-skyvote/src/Ui/Layout.sky
@@ -44,19 +44,19 @@ pageWithAuth model content =
             page
                 model
                 (div
-                     [class "auth-container"]
-                     [div
-                         [class "card"]
-                         [p
-                             [class "auth-prompt"]
-                             [ text "Please "
-                             , a
-                                   [ href "/auth/signin"
-                                   , attribute "sky-nav" ""
-                                   ]
-                                   [text "sign in"]
-                             , text " to access this page."
-                             ]]])
+                    [class "auth-container"]
+                    [div
+                        [class "card"]
+                        [p
+                            [class "auth-prompt"]
+                            [ text "Please "
+                            , a
+                                  [ href "/auth/signin"
+                                  , attribute "sky-nav" ""
+                                  ]
+                                  [text "sign in"]
+                            , text " to access this page."
+                            ]]])
 
 
 -- ======================================================

--- a/examples/13-skyshop/src/Lib/Auth.sky
+++ b/examples/13-skyshop/src/Lib/Auth.sky
@@ -25,7 +25,8 @@ ctx =
 
 adminEmails _ =
     let
-        envAdmins = Result.withDefault "" (Task.run (System.getenv "ADMIN_EMAILS"))
+        envAdmins =
+            Result.withDefault "" (Task.run (System.getenv "ADMIN_EMAILS"))
     in
     -- Idempotent upsert using firebase_uid as document ID.
     -- Concurrent calls from onAuthStateChanged can never create duplicates
@@ -50,13 +51,21 @@ isAdmin user =
 getAuthClient _ =
     let
         credFile =
-            Result.withDefault "" (Task.run (System.getenv "GOOGLE_APPLICATION_CREDENTIALS"))
+            Result.withDefault
+                ""
+                (Task.run (System.getenv "GOOGLE_APPLICATION_CREDENTIALS"))
         opts =
             if credFile == "" then
                 []
 
             else
-                [Option.withCredentialsFile credFile]
+                case Option.withCredentialsFile credFile of
+
+                    Ok opt ->
+                        [opt]
+
+                    Err _ ->
+                        []
         appResult = Firebase.newApp ctx (js "nil") opts
     in
         case appResult of
@@ -88,17 +97,33 @@ verifyToken idToken =
             case FirebaseAuth.clientVerifyIDToken client ctx idToken of
 
                 Ok token ->
+                -- tokenUID + tokenClaims are FFI getters returning
+                -- Result Error _; unwrap before downstream use.
                     let
-                        uid = FirebaseAuth.tokenUID token
-                        claims = FirebaseAuth.tokenClaims token
+                        uid =
+                            case FirebaseAuth.tokenUID token of
+
+                                Ok u ->
+                                    u
+
+                                Err _ ->
+                                    ""
+                        claims =
+                            case FirebaseAuth.tokenClaims token of
+
+                                Ok c ->
+                                    c
+
+                                Err _ ->
+                                    Dict.empty
                         email = claimString "email" claims
                         name = claimString "name" claims
                         _ =
                             println
                                 ("[AUTH] Firebase token verified for: " ++ email
-                                     ++ " (uid: "
-                                     ++ uid
-                                     ++ ")")
+                                    ++ " (uid: "
+                                    ++ uid
+                                    ++ ")")
                     in
                         findOrCreateUser uid email name
 
@@ -107,19 +132,18 @@ verifyToken idToken =
                         _ =
                             println
                                 ("[AUTH] Firebase token verification failed: "
-                                     ++ errorToString e)
+                                    ++ errorToString e)
                     in
                         Err
                             (Error.permissionDenied
-                                 |> Error.withMessage
-                                        "Authentication failed. Please try again.")
+                                |> Error.withMessage
+                                       "Authentication failed. Please try again.")
 
         Err e ->
             let
                 _ =
                     println
-                        ("[AUTH] Firebase auth client error: "
-                             ++ errorToString e)
+                        ("[AUTH] Firebase auth client error: " ++ errorToString e)
             in
                 Err (Error.network "Authentication service unavailable.")
 
@@ -156,17 +180,17 @@ findOrCreateUser uid email name =
                         if Db.getBool "suspended" user then
                             Err
                                 (Error.permissionDenied
-                                     |> Error.withMessage
-                                            "Account suspended. Please contact support.")
+                                    |> Error.withMessage
+                                           "Account suspended. Please contact support.")
 
                         else
                             let
                                 _ =
                                     println
                                         ("[AUTH] Signed in: " ++ email
-                                             ++ " (admin: "
-                                             ++ adminStr
-                                             ++ ")")
+                                            ++ " (admin: "
+                                            ++ adminStr
+                                            ++ ")")
                             in
                                 Ok user
 

--- a/examples/13-skyshop/src/Lib/Cart.sky
+++ b/examples/13-skyshop/src/Lib/Cart.sky
@@ -1,4 +1,24 @@
-module Lib.Cart exposing (getOrCreateCart, createCart, getCart, getCartItems, getCartWithItems, addItem, updateItemQty, removeItem, recalculateTotal, setCartState, setCheckout, setShipping, getUserCarts, getOrdersByState, getAllOrders, checkoutToOrder, getOrder, getOrderItems, getOrderWithItems)
+module Lib.Cart exposing
+    ( getOrCreateCart
+    , createCart
+    , getCart
+    , getCartItems
+    , getCartWithItems
+    , addItem
+    , updateItemQty
+    , removeItem
+    , recalculateTotal
+    , setCartState
+    , setCheckout
+    , setShipping
+    , getUserCarts
+    , getOrdersByState
+    , getAllOrders
+    , checkoutToOrder
+    , getOrder
+    , getOrderItems
+    , getOrderWithItems
+    )
 
 import Sky.Core.Prelude exposing (..)
 import Sky.Core.Maybe exposing (..)
@@ -99,24 +119,24 @@ enrichCartItem item =
                     "title"
                     (Db.getField "title" product)
                     (Dict.insert
-                         "summary"
-                         (Db.getField "summary" product)
-                         (Dict.insert
-                              "price_amount"
-                              (Db.getField "price_amount" product)
-                              (Dict.insert
-                                   "price_currency"
-                                   (Db.getField "price_currency" product)
-                                   (Dict.insert
-                                        "price_discount"
-                                        (Db.getField "price_discount" product)
+                        "summary"
+                        (Db.getField "summary" product)
+                        (Dict.insert
+                            "price_amount"
+                            (Db.getField "price_amount" product)
+                            (Dict.insert
+                                "price_currency"
+                                (Db.getField "price_currency" product)
+                                (Dict.insert
+                                    "price_discount"
+                                    (Db.getField "price_discount" product)
+                                    (Dict.insert
+                                        "price_tax"
+                                        (Db.getField "price_tax" product)
                                         (Dict.insert
-                                             "price_tax"
-                                             (Db.getField "price_tax" product)
-                                             (Dict.insert
-                                                  "stock"
-                                                  (Db.getField "stock" product)
-                                                  item))))))
+                                            "stock"
+                                            (Db.getField "stock" product)
+                                            item))))))
 
             _ ->
                 item
@@ -226,19 +246,19 @@ recalculateTotal cartId =
         total =
             List.foldl
                 (\item acc ->
-                     let
-                         price = Db.getInt "price_amount" item
-                         discount = Db.getInt "price_discount" item
-                         qty = Db.getInt "quantity" item
-                         effectivePrice = price - discount
-                         itemTotal =
-                             if effectivePrice > 0 then
-                                 effectivePrice * qty
+                    let
+                        price = Db.getInt "price_amount" item
+                        discount = Db.getInt "price_discount" item
+                        qty = Db.getInt "quantity" item
+                        effectivePrice = price - discount
+                        itemTotal =
+                            if effectivePrice > 0 then
+                                effectivePrice * qty
 
-                             else
-                                 0
-                     in
-                         acc + itemTotal)
+                            else
+                                0
+                    in
+                        acc + itemTotal)
                 0
                 items
         currency =
@@ -282,7 +302,7 @@ findDocAndCollection docId =
                 Ok Nothing ->
                     Err
                         (Error.notFound
-                             |> Error.withMessage "Document not found.")
+                            |> Error.withMessage "Document not found.")
 
                 Err e ->
                     Err e
@@ -297,8 +317,7 @@ setCartState docId newState =
                 result = Db.setDoc collection docId updatedDoc
                 _ =
                     println
-                        ("[ORDER] State changed: " ++ docId ++ " -> "
-                             ++ newState)
+                        ("[ORDER] State changed: " ++ docId ++ " -> " ++ newState)
             in
                 case result of
 
@@ -322,9 +341,9 @@ setCheckout docId link reference remarks =
                         "checkout_link"
                         link
                         (Dict.insert
-                             "checkout_reference"
-                             reference
-                             (Dict.insert "checkout_remarks" remarks doc))
+                            "checkout_reference"
+                            reference
+                            (Dict.insert "checkout_remarks" remarks doc))
             in
                 Db.setDoc collection docId updatedDoc
 
@@ -342,27 +361,27 @@ setShipping docId name email phone line1 line2 city country postcode =
                         "shipping_name"
                         name
                         (Dict.insert
-                             "shipping_email"
-                             email
-                             (Dict.insert
-                                  "shipping_phone"
-                                  phone
-                                  (Dict.insert
-                                       "shipping_line1"
-                                       line1
-                                       (Dict.insert
-                                            "shipping_line2"
-                                            line2
+                            "shipping_email"
+                            email
+                            (Dict.insert
+                                "shipping_phone"
+                                phone
+                                (Dict.insert
+                                    "shipping_line1"
+                                    line1
+                                    (Dict.insert
+                                        "shipping_line2"
+                                        line2
+                                        (Dict.insert
+                                            "shipping_city"
+                                            city
                                             (Dict.insert
-                                                 "shipping_city"
-                                                 city
-                                                 (Dict.insert
-                                                      "shipping_country"
-                                                      country
-                                                      (Dict.insert
-                                                           "shipping_postcode"
-                                                           postcode
-                                                           doc)))))))
+                                                "shipping_country"
+                                                country
+                                                (Dict.insert
+                                                    "shipping_postcode"
+                                                    postcode
+                                                    doc)))))))
             in
                 Db.setDoc collection docId updatedDoc
 
@@ -394,31 +413,31 @@ checkoutToOrder cartId =
                     _ =
                         List.map
                             (\item ->
-                                 let
-                                     itemId =
-                                         Result.withDefault
-                                             ""
-                                             (Uuid.newString ())
-                                     enriched = enrichCartItem item
-                                     orderItem =
-                                         Dict.insert
-                                             "id"
-                                             itemId
-                                             (Dict.insert
-                                                  "order_id"
-                                                  orderId
-                                                  (Dict.insert
-                                                       "cart_id"
-                                                       cartId
-                                                       enriched))
-                                 in
-                                     Db.setDoc "order_items" itemId orderItem)
+                                let
+                                    itemId =
+                                        Result.withDefault
+                                            ""
+                                            (Uuid.newString ())
+                                    enriched = enrichCartItem item
+                                    orderItem =
+                                        Dict.insert
+                                            "id"
+                                            itemId
+                                            (Dict.insert
+                                                "order_id"
+                                                orderId
+                                                (Dict.insert
+                                                    "cart_id"
+                                                    cartId
+                                                    enriched))
+                                in
+                                    Db.setDoc "order_items" itemId orderItem)
                             cartItems
                     _ =
                         println
                             ("[CHECKOUT] Created order " ++ orderId
-                                 ++ " from cart "
-                                 ++ cartId)
+                                ++ " from cart "
+                                ++ cartId)
                 in
                     Ok orderId
 

--- a/examples/13-skyshop/src/Lib/Db.sky
+++ b/examples/13-skyshop/src/Lib/Db.sky
@@ -1,7 +1,24 @@
 -- ══════════════════════════════════════════════════════
 -- FIELD ACCESSORS
 -- ══════════════════════════════════════════════════════
-module Lib.Db exposing (getDoc, setDoc, queryDocs, queryWhere, queryWhereOrder, deleteDoc, getField, getInt, getBool, intVal, boolVal, floatVal, initDb, queryWhereOrLog, queryWhereOrderOrLog, queryDocsOrLog)
+module Lib.Db exposing
+    ( getDoc
+    , setDoc
+    , queryDocs
+    , queryWhere
+    , queryWhereOrder
+    , deleteDoc
+    , getField
+    , getInt
+    , getBool
+    , intVal
+    , boolVal
+    , floatVal
+    , initDb
+    , queryWhereOrLog
+    , queryWhereOrderOrLog
+    , queryDocsOrLog
+    )
 
 import Sky.Core.Prelude exposing (..)
 import Sky.Core.Maybe as Maybe
@@ -85,7 +102,7 @@ initDb _ =
                 _ =
                     println
                         ("[DB] ERROR: Failed to initialise Firestore: "
-                             ++ errorToString e)
+                            ++ errorToString e)
             in
                 ()
 
@@ -119,7 +136,10 @@ ctx =
 
 getProjectId _ =
     let
-        env = Result.withDefault "" (Task.run (System.getenv "GOOGLE_CLOUD_PROJECT"))
+        env =
+            Result.withDefault
+                ""
+                (Task.run (System.getenv "GOOGLE_CLOUD_PROJECT"))
     in
         if env == "" then
             "skyshop"
@@ -145,14 +165,16 @@ snapshotToDict snapshot =
             Result.withDefault
                 Dict.empty
                 (Firestore.documentSnapshotData snapshot)
-        -- v0.10.0: every Go FFI call returns Result Error T per the
-        -- doctrine. Pre-fix, the typed-codegen tolerated direct
-        -- composition; foreign-fatal now requires explicit
-        -- unwrapping at each boundary.
+                -- v0.10.0: every Go FFI call returns Result Error T per the
+                -- doctrine. Pre-fix, the typed-codegen tolerated direct
+                -- composition; foreign-fatal now requires explicit
+                -- unwrapping at each boundary.
         docId =
             case Firestore.documentSnapshotRef snapshot of
+
                 Ok ref ->
                     Result.withDefault "" (Firestore.documentRefID ref)
+
                 Err _ ->
                     ""
     in
@@ -223,8 +245,8 @@ getDocInner colRef docId =
         Err e ->
             Err
                 (Error.io
-                     ("Firestore.collectionRefDoc failed for " ++ docId ++ ": "
-                          ++ Error.toString e))
+                    ("Firestore.collectionRefDoc failed for " ++ docId ++ ": "
+                        ++ Error.toString e))
 
         Ok docRef ->
             getDocRef docRef
@@ -239,7 +261,7 @@ getDocRef docRef =
         Err e ->
             Err
                 (Error.io
-                     ("Firestore.documentRefGet failed: " ++ Error.toString e))
+                    ("Firestore.documentRefGet failed: " ++ Error.toString e))
 
 
 getDocSnapshot snapshot =
@@ -253,7 +275,13 @@ getDocSnapshot snapshot =
 
 
 mergeOpts =
-    [Firestore.mergeAll ()]
+    case Firestore.mergeAll () of
+
+        Ok opt ->
+            [opt]
+
+        Err _ ->
+            []
 
 
 setDoc collection docId data =
@@ -401,14 +429,17 @@ queryWhereOrderInner colRef field op value orderField dir =
 
 queryWhereOrderQuery q orderField dir =
     let
-        direction =
+        directionR =
             if dir == "desc" then
-                Firestore.desc
+                Firestore.desc ()
 
             else
-                Firestore.asc
+                Firestore.asc ()
+        orderedR =
+            directionR
+                |> Result.andThen (\d -> Firestore.queryOrderBy q orderField d)
     in
-        case Firestore.queryOrderBy q orderField direction of
+        case orderedR of
 
             Err e ->
                 Err (wrapDbError (errorToString e))

--- a/examples/13-skyshop/src/Lib/Money.sky
+++ b/examples/13-skyshop/src/Lib/Money.sky
@@ -5,9 +5,11 @@ import Sky.Core.String as String
 import Sky.Core.Maybe as Maybe
 import Lib.Db as Db
 
-
 type alias Price =
-    { original : String, discounted : String, hasDiscount : Bool }
+    { original : String
+    , discounted : String
+    , hasDiscount : Bool
+    }
 
 
 currencySymbol currency =

--- a/examples/13-skyshop/src/Lib/Notify.sky
+++ b/examples/13-skyshop/src/Lib/Notify.sky
@@ -64,8 +64,10 @@ ignoreResult result =
 
 sendEmailNotification notificationId subject body =
     let
-        smtpHost = Result.withDefault "" (Task.run (System.getenv "SMTP_HOST"))
-        notifyTo = Result.withDefault "" (Task.run (System.getenv "NOTIFY_TO"))
+        smtpHost =
+            Result.withDefault "" (Task.run (System.getenv "SMTP_HOST"))
+        notifyTo =
+            Result.withDefault "" (Task.run (System.getenv "NOTIFY_TO"))
     in
         if smtpHost == "" || notifyTo == "" then
             let
@@ -80,7 +82,7 @@ sendEmailNotification notificationId subject body =
                 _ =
                     println
                         ("[NOTIFY] Would send email to " ++ notifyTo ++ ": "
-                             ++ subject)
+                            ++ subject)
                 _ =
                     case Db.getDoc "notifications" notificationId of
 
@@ -89,9 +91,9 @@ sendEmailNotification notificationId subject body =
                                 "notifications"
                                 notificationId
                                 (Dict.insert
-                                     "sent"
-                                     (Db.boolVal True)
-                                     notification)
+                                    "sent"
+                                    (Db.boolVal True)
+                                    notification)
 
                         _ ->
                             Ok ()

--- a/examples/13-skyshop/src/Lib/OAuth.sky
+++ b/examples/13-skyshop/src/Lib/OAuth.sky
@@ -34,9 +34,14 @@ import Lib.Auth as Auth
 
 firebaseAuthScript _ =
     let
-        apiKey = Result.withDefault "" (Task.run (System.getenv "FIREBASE_API_KEY"))
-        authDomain = Result.withDefault "" (Task.run (System.getenv "AUTH_DOMAIN"))
-        projectId = Result.withDefault "" (Task.run (System.getenv "GOOGLE_CLOUD_PROJECT"))
+        apiKey =
+            Result.withDefault "" (Task.run (System.getenv "FIREBASE_API_KEY"))
+        authDomain =
+            Result.withDefault "" (Task.run (System.getenv "AUTH_DOMAIN"))
+        projectId =
+            Result.withDefault
+                ""
+                (Task.run (System.getenv "GOOGLE_CLOUD_PROJECT"))
     in
         """<script>
 var _fbReady=false,_fbUser=null;

--- a/examples/13-skyshop/src/Lib/Products.sky
+++ b/examples/13-skyshop/src/Lib/Products.sky
@@ -41,7 +41,7 @@ listAllProducts =
                             ++ " products")
 
                 Err e ->
-                    println ("[PRODUCTS] ERROR loading products: " ++ e)
+                    println ("[PRODUCTS] ERROR loading products: " ++ errorToString e)
     in
         Result.withDefault [] result
 

--- a/examples/13-skyshop/src/Lib/Products.sky
+++ b/examples/13-skyshop/src/Lib/Products.sky
@@ -1,4 +1,15 @@
-module Lib.Products exposing (listProducts, listAllProducts, getProduct, createProduct, updateProduct, deleteProduct, listProductImages, addProductImage, deleteProductImage, searchProducts)
+module Lib.Products exposing
+    ( listProducts
+    , listAllProducts
+    , getProduct
+    , createProduct
+    , updateProduct
+    , deleteProduct
+    , listProductImages
+    , addProductImage
+    , deleteProductImage
+    , searchProducts
+    )
 
 import Sky.Core.Prelude exposing (..)
 import Sky.Core.Maybe exposing (..)
@@ -26,8 +37,8 @@ listAllProducts =
                 Ok products ->
                     println
                         ("[PRODUCTS] Loaded "
-                             ++ String.fromInt (List.length products)
-                             ++ " products")
+                            ++ String.fromInt (List.length products)
+                            ++ " products")
 
                 Err e ->
                     println ("[PRODUCTS] ERROR loading products: " ++ e)
@@ -72,12 +83,12 @@ filterBySearch query products =
         in
             List.filter
                 (\p ->
-                     String.contains
-                         lowerQuery
-                         (String.toLower (Db.getField "title" p))
-                         || String.contains
-                                lowerQuery
-                                (String.toLower (Db.getField "summary" p)))
+                    String.contains
+                        lowerQuery
+                        (String.toLower (Db.getField "title" p))
+                        || String.contains
+                               lowerQuery
+                               (String.toLower (Db.getField "summary" p)))
                 products
 
 
@@ -87,8 +98,8 @@ sortProducts sortBy sortDir products =
             if sortBy == "price" then
                 List.sortBy
                     (\p ->
-                         Db.getInt "price_amount" p
-                             - Db.getInt "price_discount" p)
+                        Db.getInt "price_amount" p
+                            - Db.getInt "price_discount" p)
                     products
 
             else if sortBy == "title" then

--- a/examples/13-skyshop/src/Lib/Stripe.sky
+++ b/examples/13-skyshop/src/Lib/Stripe.sky
@@ -297,13 +297,41 @@ createCheckoutSession cartId items userId userName userEmail remarks =
 
                                     Ok phoneCollection ->
                                         Stripe.newCheckoutSessionParams ()
-                                            |> Result.andThen (\p -> Stripe.checkoutSessionParamsSetMode "payment" p)
-                                            |> Result.andThen (\p -> Stripe.checkoutSessionParamsSetSuccessURL successUrl p)
-                                            |> Result.andThen (\p -> Stripe.checkoutSessionParamsSetCancelURL cancelUrl p)
-                                            |> Result.andThen (\p -> Stripe.checkoutSessionParamsSetCustomer customerId p)
-                                            |> Result.andThen (\p -> Stripe.checkoutSessionParamsSetLineItems lineItems p)
-                                            |> Result.andThen (\p -> Stripe.checkoutSessionParamsSetShippingAddressCollection shippingCollection p)
-                                            |> Result.andThen (\p -> Stripe.checkoutSessionParamsSetPhoneNumberCollection phoneCollection p)
+                                            |> Result.andThen
+                                                   (\p ->
+                                                       Stripe.checkoutSessionParamsSetMode
+                                                           "payment"
+                                                           p)
+                                            |> Result.andThen
+                                                   (\p ->
+                                                       Stripe.checkoutSessionParamsSetSuccessURL
+                                                           successUrl
+                                                           p)
+                                            |> Result.andThen
+                                                   (\p ->
+                                                       Stripe.checkoutSessionParamsSetCancelURL
+                                                           cancelUrl
+                                                           p)
+                                            |> Result.andThen
+                                                   (\p ->
+                                                       Stripe.checkoutSessionParamsSetCustomer
+                                                           customerId
+                                                           p)
+                                            |> Result.andThen
+                                                   (\p ->
+                                                       Stripe.checkoutSessionParamsSetLineItems
+                                                           lineItems
+                                                           p)
+                                            |> Result.andThen
+                                                   (\p ->
+                                                       Stripe.checkoutSessionParamsSetShippingAddressCollection
+                                                           shippingCollection
+                                                           p)
+                                            |> Result.andThen
+                                                   (\p ->
+                                                       Stripe.checkoutSessionParamsSetPhoneNumberCollection
+                                                           phoneCollection
+                                                           p)
                     _ =
                         println
                             ("[STRIPE] Creating checkout session for cart: "

--- a/examples/13-skyshop/src/Lib/Stripe.sky
+++ b/examples/13-skyshop/src/Lib/Stripe.sky
@@ -17,16 +17,34 @@ import Github.Com.Stripe.StripeGo.V84.Checkout.Session as Session
 import Github.Com.Stripe.StripeGo.V84.Customer as Customer
 
 type alias PaymentStatus =
-    { status : String, paymentStatus : String, customerName : String, customerEmail : String, customerPhone : String, shippingLine1 : String, shippingLine2 : String, shippingCity : String, shippingCountry : String, shippingPostalCode : String }
-
+    { status : String
+    , paymentStatus : String
+    , customerName : String
+    , customerEmail : String
+    , customerPhone : String
+    , shippingLine1 : String
+    , shippingLine2 : String
+    , shippingCity : String
+    , shippingCountry : String
+    , shippingPostalCode : String
+    }
 
 type alias CheckoutInfo =
-    { id : String, url : String }
+    { id : String
+    , url : String
+    }
 
 
 initStripe _ =
     let
-        key = Result.withDefault "" (Task.run (System.getenv "STRIPE_API_KEY"))
+    -- FFI trust boundary: every Stripe getter returns
+    -- Result Error T so a nil receiver / unexpected
+    -- Go panic surfaces as Err rather than corrupting
+    -- downstream logic. Unwrap with sensible defaults
+    -- at the call site since Stripe rarely fails on a
+    -- completed session.
+        key =
+            Result.withDefault "" (Task.run (System.getenv "STRIPE_API_KEY"))
         _ = Stripe.setKey key
     in
         key
@@ -39,7 +57,8 @@ apiKey =
 domainUrl _ =
     let
         domain = Result.withDefault "" (Task.run (System.getenv "DOMAIN"))
-        port_ = Result.withDefault "" (Task.run (System.getenv "SKY_LIVE_PORT"))
+        port_ =
+            Result.withDefault "" (Task.run (System.getenv "SKY_LIVE_PORT"))
     in
         if domain != "" then
             domain
@@ -58,46 +77,110 @@ domainUrl _ =
 
 getOrCreateCustomer userId userName userEmail =
     let
-        listParams =
+        listParamsR =
             Stripe.newCustomerListParams ()
-                |> Stripe.customerListParamsSetEmail userEmail
-        iter = Customer.list listParams
+                |> Result.andThen
+                       (\p -> Stripe.customerListParamsSetEmail userEmail p)
     in
-        if Customer.iterNext iter then
-            let
-                c = Customer.iterCustomer iter
-                customerId = Stripe.customerID c
-                _ =
-                    println ("[STRIPE] Found existing customer: " ++ customerId)
-            in
-                Ok customerId
+        case listParamsR of
 
-        else
-            createCustomer userId userName userEmail
+            Ok listParams ->
+                case Customer.list listParams of
 
+                    Ok iter ->
+                        let
+                            hasNext =
+                                case Customer.iterNext iter of
 
-createCustomer userId userName userEmail =
-    let
-        params =
-            Stripe.newCustomerParams ()
-                |> Stripe.customerParamsSetEmail userEmail
-                |> Stripe.customerParamsSetName userName
-    in
-        case Customer.new params of
+                                    Ok b ->
+                                        b
 
-            Ok c ->
-                let
-                    customerId = Stripe.customerID c
-                    _ =
-                        println ("[STRIPE] Created customer: " ++ customerId)
-                in
-                    Ok customerId
+                                    Err _ ->
+                                        False
+                        in
+                            if hasNext then
+                                case Customer.iterCustomer iter of
+
+                                    Ok c ->
+                                        let
+                                            customerId =
+                                                case Stripe.customerID c of
+
+                                                    Ok cid ->
+                                                        cid
+
+                                                    Err _ ->
+                                                        ""
+                                            _ =
+                                                println
+                                                    ("[STRIPE] Found existing customer: "
+                                                        ++ customerId)
+                                        in
+                                            Ok customerId
+
+                                    Err e ->
+                                        Err
+                                            (Error.network
+                                                ("Stripe Customer.iterCustomer failed: "
+                                                    ++ errorToString e))
+
+                            else
+                                createCustomer userId userName userEmail
+
+                    Err e ->
+                        Err
+                            (Error.network
+                                ("Stripe Customer.list failed: "
+                                    ++ errorToString e))
 
             Err e ->
                 Err
                     (Error.network
-                         ("Failed to create Stripe customer: "
-                              ++ errorToString e))
+                        ("Failed to build Stripe customer-list params: "
+                            ++ errorToString e))
+
+
+createCustomer userId userName userEmail =
+    let
+        paramsR =
+            Stripe.newCustomerParams ()
+                |> Result.andThen
+                       (\p -> Stripe.customerParamsSetEmail userEmail p)
+                |> Result.andThen
+                       (\p -> Stripe.customerParamsSetName userName p)
+    in
+        case paramsR of
+
+            Ok params ->
+                case Customer.new params of
+
+                    Ok c ->
+                        let
+                            customerId =
+                                case Stripe.customerID c of
+
+                                    Ok cid ->
+                                        cid
+
+                                    Err _ ->
+                                        ""
+                            _ =
+                                println
+                                    ("[STRIPE] Created customer: " ++ customerId)
+                        in
+                            Ok customerId
+
+                    Err e ->
+                        Err
+                            (Error.network
+                                ("Failed to create Stripe customer: "
+                                    ++ errorToString e))
+
+            Err e ->
+                Err
+                    (Error.network
+                        ("Failed to build Stripe customer params: "
+                            ++ errorToString e))
 
 
 buildLineItem : Dict String String -> Result Error Value
@@ -114,22 +197,48 @@ buildLineItem item =
                 price
         qty = Db.getInt "quantity" item
         currency = String.toLower (Db.getField "price_currency" item)
-        productData =
+        productDataR =
             Stripe.newCheckoutSessionLineItemPriceDataProductDataParams ()
-                |> Stripe.checkoutSessionLineItemPriceDataProductDataParamsSetName
-                       title
-        priceData =
-            Stripe.newCheckoutSessionLineItemPriceDataParams ()
-                |> Stripe.checkoutSessionLineItemPriceDataParamsSetProductData
-                       productData
-                |> Stripe.checkoutSessionLineItemPriceDataParamsSetUnitAmount
-                       effectivePrice
-                |> Stripe.checkoutSessionLineItemPriceDataParamsSetCurrency
-                       currency
+                |> Result.andThen
+                       (\p ->
+                           Stripe.checkoutSessionLineItemPriceDataProductDataParamsSetName
+                               title
+                               p)
+        priceDataR =
+            productDataR
+                |> Result.andThen
+                       (\productData ->
+                           Stripe.newCheckoutSessionLineItemPriceDataParams ()
+                               |> Result.andThen
+                                      (\p ->
+                                          Stripe.checkoutSessionLineItemPriceDataParamsSetProductData
+                                              productData
+                                              p)
+                               |> Result.andThen
+                                      (\p ->
+                                          Stripe.checkoutSessionLineItemPriceDataParamsSetUnitAmount
+                                              effectivePrice
+                                              p)
+                               |> Result.andThen
+                                      (\p ->
+                                          Stripe.checkoutSessionLineItemPriceDataParamsSetCurrency
+                                              currency
+                                              p))
     in
-        Stripe.newCheckoutSessionLineItemParams ()
-            |> Stripe.checkoutSessionLineItemParamsSetPriceData priceData
-            |> Stripe.checkoutSessionLineItemParamsSetQuantity qty
+        priceDataR
+            |> Result.andThen
+                   (\priceData ->
+                       Stripe.newCheckoutSessionLineItemParams ()
+                           |> Result.andThen
+                                  (\p ->
+                                      Stripe.checkoutSessionLineItemParamsSetPriceData
+                                          priceData
+                                          p)
+                           |> Result.andThen
+                                  (\p ->
+                                      Stripe.checkoutSessionLineItemParamsSetQuantity
+                                          qty
+                                          p))
 
 
 createCheckoutSession : String -> List (Dict String String) -> String -> String -> String -> String -> Result Error CheckoutInfo
@@ -137,7 +246,7 @@ createCheckoutSession cartId items userId userName userEmail remarks =
     if apiKey == "" then
         Err
             (Error.invalidInput
-                 "Stripe API key not configured. Set STRIPE_API_KEY environment variable.")
+                "Stripe API key not configured. Set STRIPE_API_KEY environment variable.")
 
     else
         case getOrCreateCustomer userId userName userEmail of
@@ -150,54 +259,99 @@ createCheckoutSession cartId items userId userName userEmail remarks =
                     successUrl =
                         domainUrl () ++ "/order/" ++ cartId ++ "/success"
                     cancelUrl = domainUrl () ++ "/cart"
-                    lineItems = List.map buildLineItem items
-                    shippingCollection =
+                    -- buildLineItem returns Result Error Value; collect the
+                    -- Oks so the SetLineItems setter sees an unwrapped list.
+                    lineItems =
+                        List.foldr
+                            (\itemR acc ->
+                                case itemR of
+
+                                    Ok v ->
+                                        v :: acc
+
+                                    Err _ ->
+                                        acc)
+                            []
+                            (List.map buildLineItem items)
+                    shippingCollectionR =
                         Stripe.newCheckoutSessionShippingAddressCollectionParams
                             ()
-                    phoneCollection =
+                    phoneCollectionR =
                         Stripe.newCheckoutSessionPhoneNumberCollectionParams ()
-                            |> Stripe.checkoutSessionPhoneNumberCollectionParamsSetEnabled
-                                   True
-                    params =
-                        Stripe.newCheckoutSessionParams ()
-                            |> Stripe.checkoutSessionParamsSetMode "payment"
-                            |> Stripe.checkoutSessionParamsSetSuccessURL
-                                   successUrl
-                            |> Stripe.checkoutSessionParamsSetCancelURL
-                                   cancelUrl
-                            |> Stripe.checkoutSessionParamsSetCustomer
-                                   customerId
-                            |> Stripe.checkoutSessionParamsSetLineItems
-                                   lineItems
-                            |> Stripe.checkoutSessionParamsSetShippingAddressCollection
-                                   shippingCollection
-                            |> Stripe.checkoutSessionParamsSetPhoneNumberCollection
-                                   phoneCollection
+                            |> Result.andThen
+                                   (\p ->
+                                       Stripe.checkoutSessionPhoneNumberCollectionParamsSetEnabled
+                                           True
+                                           p)
+                    paramsR =
+                        case shippingCollectionR of
+
+                            Err e ->
+                                Err e
+
+                            Ok shippingCollection ->
+                                case phoneCollectionR of
+
+                                    Err e ->
+                                        Err e
+
+                                    Ok phoneCollection ->
+                                        Stripe.newCheckoutSessionParams ()
+                                            |> Result.andThen (\p -> Stripe.checkoutSessionParamsSetMode "payment" p)
+                                            |> Result.andThen (\p -> Stripe.checkoutSessionParamsSetSuccessURL successUrl p)
+                                            |> Result.andThen (\p -> Stripe.checkoutSessionParamsSetCancelURL cancelUrl p)
+                                            |> Result.andThen (\p -> Stripe.checkoutSessionParamsSetCustomer customerId p)
+                                            |> Result.andThen (\p -> Stripe.checkoutSessionParamsSetLineItems lineItems p)
+                                            |> Result.andThen (\p -> Stripe.checkoutSessionParamsSetShippingAddressCollection shippingCollection p)
+                                            |> Result.andThen (\p -> Stripe.checkoutSessionParamsSetPhoneNumberCollection phoneCollection p)
                     _ =
                         println
                             ("[STRIPE] Creating checkout session for cart: "
-                                 ++ cartId)
+                                ++ cartId)
                 in
-                    case Session.new params of
+                    case paramsR of
 
-                        Ok sess ->
-                            let
-                                sessionId = Stripe.checkoutSessionID sess
-                                sessionUrl = Stripe.checkoutSessionURL sess
-                            in
-                                Ok { id = sessionId, url = sessionUrl }
+                        Ok params ->
+                            case Session.new params of
+
+                                Ok sess ->
+                                    let
+                                        sessionId =
+                                            case Stripe.checkoutSessionID sess of
+
+                                                Ok sid ->
+                                                    sid
+
+                                                Err _ ->
+                                                    ""
+                                        sessionUrl =
+                                            case Stripe.checkoutSessionURL sess of
+
+                                                Ok url ->
+                                                    url
+
+                                                Err _ ->
+                                                    ""
+                                    in
+                                        Ok { id = sessionId, url = sessionUrl }
+
+                                Err e ->
+                                    let
+                                        _ =
+                                            println
+                                                ("[STRIPE] API error: "
+                                                    ++ errorToString e)
+                                    in
+                                        Err
+                                            (Error.network
+                                                ("Stripe API error: "
+                                                    ++ errorToString e))
 
                         Err e ->
-                            let
-                                _ =
-                                    println
-                                        ("[STRIPE] API error: "
-                                             ++ errorToString e)
-                            in
-                                Err
-                                    (Error.network
-                                         ("Stripe API error: "
-                                              ++ errorToString e))
+                            Err
+                                (Error.network
+                                    ("Failed to build Stripe checkout params: "
+                                        ++ errorToString e))
 
 
 verifyPayment orderId =
@@ -234,47 +388,44 @@ verifyPayment orderId =
 
 
 verifyStripeSession cartId sessionId =
-    case Session.get sessionId Nothing of
+-- Stripe SDK accepts a nil RetrieveParams; bridge via Basics.js
+-- so the FFI sees a Go nil at this typed boundary.
+    case Session.get sessionId (js "nil") of
 
         Ok sess ->
             let
-                -- FFI trust boundary: every Stripe getter returns
-                -- Result Error T so a nil receiver / unexpected
-                -- Go panic surfaces as Err rather than corrupting
-                -- downstream logic. Unwrap with sensible defaults
-                -- at the call site since Stripe rarely fails on a
-                -- completed session.
                 rd = \d r -> Result.withDefault d r
                 status = rd "" (Stripe.checkoutSessionStatus sess)
-                paymentStatus = rd "" (Stripe.checkoutSessionPaymentStatus sess)
+                paymentStatus =
+                    rd "" (Stripe.checkoutSessionPaymentStatus sess)
             in
-                if status == Stripe.checkoutSessionStatusComplete && paymentStatus
-                    == Stripe.checkoutSessionPaymentStatusPaid then
+                if status == rd "" (Stripe.checkoutSessionStatusComplete ())
+                    && paymentStatus
+                    == rd "" (Stripe.checkoutSessionPaymentStatusPaid ()) then
                     let
                         _ =
                             println
-                                ("[STRIPE] Payment verified for cart: "
-                                     ++ cartId)
+                                ("[STRIPE] Payment verified for cart: " ++ cartId)
                         customerDetailsR =
                             Stripe.checkoutSessionCustomerDetails sess
                         custName =
                             rd
                                 ""
                                 (customerDetailsR
-                                     |> Result.andThen
-                                            Stripe.checkoutSessionCustomerDetailsName)
+                                    |> Result.andThen
+                                           Stripe.checkoutSessionCustomerDetailsName)
                         custEmail =
                             rd
                                 ""
                                 (customerDetailsR
-                                     |> Result.andThen
-                                            Stripe.checkoutSessionCustomerDetailsEmail)
+                                    |> Result.andThen
+                                           Stripe.checkoutSessionCustomerDetailsEmail)
                         custPhone =
                             rd
                                 ""
                                 (customerDetailsR
-                                     |> Result.andThen
-                                            Stripe.checkoutSessionCustomerDetailsPhone)
+                                    |> Result.andThen
+                                           Stripe.checkoutSessionCustomerDetailsPhone)
                         shippingDetailsR =
                             Stripe.checkoutSessionCollectedInformation sess
                                 |> Result.andThen
@@ -283,8 +434,8 @@ verifyStripeSession cartId sessionId =
                             rd
                                 ""
                                 (shippingDetailsR
-                                     |> Result.andThen
-                                            Stripe.checkoutSessionCollectedInformationShippingDetailsName)
+                                    |> Result.andThen
+                                           Stripe.checkoutSessionCollectedInformationShippingDetailsName)
                         shippingAddrR =
                             shippingDetailsR
                                 |> Result.andThen
@@ -300,31 +451,26 @@ verifyStripeSession cartId sessionId =
                                   shippingName
                             , customerEmail = custEmail
                             , customerPhone = custPhone
-                            , shippingLine1 =
-                                  rd
-                                      ""
-                                      (shippingAddrR
-                                           |> Result.andThen Stripe.addressLine1)
-                            , shippingLine2 =
-                                  rd
-                                      ""
-                                      (shippingAddrR
-                                           |> Result.andThen Stripe.addressLine2)
-                            , shippingCity =
-                                  rd
-                                      ""
-                                      (shippingAddrR
-                                           |> Result.andThen Stripe.addressCity)
-                            , shippingCountry =
-                                  rd
-                                      ""
-                                      (shippingAddrR
-                                           |> Result.andThen Stripe.addressCountry)
-                            , shippingPostalCode =
-                                  rd
-                                      ""
-                                      (shippingAddrR
-                                           |> Result.andThen Stripe.addressPostalCode)
+                            , shippingLine1 = rd
+                                  ""
+                                  (shippingAddrR
+                                      |> Result.andThen Stripe.addressLine1)
+                            , shippingLine2 = rd
+                                  ""
+                                  (shippingAddrR
+                                      |> Result.andThen Stripe.addressLine2)
+                            , shippingCity = rd
+                                  ""
+                                  (shippingAddrR
+                                      |> Result.andThen Stripe.addressCity)
+                            , shippingCountry = rd
+                                  ""
+                                  (shippingAddrR
+                                      |> Result.andThen Stripe.addressCountry)
+                            , shippingPostalCode = rd
+                                  ""
+                                  (shippingAddrR
+                                      |> Result.andThen Stripe.addressPostalCode)
                             }
 
                 else
@@ -333,7 +479,7 @@ verifyStripeSession cartId sessionId =
         Err e ->
             Err
                 (Error.network
-                     ("Failed to retrieve checkout session: " ++ errorToString e))
+                    ("Failed to retrieve checkout session: " ++ errorToString e))
 
 
 deductStock orderId =

--- a/examples/13-skyshop/src/Main.sky
+++ b/examples/13-skyshop/src/Main.sky
@@ -332,8 +332,7 @@ handleAddToCart productId model =
                         let
                             _ =
                                 println
-                                    ("[CART ERROR] addItem: "
-                                         ++ Error.toString e)
+                                    ("[CART ERROR] addItem: " ++ Error.toString e)
                         in
                             ( { model | notification = "Failed to add to cart: " ++ Error.toString e
                               , notificationType = "error"
@@ -495,7 +494,7 @@ handleVerifyPayment orderId model =
                             _ =
                                 println
                                     ("[VERIFY] Checking payment for order: "
-                                         ++ orderId)
+                                        ++ orderId)
                         in
                             case Stripe.verifyPayment orderId of
 
@@ -572,9 +571,7 @@ handleVerifyPayment orderId model =
                                                         orderDoc
                                                         items
                                                         (Db.getField "name" user)
-                                                        (Db.getField
-                                                             "email"
-                                                             user)
+                                                        (Db.getField "email" user)
 
                                                 Nothing ->
                                                     ()
@@ -594,8 +591,8 @@ handleVerifyPayment orderId model =
                                                         _ =
                                                             println
                                                                 ("[VERIFY] post-paid lookup failed: "
-                                                                     ++ Error.toString
-                                                                            e)
+                                                                    ++ Error.toString
+                                                                           e)
                                                     in
                                                         Nothing
                                         orderItems =
@@ -616,7 +613,7 @@ handleVerifyPayment orderId model =
                                         _ =
                                             println
                                                 ("[VERIFY] Payment failed: "
-                                                     ++ Error.toString e)
+                                                    ++ Error.toString e)
                                     in
                                         ( { base | notification = Error.toString e
                                           , notificationType = "error"
@@ -736,10 +733,10 @@ handleDeleteProduct productId model =
         Ok _ ->
             ( refreshAdminProducts
                   (clearEditForm
-                       { model | page = AdminProductsPage
-                       , notification = "Product deleted."
-                       , notificationType = "success"
-                       })
+                      { model | page = AdminProductsPage
+                      , notification = "Product deleted."
+                      , notificationType = "success"
+                      })
             , Cmd.none
             )
 
@@ -872,12 +869,12 @@ handleFirebaseAuth token model =
                 updated =
                     refreshProducts
                         (refreshCart
-                             { model | user = Just user
-                             , page = newPage
-                             , notification = "Welcome!"
-                             , notificationType = "success"
-                             , authError = ""
-                             })
+                            { model | user = Just user
+                            , page = newPage
+                            , notification = "Welcome!"
+                            , notificationType = "success"
+                            , authError = ""
+                            })
             in
                 ( updated, Cmd.none )
 
@@ -886,7 +883,7 @@ handleFirebaseAuth token model =
                 _ =
                     println
                         ("[AUTH] Error: " ++ Error.toString e
-                             ++ " — signing out to self-heal")
+                            ++ " — signing out to self-heal")
             in
                 handleSignOut { model | authError = Error.toString e }
 

--- a/examples/13-skyshop/src/Page/Admin.sky
+++ b/examples/13-skyshop/src/Page/Admin.sky
@@ -1,4 +1,10 @@
-module Page.Admin exposing (viewAdminProducts, viewAdminNewProduct, viewAdminEditProduct, viewAdminOrders, viewAdminOrder)
+module Page.Admin exposing
+    ( viewAdminProducts
+    , viewAdminNewProduct
+    , viewAdminEditProduct
+    , viewAdminOrders
+    , viewAdminOrder
+    )
 
 import Sky.Core.Prelude exposing (..)
 import Sky.Core.Maybe exposing (..)
@@ -33,67 +39,67 @@ viewAdminProducts model =
         Layout.adminPage
             model
             (div
-                 []
-                 [ div
-                       [tw [ flex, justifyBetween, itemsCenter, mb6 ]]
-                       [ div
-                             []
-                             [ Html.h1
-                                   [tw [ text2xl, fontBold, textGray900 ]]
-                                   [text (Tr.t lang "admin.products")]
-                             , p
-                                   [tw [ textGray500, mt1 ]]
-                                   [text
-                                       (String.fromInt (List.length products)
-                                            ++ " total / "
-                                            ++ String.fromInt publishedCount
-                                            ++ " published / "
-                                            ++ String.fromInt draftCount
-                                            ++ " draft")]
-                             ]
-                       , a
-                             [ href "/admin/products/new"
-                             , attribute "sky-nav" ""
-                             , Layout.btnPrimary
-                             ]
-                             [text ("+ " ++ Tr.t lang "admin.newProduct")]
-                       ]
-                 , div
-                       [ Layout.card, style "overflow-x:auto" ]
-                       (if List.isEmpty products then
-                            [div
-                                [tw [ p8, textCenter ]]
-                                [ p
-                                      [tw [ textGray400, mb4 ]]
-                                      [text "No products yet"]
-                                , a
-                                      [ href "/admin/products/new"
-                                      , attribute "sky-nav" ""
-                                      , tw [ textSm, textBlue600, fontSemibold ]
-                                      ]
-                                      [text "Create your first product"]
-                                ]]
+                []
+                [ div
+                      [tw [ flex, justifyBetween, itemsCenter, mb6 ]]
+                      [ div
+                            []
+                            [ Html.h1
+                                  [tw [ text2xl, fontBold, textGray900 ]]
+                                  [text (Tr.t lang "admin.products")]
+                            , p
+                                  [tw [ textGray500, mt1 ]]
+                                  [text
+                                      (String.fromInt (List.length products)
+                                          ++ " total / "
+                                          ++ String.fromInt publishedCount
+                                          ++ " published / "
+                                          ++ String.fromInt draftCount
+                                          ++ " draft")]
+                            ]
+                      , a
+                            [ href "/admin/products/new"
+                            , attribute "sky-nav" ""
+                            , Layout.btnPrimary
+                            ]
+                            [text ("+ " ++ Tr.t lang "admin.newProduct")]
+                      ]
+                , div
+                      [ Layout.card, style "overflow-x:auto" ]
+                      (if List.isEmpty products then
+                          [div
+                              [tw [ p8, textCenter ]]
+                              [ p
+                                    [tw [ textGray400, mb4 ]]
+                                    [text "No products yet"]
+                              , a
+                                    [ href "/admin/products/new"
+                                    , attribute "sky-nav" ""
+                                    , tw [ textSm, textBlue600, fontSemibold ]
+                                    ]
+                                    [text "Create your first product"]
+                              ]]
 
-                        else
-                            [div
-                                [ Layout.tableHeader_
-                                , style
-                                      "display:grid;grid-template-columns:2fr 1fr 1fr 1fr .5fr;align-items:center;min-width:600px"
-                                ]
-                                [ text "Product"
-                                , span
-                                      [tw [ hidden_, Responsive.md block ]]
-                                      [text "Category"]
-                                , span
-                                      [tw [ hidden_, Responsive.md block ]]
-                                      [text "Price"]
-                                , span
-                                      [tw [ hidden_, Responsive.md block ]]
-                                      [text "Stock"]
-                                , text "Status"
-                                ]]
-                                ++ List.map (viewAdminProductRow model) products)
-                 ])
+                      else
+                          [div
+                              [ Layout.tableHeader_
+                              , style
+                                    "display:grid;grid-template-columns:2fr 1fr 1fr 1fr .5fr;align-items:center;min-width:600px"
+                              ]
+                              [ text "Product"
+                              , span
+                                    [tw [ hidden_, Responsive.md block ]]
+                                    [text "Category"]
+                              , span
+                                    [tw [ hidden_, Responsive.md block ]]
+                                    [text "Price"]
+                              , span
+                                    [tw [ hidden_, Responsive.md block ]]
+                                    [text "Stock"]
+                              , text "Status"
+                              ]]
+                              ++ List.map (viewAdminProductRow model) products)
+                ])
 
 
 viewAdminProductRow model product =
@@ -146,10 +152,10 @@ viewAdminProductRow model product =
                   [tw [ hidden_, Responsive.md block, textSm, textGray500 ]]
                   [text
                       (if stock < 0 then
-                           "Unlimited"
+                          "Unlimited"
 
-                       else
-                           String.fromInt stock)]
+                      else
+                          String.fromInt stock)]
             , if published then
                   span [Layout.badgeLive] [text "Live"]
 
@@ -165,56 +171,56 @@ viewAdminNewProduct model =
     Layout.adminPage
         model
         (div
-             []
-             [ div
-                   [tw [mb6]]
-                   [ a
-                         [ href "/admin/products"
-                         -- Image Manager
-                         , attribute "sky-nav" ""
-                         , tw [ textSm, textGray500 ]
-                         ]
-                         [text "< Products"]
-                   , Html.h1
-                         [tw [ text2xl, fontBold, textGray900, mt2 ]]
-                         [text (Tr.t model.lang "admin.newProduct")]
-                   ]
-             , viewProductForm model
-             ])
+            []
+            [ div
+                  [tw [mb6]]
+                  [ a
+                        [ href "/admin/products"
+                        -- Image Manager
+                        , attribute "sky-nav" ""
+                        , tw [ textSm, textGray500 ]
+                        ]
+                        [text "< Products"]
+                  , Html.h1
+                        [tw [ text2xl, fontBold, textGray900, mt2 ]]
+                        [text (Tr.t model.lang "admin.newProduct")]
+                  ]
+            , viewProductForm model
+            ])
 
 
 viewAdminEditProduct model =
     Layout.adminPage
         model
         (div
-             []
-             [ div
-                   [tw [mb6]]
-                   [ a
-                         [ href "/admin/products"
-                         , attribute "sky-nav" ""
-                         , tw [ textSm, textGray500 ]
-                         ]
-                         [text "< Products"]
-                   , div
-                         [tw [ flex, justifyBetween, itemsCenter, mt2 ]]
-                         [ Html.h1
-                               [tw [ text2xl, fontBold, textGray900 ]]
-                               [text (Tr.t model.lang "admin.editProduct")]
-                         , button
-                               [ onClick (DeleteProduct model.editProductId)
-                               , Layout.btnDangerOutline
-                               ]
-                               [text (Tr.t model.lang "admin.product.delete")]
-                         ]
-                   ]
-             , viewProductForm model
-             , if model.editProductId != "" then
-                   viewImageManager model
+            []
+            [ div
+                  [tw [mb6]]
+                  [ a
+                        [ href "/admin/products"
+                        , attribute "sky-nav" ""
+                        , tw [ textSm, textGray500 ]
+                        ]
+                        [text "< Products"]
+                  , div
+                        [tw [ flex, justifyBetween, itemsCenter, mt2 ]]
+                        [ Html.h1
+                              [tw [ text2xl, fontBold, textGray900 ]]
+                              [text (Tr.t model.lang "admin.editProduct")]
+                        , button
+                              [ onClick (DeleteProduct model.editProductId)
+                              , Layout.btnDangerOutline
+                              ]
+                              [text (Tr.t model.lang "admin.product.delete")]
+                        ]
+                  ]
+            , viewProductForm model
+            , if model.editProductId != "" then
+                  viewImageManager model
 
-               else
-                   text ""
-             ])
+              else
+                  text ""
+            ])
 
 
 viewProductForm model =
@@ -270,17 +276,17 @@ viewProductForm model =
                                     , Layout.formInput
                                     ]
                                     (List.map
-                                         (\cat ->
-                                              option
-                                                  [ value cat
-                                                  , if cat == model.editCategory then
-                                                        selected ()
+                                        (\cat ->
+                                            option
+                                                [ value cat
+                                                , if cat == model.editCategory then
+                                                      selected ()
 
-                                                    else
-                                                        class ""
-                                                  ]
-                                                  [text cat])
-                                         allCategories)
+                                                  else
+                                                      class ""
+                                                ]
+                                                [text cat])
+                                        allCategories)
                               ]
                         , div
                               []
@@ -292,17 +298,17 @@ viewProductForm model =
                                     , Layout.formInput
                                     ]
                                     (List.map
-                                         (\cur ->
-                                              option
-                                                  [ value cur
-                                                  , if cur == model.editCurrency then
-                                                        selected ()
+                                        (\cur ->
+                                            option
+                                                [ value cur
+                                                , if cur == model.editCurrency then
+                                                      selected ()
 
-                                                    else
-                                                        class ""
-                                                  ]
-                                                  [text cur])
-                                         allCurrencies)
+                                                  else
+                                                      class ""
+                                                ]
+                                                [text cur])
+                                        allCurrencies)
                               ]
                         ]
                   ]
@@ -329,8 +335,7 @@ viewProductForm model =
                                               UpdateEditPrice
                                                   (Maybe.withDefault
                                                       model.editPrice
-                                                      (String.toInt s))
-                                          )
+                                                      (String.toInt s)))
                                     , Layout.formInput
                                     , placeholder "0"
                                     , required ()
@@ -350,8 +355,7 @@ viewProductForm model =
                                               UpdateEditDiscount
                                                   (Maybe.withDefault
                                                       model.editDiscount
-                                                      (String.toInt s))
-                                          )
+                                                      (String.toInt s)))
                                     , Layout.formInput
                                     , placeholder "0"
                                     , Attr.min "0"
@@ -370,8 +374,7 @@ viewProductForm model =
                                               UpdateEditStock
                                                   (Maybe.withDefault
                                                       model.editStock
-                                                      (String.toInt s))
-                                          )
+                                                      (String.toInt s)))
                                     , Layout.formInput
                                     , placeholder "-1"
                                     , Attr.min "-1"
@@ -387,18 +390,18 @@ viewProductForm model =
                               [ onClick ToggleEditPublished
                               , class
                                     (if model.editPublished then
-                                         "toggle toggle-on"
+                                        "toggle toggle-on"
 
-                                     else
-                                         "toggle toggle-off")
+                                    else
+                                        "toggle toggle-off")
                               ]
                               [span
                                   [class
                                       (if model.editPublished then
-                                           "toggle-knob toggle-knob-on"
+                                          "toggle-knob toggle-knob-on"
 
-                                       else
-                                           "toggle-knob toggle-knob-off")]
+                                      else
+                                          "toggle-knob toggle-knob-off")]
                                   []]
                         , span
                               [tw [ textSm, fontMedium, textGray700 ]]
@@ -435,8 +438,8 @@ viewImageManager model =
                       [tw [ fontSemibold, textGray900, textSm ]]
                       [text
                           (Tr.t lang "admin.product.images" ++ " ("
-                               ++ String.fromInt (List.length images)
-                               ++ ")")]]
+                              ++ String.fromInt (List.length images)
+                              ++ ")")]]
             , div
                   [Layout.cardBody]
                   [ if List.isEmpty images then
@@ -449,28 +452,28 @@ viewImageManager model =
                                   "grid-template-columns:repeat(auto-fill,minmax(120px,1fr))"
                             ]
                             (List.map
-                                 (\imgRow ->
-                                      let
-                                          imageId = Db.getField "id" imgRow
-                                      in
-                                          div
-                                              [Layout.imgCardSquare]
-                                              [ img
-                                                    [ src
-                                                          (Db.getField
-                                                               "data"
-                                                               imgRow)
-                                                    , alt "Product image"
-                                                    , Layout.objectCover_
-                                                    ]
-                                              , button
-                                                    [ onClick
-                                                          (DeleteImage imageId)
-                                                    , Layout.imgOverlayDelete
-                                                    ]
-                                                    [text "x"]
-                                              ])
-                                 images)
+                                (\imgRow ->
+                                    let
+                                        imageId = Db.getField "id" imgRow
+                                    in
+                                        div
+                                            [Layout.imgCardSquare]
+                                            [ img
+                                                  [ src
+                                                        (Db.getField
+                                                            "data"
+                                                            imgRow)
+                                                  , alt "Product image"
+                                                  , Layout.objectCover_
+                                                  ]
+                                            , button
+                                                  [ onClick
+                                                        (DeleteImage imageId)
+                                                  , Layout.imgOverlayDelete
+                                                  ]
+                                                  [text "x"]
+                                            ])
+                                images)
                   , div
                         [Layout.uploadZone]
                         [ div
@@ -501,64 +504,64 @@ viewAdminOrders model =
         Layout.adminPage
             model
             (div
-                 []
-                 [ div
-                       [tw [mb6]]
-                       [ Html.h1
-                             [tw [ text2xl, fontBold, textGray900 ]]
-                             [text (Tr.t lang "admin.orders")]
-                       , p
-                             [tw [ textGray500, mt1 ]]
-                             [text
-                                 (String.fromInt (List.length model.adminOrders)
-                                      ++ " orders")]
-                       ]
-                 , viewOrderFilter model
-                 , div
-                       [ Layout.card, style "overflow-x:auto" ]
-                       (if List.isEmpty model.adminOrders then
-                            [div
-                                [tw [ p8, textCenter ]]
-                                [p [tw [textGray400]] [text "No orders found"]]]
+                []
+                [ div
+                      [tw [mb6]]
+                      [ Html.h1
+                            [tw [ text2xl, fontBold, textGray900 ]]
+                            [text (Tr.t lang "admin.orders")]
+                      , p
+                            [tw [ textGray500, mt1 ]]
+                            [text
+                                (String.fromInt (List.length model.adminOrders)
+                                    ++ " orders")]
+                      ]
+                , viewOrderFilter model
+                , div
+                      [ Layout.card, style "overflow-x:auto" ]
+                      (if List.isEmpty model.adminOrders then
+                          [div
+                              [tw [ p8, textCenter ]]
+                              [p [tw [textGray400]] [text "No orders found"]]]
 
-                        else
-                            [div
-                                [ Layout.tableHeader_
-                                , style
-                                      "display:grid;grid-template-columns:2fr 1fr 1fr 1fr;align-items:center;min-width:500px"
-                                ]
-                                [ text "Customer"
-                                , span
-                                      [tw [ hidden_, Responsive.md block ]]
-                                      [text "Total"]
-                                , span
-                                      [tw [ hidden_, Responsive.md block ]]
-                                      [text "Date"]
-                                , text "Status"
-                                ]]
-                                ++ List.map
-                                       (viewAdminOrderRow model)
-                                       model.adminOrders)
-                 ])
+                      else
+                          [div
+                              [ Layout.tableHeader_
+                              , style
+                                    "display:grid;grid-template-columns:2fr 1fr 1fr 1fr;align-items:center;min-width:500px"
+                              ]
+                              [ text "Customer"
+                              , span
+                                    [tw [ hidden_, Responsive.md block ]]
+                                    [text "Total"]
+                              , span
+                                    [tw [ hidden_, Responsive.md block ]]
+                                    [text "Date"]
+                              , text "Status"
+                              ]]
+                              ++ List.map
+                                     (viewAdminOrderRow model)
+                                     model.adminOrders)
+                ])
 
 
 viewOrderFilter model =
     div
         [tw [ flex, flexWrap, gap2, mb4 ]]
         ([orderFilterBtn "all" "All" model.adminOrderFilter]
-             ++ List.map
-                    (\st ->
-                         orderFilterBtn
-                             st
-                             (Tr.tCartState model.lang st)
-                             model.adminOrderFilter)
-                    [ "pending"
-                    , "ordered"
-                    , "shipped"
-                    , "delivered"
-                    , "cancelled"
-                    , "refunded"
-                    ])
+            ++ List.map
+                   (\st ->
+                       orderFilterBtn
+                           st
+                           (Tr.tCartState model.lang st)
+                           model.adminOrderFilter)
+                   [ "pending"
+                   , "ordered"
+                   , "shipped"
+                   , "delivered"
+                   , "cancelled"
+                   , "refunded"
+                   ])
 
 
 orderFilterBtn filterValue label activeFilter =
@@ -669,13 +672,13 @@ viewAdminOrder model =
         model
         (case model.order of
 
-             Just order ->
-                 viewAdminOrderDetail model order
+            Just order ->
+                viewAdminOrderDetail model order
 
-             Nothing ->
-                 div
-                     [tw [ textCenter, py16 ]]
-                     [p [tw [textGray400]] [text "Order not found."]])
+            Nothing ->
+                div
+                    [tw [ textCenter, py16 ]]
+                    [p [tw [textGray400]] [text "Order not found."]])
 
 
 viewAdminOrderDetail model order =
@@ -747,20 +750,20 @@ viewAdminOrderDetail model order =
                       , div
                             [tw [ flex, flexWrap, gap2 ]]
                             (List.map
-                                 (\newState ->
-                                      if newState != st && newState != "ongoing" then
-                                          button
-                                              [ onClick
-                                                    (UpdateOrderState
-                                                         orderId
-                                                         newState)
-                                              , Layout.btnState
-                                              ]
-                                              [text (Tr.tCartState lang newState)]
+                                (\newState ->
+                                    if newState != st && newState != "ongoing" then
+                                        button
+                                            [ onClick
+                                                  (UpdateOrderState
+                                                      orderId
+                                                      newState)
+                                            , Layout.btnState
+                                            ]
+                                            [text (Tr.tCartState lang newState)]
 
-                                      else
-                                          text "")
-                                 allCartStates)
+                                    else
+                                        text "")
+                                allCartStates)
                       ]]
             , div
                   [Layout.card]
@@ -781,8 +784,8 @@ infoCard title lines =
         , div
               []
               (List.map
-                   (\line -> p [tw [ textSm, textGray700 ]] [text line])
-                   lines)
+                  (\line -> p [tw [ textSm, textGray700 ]] [text line])
+                  lines)
         ]
 
 

--- a/examples/13-skyshop/src/Page/AuthPage.sky
+++ b/examples/13-skyshop/src/Page/AuthPage.sky
@@ -18,73 +18,73 @@ viewSignIn model =
         Layout.page
             model
             (div
-                 [tw [ maxWSm, mxAuto, py12 ]]
-                 [div
-                     [tw [ bgWhite, roundedXl, shadow, p8 ]]
-                     [ Html.h1
-                           [tw [ text2xl, fontBold, mb6, textCenter ]]
-                           [text (Tr.t lang "auth.welcome")]
-                     , div
-                           [ id "auth-error"
-                           , tw
-                                 [ bgRed50
-                                 , textRed700
-                                 , p3
-                                 , roundedMd
-                                 , mb4
-                                 , textSm
-                                 ]
-                           , style "display:none"
-                           ]
-                           [text model.authError]
-                     , div
-                           [tw [ flexCol, gap4 ]]
-                           [ button
-                                 [ attribute "onclick" "skySignIn('google')"
-                                 , tw
-                                       [ wFull
-                                       , bgWhite
-                                       , textGray700
-                                       , py3
-                                       , px4
-                                       , roundedLg
-                                       , fontSemibold
-                                       , textCenter
-                                       , border
-                                       , borderGray300
-                                       , flex
-                                       , itemsCenter
-                                       , justifyCenter
-                                       , gap3
-                                       , hover bgGray50
-                                       , transitionColors
-                                       , cursorPointer
-                                       ]
-                                 ]
-                                 [text "Sign in with Google"]
-                           , button
-                                 [ attribute "onclick" "skySignIn('facebook')"
-                                 , tw
-                                       [ wFull
-                                       , bgBlue600
-                                       , textWhite
-                                       , py3
-                                       , px4
-                                       , roundedLg
-                                       , fontSemibold
-                                       , textCenter
-                                       , flex
-                                       , itemsCenter
-                                       , justifyCenter
-                                       , gap3
-                                       , hover bgBlue700
-                                       , transitionColors
-                                       , cursorPointer
-                                       ]
-                                 ]
-                                 [text "Sign in with Facebook"]
-                           ]
-                     , p
-                           [tw [ textCenter, textSm, textGray500, mt6 ]]
-                           [text (Tr.t lang "auth.terms_notice")]
-                     ]])
+                [tw [ maxWSm, mxAuto, py12 ]]
+                [div
+                    [tw [ bgWhite, roundedXl, shadow, p8 ]]
+                    [ Html.h1
+                          [tw [ text2xl, fontBold, mb6, textCenter ]]
+                          [text (Tr.t lang "auth.welcome")]
+                    , div
+                          [ id "auth-error"
+                          , tw
+                                [ bgRed50
+                                , textRed700
+                                , p3
+                                , roundedMd
+                                , mb4
+                                , textSm
+                                ]
+                          , style "display:none"
+                          ]
+                          [text model.authError]
+                    , div
+                          [tw [ flexCol, gap4 ]]
+                          [ button
+                                [ attribute "onclick" "skySignIn('google')"
+                                , tw
+                                      [ wFull
+                                      , bgWhite
+                                      , textGray700
+                                      , py3
+                                      , px4
+                                      , roundedLg
+                                      , fontSemibold
+                                      , textCenter
+                                      , border
+                                      , borderGray300
+                                      , flex
+                                      , itemsCenter
+                                      , justifyCenter
+                                      , gap3
+                                      , hover bgGray50
+                                      , transitionColors
+                                      , cursorPointer
+                                      ]
+                                ]
+                                [text "Sign in with Google"]
+                          , button
+                                [ attribute "onclick" "skySignIn('facebook')"
+                                , tw
+                                      [ wFull
+                                      , bgBlue600
+                                      , textWhite
+                                      , py3
+                                      , px4
+                                      , roundedLg
+                                      , fontSemibold
+                                      , textCenter
+                                      , flex
+                                      , itemsCenter
+                                      , justifyCenter
+                                      , gap3
+                                      , hover bgBlue700
+                                      , transitionColors
+                                      , cursorPointer
+                                      ]
+                                ]
+                                [text "Sign in with Facebook"]
+                          ]
+                    , p
+                          [tw [ textCenter, textSm, textGray500, mt6 ]]
+                          [text (Tr.t lang "auth.terms_notice")]
+                    ]])

--- a/examples/13-skyshop/src/Page/CartPage.sky
+++ b/examples/13-skyshop/src/Page/CartPage.sky
@@ -24,11 +24,11 @@ viewCart model =
         model
         (case model.user of
 
-             Nothing ->
-                 viewSignInPrompt model
+            Nothing ->
+                viewSignInPrompt model
 
-             Just _ ->
-                 viewCartContent model)
+            Just _ ->
+                viewCartContent model)
 
 
 viewSignInPrompt model =
@@ -69,7 +69,7 @@ viewCartContent model =
                             [tw [ textGray500, mt1, mb6 ]]
                             [text
                                 (String.fromInt (List.length model.cartItems)
-                                     ++ " items")]
+                                    ++ " items")]
                       , div
                             [tw
                                 [ flex
@@ -178,8 +178,8 @@ viewCartItem model item =
                         [ button
                               [ onClick
                                     (UpdateCartItemQty
-                                         itemId
-                                         (String.fromInt (qty - 1)))
+                                        itemId
+                                        (String.fromInt (qty - 1)))
                               , Layout.qtyBtn
                               ]
                               [text "-"]
@@ -189,8 +189,8 @@ viewCartItem model item =
                         , button
                               [ onClick
                                     (UpdateCartItemQty
-                                         itemId
-                                         (String.fromInt (qty + 1)))
+                                        itemId
+                                        (String.fromInt (qty + 1)))
                               , Layout.qtyBtn
                               ]
                               [text "+"]

--- a/examples/13-skyshop/src/Page/Home.sky
+++ b/examples/13-skyshop/src/Page/Home.sky
@@ -26,11 +26,11 @@ viewHome model =
     Layout.page
         model
         (div
-             []
-             [ viewHero model
-             , viewCategoryBar model
-             , viewFeaturedProducts model
-             ])
+            []
+            [ viewHero model
+            , viewCategoryBar model
+            , viewFeaturedProducts model
+            ])
 
 
 viewHero model =
@@ -104,26 +104,26 @@ viewCategoryBar model =
     div
         [tw [ mb8, flex, flexWrap, gap2, justifyCenter ]]
         (List.map
-             (\cat ->
-                  a
-                      [ href "/products"
-                      , attribute "sky-nav" ""
-                      , onClick (SetCategoryFilter cat)
-                      , tw
-                            [ inlineBlock
-                            , px4
-                            , py2
-                            , roundedFull
-                            , textSm
-                            , fontMedium
-                            , textGray500
-                            , bgGray100
-                            , hover bgGray200
-                            , hover textGray900
-                            ]
-                      ]
-                      [text (Tr.tCategory model.lang cat)])
-             (List.take 6 allCategories))
+            (\cat ->
+                a
+                    [ href "/products"
+                    , attribute "sky-nav" ""
+                    , onClick (SetCategoryFilter cat)
+                    , tw
+                          [ inlineBlock
+                          , px4
+                          , py2
+                          , roundedFull
+                          , textSm
+                          , fontMedium
+                          , textGray500
+                          , bgGray100
+                          , hover bgGray200
+                          , hover textGray900
+                          ]
+                    ]
+                    [text (Tr.tCategory model.lang cat)])
+            (List.take 6 allCategories))
 
 
 viewFeaturedProducts model =
@@ -155,19 +155,19 @@ viewProducts model =
     Layout.page
         model
         (div
-             []
-             [ div
-                   [tw [mb8]]
-                   [ Html.h1
-                         [tw [ text3xl, fontBold, textGray900 ]]
-                         [text (Tr.t model.lang "nav.products")]
-                   , p
-                         [tw [ textGray500, mt1 ]]
-                         [text (Tr.t model.lang "hero.browse")]
-                   ]
-             , viewToolbar model
-             , viewProductGrid model model.products
-             ])
+            []
+            [ div
+                  [tw [mb8]]
+                  [ Html.h1
+                        [tw [ text3xl, fontBold, textGray900 ]]
+                        [text (Tr.t model.lang "nav.products")]
+                  , p
+                        [tw [ textGray500, mt1 ]]
+                        [text (Tr.t model.lang "hero.browse")]
+                  ]
+            , viewToolbar model
+            , viewProductGrid model model.products
+            ])
 
 
 viewToolbar model =
@@ -185,17 +185,14 @@ viewToolbar model =
                   ]
             , div
                   [tw [ flex, flexWrap, gap2 ]]
-                  ([filterBtn
-                       "all"
-                       (Tr.t lang "product.all")
-                       model.categoryFilter]
-                       ++ List.map
-                              (\cat ->
-                                   filterBtn
-                                       cat
-                                       (Tr.tCategory lang cat)
-                                       model.categoryFilter)
-                              allCategories)
+                  ([filterBtn "all" (Tr.t lang "product.all") model.categoryFilter]
+                      ++ List.map
+                             (\cat ->
+                                 filterBtn
+                                     cat
+                                     (Tr.tCategory lang cat)
+                                     model.categoryFilter)
+                             allCategories)
             , div
                   [tw [ flex, gap2, itemsCenter ]]
                   [ span
@@ -217,10 +214,10 @@ viewToolbar model =
                         [ onClick ToggleSortDir, Layout.qtyBtn ]
                         [text
                             (if model.sortDir == "asc" then
-                                 "↑"
+                                "↑"
 
-                             else
-                                 "↓")]
+                            else
+                                "↓")]
                   ]
             ]
 

--- a/examples/13-skyshop/src/Page/Orders.sky
+++ b/examples/13-skyshop/src/Page/Orders.sky
@@ -26,39 +26,39 @@ viewOrders model =
         model
         (case model.user of
 
-             Nothing ->
-                 div
-                     [tw [ textCenter, py16 ]]
-                     [a
-                         [ href "/auth/signin"
-                         , attribute "sky-nav" ""
-                         , tw
-                               [ bgBlue600
-                               , textWhite
-                               , px6
-                               , py3
-                               , roundedLg
-                               , fontSemibold
-                               ]
-                         ]
-                         [text (Tr.t model.lang "nav.signin")]]
+            Nothing ->
+                div
+                    [tw [ textCenter, py16 ]]
+                    [a
+                        [ href "/auth/signin"
+                        , attribute "sky-nav" ""
+                        , tw
+                              [ bgBlue600
+                              , textWhite
+                              , px6
+                              , py3
+                              , roundedLg
+                              , fontSemibold
+                              ]
+                        ]
+                        [text (Tr.t model.lang "nav.signin")]]
 
-             Just _ ->
-                 div
-                     []
-                     [ Html.h1
-                           [tw [ text3xl, fontBold, mb6 ]]
-                           [text (Tr.t model.lang "order.title")]
-                     , if List.isEmpty model.orders then
-                           div
-                               [tw [ textCenter, py16, textGray500 ]]
-                               [text (Tr.t model.lang "order.empty")]
+            Just _ ->
+                div
+                    []
+                    [ Html.h1
+                          [tw [ text3xl, fontBold, mb6 ]]
+                          [text (Tr.t model.lang "order.title")]
+                    , if List.isEmpty model.orders then
+                          div
+                              [tw [ textCenter, py16, textGray500 ]]
+                              [text (Tr.t model.lang "order.empty")]
 
-                       else
-                           div
-                               [tw [ flexCol, gap4 ]]
-                               (List.map (viewOrderCard model) model.orders)
-                     ])
+                      else
+                          div
+                              [tw [ flexCol, gap4 ]]
+                              (List.map (viewOrderCard model) model.orders)
+                    ])
 
 
 -- ══════════════════════════════════════════════════════
@@ -136,13 +136,13 @@ viewOrder model =
         model
         (case model.order of
 
-             Just order ->
-                 viewOrderDetail model order
+            Just order ->
+                viewOrderDetail model order
 
-             Nothing ->
-                 div
-                     [tw [ textCenter, py16, textGray500 ]]
-                     [text (Tr.t model.lang "common.loading")])
+            Nothing ->
+                div
+                    [tw [ textCenter, py16, textGray500 ]]
+                    [text (Tr.t model.lang "common.loading")])
 
 
 viewOrderDetail model order =
@@ -201,8 +201,8 @@ viewOrderDetail model order =
                                     [tw [ text2xl, fontBold ]]
                                     [text
                                         (Money.formatPrice
-                                             totalAmount
-                                             totalCurrency)]
+                                            totalAmount
+                                            totalCurrency)]
                               ]
                         , div
                               []
@@ -229,10 +229,10 @@ viewOrderDetail model order =
                                   [tw [ textSm, textGray600 ]]
                                   [text
                                       (shippingLine1 ++ ", " ++ shippingCity
-                                           ++ " "
-                                           ++ shippingPostcode
-                                           ++ ", "
-                                           ++ shippingCountry)]
+                                          ++ " "
+                                          ++ shippingPostcode
+                                          ++ ", "
+                                          ++ shippingCountry)]
                             ]
 
                     else
@@ -303,81 +303,77 @@ viewOrderSuccess model =
     Layout.page
         model
         (div
-             [tw [ textCenter, py16 ]]
-             [case model.order of
+            [tw [ textCenter, py16 ]]
+            [case model.order of
 
-                 Just order ->
-                     let
-                         state = Db.getField "state" order
-                     in
-                         if state == "ordered" || state == "shipped" || state
-                             == "delivered" then
-                             div
-                                 []
-                                 [ div
-                                       [tw
-                                           [ w16
-                                           , h16
-                                           , bgGreen100
-                                           , roundedFull
-                                           , flex
-                                           , itemsCenter
-                                           , justifyCenter
-                                           , mxAuto
-                                           , mb4
-                                           ]]
-                                       [span
-                                           [tw [ text2xl, textGreen600 ]]
-                                           [text "✓"]]
-                                 , Html.h1
-                                       [tw [ text2xl, fontBold, mb4 ]]
-                                       [text (Tr.t model.lang "order.success")]
-                                 , a
-                                       [ href
-                                             ("/order/"
-                                                  ++ Db.getField "id" order)
-                                       , attribute "sky-nav" ""
-                                       , tw
-                                             [ bgBlue600
-                                             , textWhite
-                                             , px6
-                                             , py3
-                                             , roundedLg
-                                             , fontSemibold
-                                             , inlineBlock
-                                             ]
-                                       ]
-                                       [text (Tr.t model.lang "order.detail")]
-                                 ]
+                Just order ->
+                    let
+                        state = Db.getField "state" order
+                    in
+                        if state == "ordered" || state == "shipped" || state
+                            == "delivered" then
+                            div
+                                []
+                                [ div
+                                      [tw
+                                          [ w16
+                                          , h16
+                                          , bgGreen100
+                                          , roundedFull
+                                          , flex
+                                          , itemsCenter
+                                          , justifyCenter
+                                          , mxAuto
+                                          , mb4
+                                          ]]
+                                      [span
+                                          [tw [ text2xl, textGreen600 ]]
+                                          [text "✓"]]
+                                , Html.h1
+                                      [tw [ text2xl, fontBold, mb4 ]]
+                                      [text (Tr.t model.lang "order.success")]
+                                , a
+                                      [ href
+                                            ("/order/" ++ Db.getField "id" order)
+                                      , attribute "sky-nav" ""
+                                      , tw
+                                            [ bgBlue600
+                                            , textWhite
+                                            , px6
+                                            , py3
+                                            , roundedLg
+                                            , fontSemibold
+                                            , inlineBlock
+                                            ]
+                                      ]
+                                      [text (Tr.t model.lang "order.detail")]
+                                ]
 
-                         else
-                             div
-                                 []
-                                 [ Html.h1
-                                       [tw [ text2xl, fontBold, mb4, textRed600 ]]
-                                       [text (Tr.t model.lang "order.failed")]
-                                 , p
-                                       [tw [ textGray500, mb4 ]]
-                                       [text
-                                           (Tr.t model.lang "order.status"
-                                                ++ ": "
-                                                ++ Tr.tCartState
-                                                       model.lang
-                                                       state)]
-                                 , a
-                                       [ href "/cart"
-                                       , attribute "sky-nav" ""
-                                       , tw [textBlue600]
-                                       ]
-                                       [text
-                                           (Tr.t
-                                                model.lang
-                                                "cart.continueShopping")]
-                                 ]
+                        else
+                            div
+                                []
+                                [ Html.h1
+                                      [tw [ text2xl, fontBold, mb4, textRed600 ]]
+                                      [text (Tr.t model.lang "order.failed")]
+                                , p
+                                      [tw [ textGray500, mb4 ]]
+                                      [text
+                                          (Tr.t model.lang "order.status" ++ ": "
+                                              ++ Tr.tCartState model.lang state)]
+                                , a
+                                      [ href "/cart"
+                                      , attribute "sky-nav" ""
+                                      , tw [textBlue600]
+                                      ]
+                                      [text
+                                          (Tr.t
+                                              model.lang
+                                              "cart.continueShopping")]
+                                ]
 
-                 Nothing ->
-                     div
-                         []
-                         [p
-                             [tw [textGray500]]
-                             [text (Tr.t model.lang "order.processing")]]])
+                Nothing ->
+                    div
+                        []
+                        [p
+                            [tw [textGray500]]
+                            [text (Tr.t model.lang "order.processing")]]])

--- a/examples/13-skyshop/src/Page/Product.sky
+++ b/examples/13-skyshop/src/Page/Product.sky
@@ -24,15 +24,15 @@ viewProduct model =
         model
         (case model.product of
 
-             Just product ->
-                 viewProductDetail model product
+            Just product ->
+                viewProductDetail model product
 
-             Nothing ->
-                 div
-                     [tw [ textCenter, py16 ]]
-                     [p
-                         [tw [textGray400]]
-                         [text (Tr.t model.lang "common.loading")]])
+            Nothing ->
+                div
+                    [tw [ textCenter, py16 ]]
+                    [p
+                        [tw [textGray400]]
+                        [text (Tr.t model.lang "common.loading")]])
 
 
 viewProductDetail model product =
@@ -165,15 +165,15 @@ viewImageGallery images =
                   div
                       [tw [ grid, gridCols3, Responsive.md gridCols4, gap2 ]]
                       (List.map
-                           (\imgRow ->
-                                div
-                                    [Layout.galleryThumb]
-                                    [img
-                                        [ src (Db.getField "data" imgRow)
-                                        , alt "Thumbnail"
-                                        , Layout.objectCover_
-                                        ]])
-                           images)
+                          (\imgRow ->
+                              div
+                                  [Layout.galleryThumb]
+                                  [img
+                                      [ src (Db.getField "data" imgRow)
+                                      , alt "Thumbnail"
+                                      , Layout.objectCover_
+                                      ]])
+                          images)
 
               else
                   text ""
@@ -243,9 +243,9 @@ viewDetailStock model stock =
                         ]]
                     [text
                         (Tr.t lang "product.inStock" ++ " - "
-                             ++ String.fromInt stock
-                             ++ " "
-                             ++ Tr.t lang "product.left")]
+                            ++ String.fromInt stock
+                            ++ " "
+                            ++ Tr.t lang "product.left")]
 
             else
                 span
@@ -299,15 +299,14 @@ viewAddToCart model product stock =
                                                 UpdateQuantity
                                                     (Maybe.withDefault
                                                         model.quantity
-                                                        (String.toInt s))
-                                            )
+                                                        (String.toInt s)))
                                       , Attr.min "1"
                                       , Attr.max
                                             (if stock > 0 then
-                                                 String.fromInt stock
+                                                String.fromInt stock
 
-                                             else
-                                                 "99")
+                                            else
+                                                "99")
                                       , class "qty-input"
                                       ]
                                 , button

--- a/examples/13-skyshop/src/Page/Static.sky
+++ b/examples/13-skyshop/src/Page/Static.sky
@@ -17,33 +17,33 @@ viewPrivacyPolicy model =
     Layout.page
         model
         (div
-             [tw [ maxW3xl, mxAuto, py8 ]]
-             [ Html.h1 [tw [ text3xl, fontBold, mb6 ]] [text "Privacy Policy"]
-             , div
-                   [tw [ textGray600, leadingRelaxed ]]
-                   [ section_
-                         "1. Information We Collect"
-                         "We collect personal information you provide when creating an account, placing an order, or contacting us. This includes your name, email address, phone number, shipping address, and payment information (processed securely through Stripe)."
-                   , section_
-                         "2. How We Use Your Information"
-                         "We use your information to process orders, communicate with you about your purchases, improve our services, and comply with legal obligations. We do not sell your personal information to third parties."
-                   , section_
-                         "3. Payment Security"
-                         "All payment processing is handled by Stripe, a PCI-compliant payment processor. We do not store credit card numbers or sensitive payment details on our servers."
-                   , section_
-                         "4. Data Retention"
-                         "We retain your account information for as long as your account is active. Order history is kept for tax and legal compliance purposes. You may request deletion of your account by contacting us."
-                   , section_
-                         "5. Cookies"
-                         "We use session cookies to maintain your login state and shopping cart. These are essential for the functioning of the website and cannot be disabled."
-                   , section_
-                         "6. Your Rights"
-                         "You have the right to access, correct, or delete your personal data. You may also withdraw consent for data processing at any time by contacting us."
-                   , section_
-                         "7. Contact"
-                         "For privacy-related inquiries, please contact us at privacy@example.com."
-                   ]
-             ])
+            [tw [ maxW3xl, mxAuto, py8 ]]
+            [ Html.h1 [tw [ text3xl, fontBold, mb6 ]] [text "Privacy Policy"]
+            , div
+                  [tw [ textGray600, leadingRelaxed ]]
+                  [ section_
+                        "1. Information We Collect"
+                        "We collect personal information you provide when creating an account, placing an order, or contacting us. This includes your name, email address, phone number, shipping address, and payment information (processed securely through Stripe)."
+                  , section_
+                        "2. How We Use Your Information"
+                        "We use your information to process orders, communicate with you about your purchases, improve our services, and comply with legal obligations. We do not sell your personal information to third parties."
+                  , section_
+                        "3. Payment Security"
+                        "All payment processing is handled by Stripe, a PCI-compliant payment processor. We do not store credit card numbers or sensitive payment details on our servers."
+                  , section_
+                        "4. Data Retention"
+                        "We retain your account information for as long as your account is active. Order history is kept for tax and legal compliance purposes. You may request deletion of your account by contacting us."
+                  , section_
+                        "5. Cookies"
+                        "We use session cookies to maintain your login state and shopping cart. These are essential for the functioning of the website and cannot be disabled."
+                  , section_
+                        "6. Your Rights"
+                        "You have the right to access, correct, or delete your personal data. You may also withdraw consent for data processing at any time by contacting us."
+                  , section_
+                        "7. Contact"
+                        "For privacy-related inquiries, please contact us at privacy@example.com."
+                  ]
+            ])
 
 
 -- ══════════════════════════════════════════════════════
@@ -53,35 +53,35 @@ viewTerms model =
     Layout.page
         model
         (div
-             [tw [ maxW3xl, mxAuto, py8 ]]
-             [ Html.h1
-                   [tw [ text3xl, fontBold, mb6 ]]
-                   [text "Terms & Conditions"]
-             , div
-                   [tw [ textGray600, leadingRelaxed ]]
-                   [ section_
-                         "1. General"
-                         "By using SkyShop, you agree to these terms and conditions. We reserve the right to modify these terms at any time."
-                   , section_
-                         "2. Products"
-                         "All products are subject to availability. We make every effort to display accurate product descriptions and images. Prices are listed in the currency shown and include applicable taxes."
-                   , section_
-                         "3. Orders"
-                         "Once an order is placed and payment is confirmed, it cannot be cancelled. We will process and ship your order as soon as possible."
-                   , section_
-                         "4. Shipping"
-                         "Shipping is available to selected countries. Delivery times vary by location. We are not responsible for customs duties or import taxes."
-                   , section_
-                         "5. Returns & Refunds"
-                         "Items may be returned within 14 days of receipt in their original condition. Refunds will be processed to the original payment method within 5-10 business days."
-                   , section_
-                         "6. Limitation of Liability"
-                         "SkyShop is not liable for any indirect, incidental, or consequential damages arising from the use of our services or products."
-                   , section_
-                         "7. Governing Law"
-                         "These terms are governed by the laws of the United Kingdom."
-                   ]
-             ])
+            [tw [ maxW3xl, mxAuto, py8 ]]
+            [ Html.h1
+                  [tw [ text3xl, fontBold, mb6 ]]
+                  [text "Terms & Conditions"]
+            , div
+                  [tw [ textGray600, leadingRelaxed ]]
+                  [ section_
+                        "1. General"
+                        "By using SkyShop, you agree to these terms and conditions. We reserve the right to modify these terms at any time."
+                  , section_
+                        "2. Products"
+                        "All products are subject to availability. We make every effort to display accurate product descriptions and images. Prices are listed in the currency shown and include applicable taxes."
+                  , section_
+                        "3. Orders"
+                        "Once an order is placed and payment is confirmed, it cannot be cancelled. We will process and ship your order as soon as possible."
+                  , section_
+                        "4. Shipping"
+                        "Shipping is available to selected countries. Delivery times vary by location. We are not responsible for customs duties or import taxes."
+                  , section_
+                        "5. Returns & Refunds"
+                        "Items may be returned within 14 days of receipt in their original condition. Refunds will be processed to the original payment method within 5-10 business days."
+                  , section_
+                        "6. Limitation of Liability"
+                        "SkyShop is not liable for any indirect, incidental, or consequential damages arising from the use of our services or products."
+                  , section_
+                        "7. Governing Law"
+                        "These terms are governed by the laws of the United Kingdom."
+                  ]
+            ])
 
 
 section_ title body =

--- a/examples/13-skyshop/src/State.sky
+++ b/examples/13-skyshop/src/State.sky
@@ -8,7 +8,41 @@ import Sky.Core.Dict as Dict
 -- MODEL
 -- ══════════════════════════════════════════════════════
 type alias Model =
-    { page : Page, lang : String, user : Maybe (Dict String String), authError : String, products : List (Dict String String), product : Maybe (Dict String String), productImages : List (Dict String String), search : String, categoryFilter : String, sortBy : String, sortDir : String, cart : Maybe (Dict String String), cartItems : List (Dict String String), cartRemarks : String, checkoutUrl : String, orders : List (Dict String String), order : Maybe (Dict String String), orderItems : List (Dict String String), editProductId : String, editTitle : String, editSummary : String, editCategory : String, editPrice : Int, editDiscount : Int, editCurrency : String, editStock : Int, editPublished : Bool, editImageData : String, adminOrders : List (Dict String String), adminOrderFilter : String, quantity : Int, notification : String, notificationType : String, signOutPending : Bool }
+    { page : Page
+    , lang : String
+    , user : Maybe (Dict String String)
+    , authError : String
+    , products : List (Dict String String)
+    , product : Maybe (Dict String String)
+    , productImages : List (Dict String String)
+    , search : String
+    , categoryFilter : String
+    , sortBy : String
+    , sortDir : String
+    , cart : Maybe (Dict String String)
+    , cartItems : List (Dict String String)
+    , cartRemarks : String
+    , checkoutUrl : String
+    , orders : List (Dict String String)
+    , order : Maybe (Dict String String)
+    , orderItems : List (Dict String String)
+    , editProductId : String
+    , editTitle : String
+    , editSummary : String
+    , editCategory : String
+    , editPrice : Int
+    , editDiscount : Int
+    , editCurrency : String
+    , editStock : Int
+    , editPublished : Bool
+    , editImageData : String
+    , adminOrders : List (Dict String String)
+    , adminOrderFilter : String
+    , quantity : Int
+    , notification : String
+    , notificationType : String
+    , signOutPending : Bool
+    }
 
 -- ══════════════════════════════════════════════════════
 -- PAGES

--- a/examples/13-skyshop/src/Ui/Layout.sky
+++ b/examples/13-skyshop/src/Ui/Layout.sky
@@ -1,4 +1,56 @@
-module Ui.Layout exposing (page, adminPage, btnPrimary, btnPrimaryLg, btnSecondary, btnCheckout, btnDangerOutline, btnState, card, cardHeader, cardBody, cardSection, cardFooter, formInput, formLabel_, qtyBtn, emptyIcon, emptyIconSm, adminThumb, adminThumbPlaceholder, notificationSuccess, notificationError, sidebarLink_, sidebarLinkActive, tableHeader_, adminRow, badge_, badgeLive, badgeDraft, badgeOrdered, badgeShipped, badgeDelivered, badgeCancelled, badgeRefunded, badgePending, infoCard_, infoCardLabel, cartItem, cartThumb, cartThumbPlaceholder, lineTotal, removeBtn, galleryMain, galleryThumb, galleryPlaceholder, imgPlaceholder, objectCover_, uploadZone, imgCardSquare, imgOverlayDelete, h2_)
+module Ui.Layout exposing
+    ( page
+    , adminPage
+    , btnPrimary
+    , btnPrimaryLg
+    , btnSecondary
+    , btnCheckout
+    , btnDangerOutline
+    , btnState
+    , card
+    , cardHeader
+    , cardBody
+    , cardSection
+    , cardFooter
+    , formInput
+    , formLabel_
+    , qtyBtn
+    , emptyIcon
+    , emptyIconSm
+    , adminThumb
+    , adminThumbPlaceholder
+    , notificationSuccess
+    , notificationError
+    , sidebarLink_
+    , sidebarLinkActive
+    , tableHeader_
+    , adminRow
+    , badge_
+    , badgeLive
+    , badgeDraft
+    , badgeOrdered
+    , badgeShipped
+    , badgeDelivered
+    , badgeCancelled
+    , badgeRefunded
+    , badgePending
+    , infoCard_
+    , infoCardLabel
+    , cartItem
+    , cartThumb
+    , cartThumbPlaceholder
+    , lineTotal
+    , removeBtn
+    , galleryMain
+    , galleryThumb
+    , galleryPlaceholder
+    , imgPlaceholder
+    , objectCover_
+    , uploadZone
+    , imgCardSquare
+    , imgOverlayDelete
+    , h2_
+    )
 
 import Sky.Core.Prelude exposing (..)
 import Sky.Core.Maybe exposing (..)
@@ -609,19 +661,19 @@ adminPage model content =
                 page
                     model
                     (div
-                         [tw [ textCenter, py20 ]]
-                         [Html.h2
-                             [tw [ text2xl, fontBold, textGray400 ]]
-                             [text "Access denied"]])
+                        [tw [ textCenter, py20 ]]
+                        [Html.h2
+                            [tw [ text2xl, fontBold, textGray400 ]]
+                            [text "Access denied"]])
 
         Nothing ->
             page
                 model
                 (div
-                     [tw [ textCenter, py20 ]]
-                     [Html.h2
-                         [tw [ text2xl, fontBold, textGray400 ]]
-                         [text "Please sign in"]])
+                    [tw [ textCenter, py20 ]]
+                    [Html.h2
+                        [tw [ text2xl, fontBold, textGray400 ]]
+                        [text "Please sign in"]])
 
 
 -- ══════════════════════════════════════════════════════
@@ -1078,93 +1130,88 @@ globalStyles =
     styleNode
         []
         (Css.stylesheet
-             [ Css.rule "*" [ "margin:0", "padding:0", "box-sizing:border-box" ]
-             , Css.rule
-                   "body"
-                   [ "font-family:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif"
-                   , "line-height:1.6"
-                   , "color:#1a202c"
-                   , "background:#f8fafc"
-                   ]
-             , Css.rule "a" [ "text-decoration:none", "color:inherit" ]
-             , Css.rule
-                   "img"
-                   [ "max-width:100%", "height:auto", "display:block" ]
-             , Css.rule
-                   "button"
-                   [ "cursor:pointer"
-                   , "border:none"
-                   , "background:none"
-                   , "font-family:inherit"
-                   ]
-             , Css.rule
-                   "input,textarea,select"
-                   [ "font-family:inherit"
-                   , "font-size:inherit"
-                   , "outline:none"
-                   ]
-             , Css.rule ".line-through" ["text-decoration:line-through"]
-             , Css.rule ".product-card" ["transition:all .2s ease"]
-             , Css.rule
-                   ".product-card:hover"
-                   [ "border-color:#cbd5e1"
-                   , "box-shadow:0 4px 12px rgba(0,0,0,.08)"
-                   , "transform:translateY(-2px)"
-                   ]
-             , Css.rule ".product-card:hover img" ["transform:scale(1.03)"]
-             , Css.rule ".product-card img" ["transition:transform .3s ease"]
-             , Css.rule
-                   ".toggle"
-                   [ "width:44px"
-                   , "height:24px"
-                   , "border-radius:12px"
-                   , "position:relative"
-                   , "transition:background .15s ease"
-                   ]
-             , Css.rule ".toggle-on" ["background:#2563eb"]
-             , Css.rule ".toggle-off" ["background:#d1d5db"]
-             , Css.rule
-                   ".toggle-knob"
-                   [ "width:20px"
-                   , "height:20px"
-                   , "background:#fff"
-                   , "border-radius:50%"
-                   , "position:absolute"
-                   , "top:2px"
-                   , "transition:all .15s ease"
-                   , "box-shadow:0 1px 3px rgba(0,0,0,.15)"
-                   ]
-             , Css.rule ".toggle-knob-on" ["right:2px"]
-             , Css.rule ".toggle-knob-off" ["left:2px"]
-             , Css.rule
-                   ".spinner"
-                   [ "width:48px"
-                   , "height:48px"
-                   , "border:3px solid #e2e8f0"
-                   , "border-top-color:#3b82f6"
-                   , "border-radius:50%"
-                   , "animation:spin 1s linear infinite"
-                   , "margin:0 auto 1.5rem"
-                   ]
-             , Css.rule
-                   ".qty-input"
-                   [ "width:3.5rem"
-                   , "text-align:center"
-                   , "font-weight:600"
-                   , "border:1px solid #d1d5db"
-                   , "border-left:none"
-                   , "border-right:none"
-                   , "height:32px"
-                   , "font-size:.875rem"
-                   ]
-             , Css.keyframes
-                   "slideDown"
-                   [ Css.frame
-                         "from"
-                         [ "opacity:0", "transform:translateY(-8px)" ]
-                   , Css.frame "to" [ "opacity:1", "transform:translateY(0)" ]
-                   ]
-             , Css.keyframes
-                   "spin"
-                   [Css.frame "to" ["transform:rotate(360deg)"]]
-             ])
+            [ Css.rule "*" [ "margin:0", "padding:0", "box-sizing:border-box" ]
+            , Css.rule
+                  "body"
+                  [ "font-family:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif"
+                  , "line-height:1.6"
+                  , "color:#1a202c"
+                  , "background:#f8fafc"
+                  ]
+            , Css.rule "a" [ "text-decoration:none", "color:inherit" ]
+            , Css.rule
+                  "img"
+                  [ "max-width:100%", "height:auto", "display:block" ]
+            , Css.rule
+                  "button"
+                  [ "cursor:pointer"
+                  , "border:none"
+                  , "background:none"
+                  , "font-family:inherit"
+                  ]
+            , Css.rule
+                  "input,textarea,select"
+                  [ "font-family:inherit", "font-size:inherit", "outline:none" ]
+            , Css.rule ".line-through" ["text-decoration:line-through"]
+            , Css.rule ".product-card" ["transition:all .2s ease"]
+            , Css.rule
+                  ".product-card:hover"
+                  [ "border-color:#cbd5e1"
+                  , "box-shadow:0 4px 12px rgba(0,0,0,.08)"
+                  , "transform:translateY(-2px)"
+                  ]
+            , Css.rule ".product-card:hover img" ["transform:scale(1.03)"]
+            , Css.rule ".product-card img" ["transition:transform .3s ease"]
+            , Css.rule
+                  ".toggle"
+                  [ "width:44px"
+                  , "height:24px"
+                  , "border-radius:12px"
+                  , "position:relative"
+                  , "transition:background .15s ease"
+                  ]
+            , Css.rule ".toggle-on" ["background:#2563eb"]
+            , Css.rule ".toggle-off" ["background:#d1d5db"]
+            , Css.rule
+                  ".toggle-knob"
+                  [ "width:20px"
+                  , "height:20px"
+                  , "background:#fff"
+                  , "border-radius:50%"
+                  , "position:absolute"
+                  , "top:2px"
+                  , "transition:all .15s ease"
+                  , "box-shadow:0 1px 3px rgba(0,0,0,.15)"
+                  ]
+            , Css.rule ".toggle-knob-on" ["right:2px"]
+            , Css.rule ".toggle-knob-off" ["left:2px"]
+            , Css.rule
+                  ".spinner"
+                  [ "width:48px"
+                  , "height:48px"
+                  , "border:3px solid #e2e8f0"
+                  , "border-top-color:#3b82f6"
+                  , "border-radius:50%"
+                  , "animation:spin 1s linear infinite"
+                  , "margin:0 auto 1.5rem"
+                  ]
+            , Css.rule
+                  ".qty-input"
+                  [ "width:3.5rem"
+                  , "text-align:center"
+                  , "font-weight:600"
+                  , "border:1px solid #d1d5db"
+                  , "border-left:none"
+                  , "border-right:none"
+                  , "height:32px"
+                  , "font-size:.875rem"
+                  ]
+            , Css.keyframes
+                  "slideDown"
+                  [ Css.frame
+                        "from"
+                        [ "opacity:0", "transform:translateY(-8px)" ]
+                  , Css.frame "to" [ "opacity:1", "transform:translateY(0)" ]
+                  ]
+            , Css.keyframes "spin" [Css.frame "to" ["transform:rotate(360deg)"]]
+            ])

--- a/examples/14-task-demo/src/Main.sky
+++ b/examples/14-task-demo/src/Main.sky
@@ -20,7 +20,7 @@ main =
         _ = printResult "Success" successResult
         failResult =
             Task.run
-                (Task.fail "intentional"
+                (Task.fail (Error.unexpected "intentional")
                     |> Task.andThen (\_ -> Task.succeed "unreachable"))
     in
         printResult "Fail" failResult
@@ -33,4 +33,4 @@ printResult label result =
             println (label ++ ": " ++ val)
 
         Err e ->
-            println (label ++ " error: " ++ errorToString e)
+            println (label ++ " error: " ++ Error.toString e)

--- a/examples/14-task-demo/src/Main.sky
+++ b/examples/14-task-demo/src/Main.sky
@@ -14,14 +14,14 @@ main =
                        (\name -> Task.succeed ("Hello, " ++ name ++ "!"))
                 |> Task.andThen
                        (\greeting ->
-                            Task.succeed
-                                (greeting ++ " Task is the effect boundary."))
+                           Task.succeed
+                               (greeting ++ " Task is the effect boundary."))
         successResult = Task.run pipeline
         _ = printResult "Success" successResult
         failResult =
             Task.run
                 (Task.fail "intentional"
-                     |> Task.andThen (\_ -> Task.succeed "unreachable"))
+                    |> Task.andThen (\_ -> Task.succeed "unreachable"))
     in
         printResult "Fail" failResult
 

--- a/examples/14-task-demo/src/Main.sky
+++ b/examples/14-task-demo/src/Main.sky
@@ -33,4 +33,4 @@ printResult label result =
             println (label ++ ": " ++ val)
 
         Err e ->
-            println (label ++ " error: " ++ e)
+            println (label ++ " error: " ++ errorToString e)

--- a/examples/15-http-server/src/Main.sky
+++ b/examples/15-http-server/src/Main.sky
@@ -24,7 +24,7 @@ handleHome : Request -> Task Error Response
 handleHome req =
     Task.succeed
         (Server.html
-             """<h1>Sky HTTP Server</h1>
+            """<h1>Sky HTTP Server</h1>
 <ul>
     <li><a href='/hello/world'>Hello World</a></li>
     <li><a href='/api/status'>API Status</a></li>
@@ -88,11 +88,11 @@ handleCookieDemo req =
     in
         Task.succeed
             (let
-                 countStr = String.fromInt visitCount
-             in
-                 Server.html
-                     """<h1>Visit #{{countStr}}</h1><p>Refresh to increment!</p>"""
-                     |> Server.withCookie visitCookie)
+                countStr = String.fromInt visitCount
+            in
+                Server.html
+                    """<h1>Visit #{{countStr}}</h1><p>Refresh to increment!</p>"""
+                    |> Server.withCookie visitCookie)
 
 
 handleRedirect : Request -> Task Error Response

--- a/examples/16-skychess/src/Chess/Eval.sky
+++ b/examples/16-skychess/src/Chess/Eval.sky
@@ -14,13 +14,13 @@ evaluate : Dict Int Piece -> Int
 evaluate board =
     List.foldl
         (\sq acc ->
-             case Dict.get sq board of
+            case Dict.get sq board of
 
-                 Just piece ->
-                     acc + evaluatePieceAt sq piece
+                Just piece ->
+                    acc + evaluatePieceAt sq piece
 
-                 Nothing ->
-                     acc)
+                Nothing ->
+                    acc)
         0
         Board.allSquares
 

--- a/examples/16-skychess/src/Chess/Move.sky
+++ b/examples/16-skychess/src/Chess/Move.sky
@@ -644,9 +644,9 @@ hasLegalMoves colour board model =
     in
         List.any
             (\pair ->
-                 not
-                     (List.isEmpty
-                          (legalMovesForSquare (fst pair) colour board model)))
+                not
+                    (List.isEmpty
+                        (legalMovesForSquare (fst pair) colour board model)))
             pieces
 
 
@@ -657,11 +657,11 @@ allLegalMoves colour board model =
     in
         List.concatMap
             (\pair ->
-                 let
-                     from = fst pair
-                     targets = legalMovesForSquare from colour board model
-                 in
-                     List.map (\to -> ( from, to )) targets)
+                let
+                    from = fst pair
+                    targets = legalMovesForSquare from colour board model
+                in
+                    List.map (\to -> ( from, to )) targets)
             pieces
 
 

--- a/examples/16-skychess/src/Lib/GameLogic.sky
+++ b/examples/16-skychess/src/Lib/GameLogic.sky
@@ -32,7 +32,7 @@ logIfErr tag r =
                 _ =
                     println
                         ("[CHESS][persist-fail] " ++ tag ++ ": "
-                             ++ Error.toString e)
+                            ++ Error.toString e)
             in
                 ()
 
@@ -120,17 +120,17 @@ executeBlackMove model =
         _ =
             println
                 ("[AI] Best: " ++ String.fromInt from ++ "->"
-                     ++ String.fromInt to)
+                    ++ String.fromInt to)
         _ =
             println
                 ("[AI] First 10: "
-                     ++ String.join
-                            " "
-                            (List.map
-                                 (\m ->
-                                      String.fromInt (fst m) ++ "->"
-                                          ++ String.fromInt (snd m))
-                                 (List.take 10 allMoves)))
+                    ++ String.join
+                           " "
+                           (List.map
+                               (\m ->
+                                   String.fromInt (fst m) ++ "->"
+                                       ++ String.fromInt (snd m))
+                               (List.take 10 allMoves)))
     in
         applyBlackOr from to model
 

--- a/examples/16-skychess/src/Lib/Games.sky
+++ b/examples/16-skychess/src/Lib/Games.sky
@@ -38,8 +38,7 @@ dbConn =
             let
                 _ =
                     println
-                        ("[FATAL] Cannot open skychess.db: "
-                             ++ Error.toString e)
+                        ("[FATAL] Cannot open skychess.db: " ++ Error.toString e)
             in
                 System.exit 1
 

--- a/examples/16-skychess/src/Main.sky
+++ b/examples/16-skychess/src/Main.sky
@@ -126,7 +126,7 @@ update msg model =
                                 _ =
                                     println
                                         ("[CHESS ERROR] loadGames: "
-                                             ++ Error.toString e)
+                                            ++ Error.toString e)
                             in
                                 Error.toString e
             in
@@ -192,7 +192,7 @@ handleLoadGame gameId model =
                         _ =
                             println
                                 ("[CHESS ERROR] getGameMoves: "
-                                     ++ Error.toString e)
+                                    ++ Error.toString e)
                     in
                         ()
         _ =
@@ -321,7 +321,7 @@ replayMovesLoop moves board history =
                                     _ =
                                         println
                                             ("[REPLAY ERROR] bad to_square: "
-                                                 ++ toStr)
+                                                ++ toStr)
                                 in
                                     replayMovesLoop rest board history
 
@@ -330,7 +330,7 @@ replayMovesLoop moves board history =
                             _ =
                                 println
                                     ("[REPLAY ERROR] bad from_square: "
-                                         ++ fromStr)
+                                        ++ fromStr)
                         in
                             replayMovesLoop rest board history
 
@@ -508,8 +508,7 @@ handleDeleteGame gameId model =
                     let
                         _ =
                             println
-                                ("[CHESS ERROR] deleteGame: "
-                                     ++ Error.toString e)
+                                ("[CHESS ERROR] deleteGame: " ++ Error.toString e)
                     in
                         ()
         gamesResult = Games.getGames model.playerName
@@ -528,7 +527,7 @@ handleDeleteGame gameId model =
                                 _ =
                                     println
                                         ("[CHESS ERROR] getGames: "
-                                             ++ Error.toString e)
+                                            ++ Error.toString e)
                             in
                                 Error.toString e
 

--- a/examples/16-skychess/src/Page/Game.sky
+++ b/examples/16-skychess/src/Page/Game.sky
@@ -19,21 +19,21 @@ viewGame model =
     Layout.page
         model
         (div
-             []
-             [ viewStatusBar model
-             , div
-                   [class "game-layout"]
-                   [ div
-                         [class "board-section"]
-                         [ viewBoard model, viewGameActions model ]
-                   , div
-                         [class "side-panel"]
-                         [ viewCaptured "White captures" model.capturedByWhite
-                         , viewMoveHistory model
-                         , viewCaptured "Black captures" model.capturedByBlack
-                         ]
-                   ]
-             ])
+            []
+            [ viewStatusBar model
+            , div
+                  [class "game-layout"]
+                  [ div
+                        [class "board-section"]
+                        [ viewBoard model, viewGameActions model ]
+                  , div
+                        [class "side-panel"]
+                        [ viewCaptured "White captures" model.capturedByWhite
+                        , viewMoveHistory model
+                        , viewCaptured "Black captures" model.capturedByBlack
+                        ]
+                  ]
+            ])
 
 
 viewStatusBar model =
@@ -86,8 +86,8 @@ viewRank rank model =
     tr
         []
         (List.map
-             (\file -> viewSquare (rank * 8 + file) model)
-             [ 0, 1, 2, 3, 4, 5, 6, 7 ])
+            (\file -> viewSquare (rank * 8 + file) model)
+            [ 0, 1, 2, 3, 4, 5, 6, 7 ])
 
 
 viewSquare : Int -> Model -> VNode

--- a/examples/16-skychess/src/Page/Home.sky
+++ b/examples/16-skychess/src/Page/Home.sky
@@ -17,16 +17,16 @@ viewHome model =
     Layout.page
         model
         (div
-             [class "home-container"]
-             [ h1 [class "home-title"] [text "♞ SkyChess"]
-             , p
-                   [class "home-subtitle"]
-                   [text "Play chess against the computer. White moves first."]
-             , viewNotification model
-             , viewNameForm model
-             , viewStats model
-             , viewGameList model
-             ])
+            [class "home-container"]
+            [ h1 [class "home-title"] [text "♞ SkyChess"]
+            , p
+                  [class "home-subtitle"]
+                  [text "Play chess against the computer. White moves first."]
+            , viewNotification model
+            , viewNameForm model
+            , viewStats model
+            , viewGameList model
+            ])
 
 
 viewNotification model =

--- a/examples/16-skychess/src/State.sky
+++ b/examples/16-skychess/src/State.sky
@@ -4,7 +4,34 @@ import Sky.Core.Maybe exposing (..)
 import Chess.Piece exposing (..)
 
 type alias Model =
-    { page : Page, playerName : String, nameInput : String, gameId : String, board : Dict Int Piece, turn : Colour, selectedSquare : Int, legalMoves : List Int, moveHistory : List String, gameStatus : String, computerThinking : Bool, lastMoveFrom : Int, lastMoveTo : Int, capturedByWhite : List String, capturedByBlack : List String, whiteKingMoved : Bool, blackKingMoved : Bool, whiteRookAMoved : Bool, whiteRookHMoved : Bool, blackRookAMoved : Bool, blackRookHMoved : Bool, enPassantSquare : Int, halfMoveClock : Int, fullMoveNumber : Int, savedGames : List (Dict String String), notification : String, errorMessage : String }
+    { page : Page
+    , playerName : String
+    , nameInput : String
+    , gameId : String
+    , board : Dict Int Piece
+    , turn : Colour
+    , selectedSquare : Int
+    , legalMoves : List Int
+    , moveHistory : List String
+    , gameStatus : String
+    , computerThinking : Bool
+    , lastMoveFrom : Int
+    , lastMoveTo : Int
+    , capturedByWhite : List String
+    , capturedByBlack : List String
+    , whiteKingMoved : Bool
+    , blackKingMoved : Bool
+    , whiteRookAMoved : Bool
+    , whiteRookHMoved : Bool
+    , blackRookAMoved : Bool
+    , blackRookHMoved : Bool
+    , enPassantSquare : Int
+    , halfMoveClock : Int
+    , fullMoveNumber : Int
+    , savedGames : List (Dict String String)
+    , notification : String
+    , errorMessage : String
+    }
 
 type Page
     = HomePage

--- a/examples/16-skychess/tests/ChessPrimitivesTest.sky
+++ b/examples/16-skychess/tests/ChessPrimitivesTest.sky
@@ -22,21 +22,21 @@ testSetAndGetPiece =
     Test.test
         "setPiece + getPiece round-trip"
         (\_ ->
-             let
-                 piece = { kind = Queen, colour = White }
-                 board = Board.setPiece 27 piece Dict.empty
-             in
-                 case Board.getPiece 27 board of
+            let
+                piece = { kind = Queen, colour = White }
+                board = Board.setPiece 27 piece Dict.empty
+            in
+                case Board.getPiece 27 board of
 
-                     Just p ->
-                         if p.kind == Queen && p.colour == White then
-                             Test.pass
+                    Just p ->
+                        if p.kind == Queen && p.colour == White then
+                            Test.pass
 
-                         else
-                             Test.fail "piece readback has wrong fields"
+                        else
+                            Test.fail "piece readback has wrong fields"
 
-                     Nothing ->
-                         Test.fail "piece disappeared after setPiece")
+                    Nothing ->
+                        Test.fail "piece disappeared after setPiece")
 
 
 -- movePiece: White queen d1 (sq 59) → d4 (sq 35).
@@ -46,33 +46,33 @@ testMovePieceBasic =
     Test.test
         "movePiece relocates the piece"
         (\_ ->
-             let
-                 board =
-                     Board.setPiece
-                         59
-                         { kind = Queen, colour = White }
-                         Dict.empty
-                 after = Board.movePiece 59 35 board
-                 atFrom = Board.getPiece 59 after
-                 atTo = Board.getPiece 35 after
-             in
-                 case atFrom of
+            let
+                board =
+                    Board.setPiece
+                        59
+                        { kind = Queen, colour = White }
+                        Dict.empty
+                after = Board.movePiece 59 35 board
+                atFrom = Board.getPiece 59 after
+                atTo = Board.getPiece 35 after
+            in
+                case atFrom of
 
-                     Just _ ->
-                         Test.fail "source square not cleared after move"
+                    Just _ ->
+                        Test.fail "source square not cleared after move"
 
-                     Nothing ->
-                         case atTo of
+                    Nothing ->
+                        case atTo of
 
-                             Nothing ->
-                                 Test.fail "target square empty after move"
+                            Nothing ->
+                                Test.fail "target square empty after move"
 
-                             Just p ->
-                                 if p.kind == Queen && p.colour == White then
-                                     Test.pass
+                            Just p ->
+                                if p.kind == Queen && p.colour == White then
+                                    Test.pass
 
-                                 else
-                                     Test.fail "moved piece has wrong fields")
+                                else
+                                    Test.fail "moved piece has wrong fields")
 
 
 -- materialValue returns Queen > Rook > Bishop > Knight > Pawn > King.
@@ -83,30 +83,30 @@ testMaterialValues =
     Test.test
         "materialValue returns the expected ranking"
         (\_ ->
-             let
-                 q = materialValue Queen
-                 r = materialValue Rook
-                 b = materialValue Bishop
-                 n = materialValue Knight
-                 p = materialValue Pawn
-                 k = materialValue King
-             in
-                 if q == 900 && r == 500 && b == 330 && n == 320 && p == 100 && k
-                     == 0 then
-                     Test.pass
+            let
+                q = materialValue Queen
+                r = materialValue Rook
+                b = materialValue Bishop
+                n = materialValue Knight
+                p = materialValue Pawn
+                k = materialValue King
+            in
+                if q == 900 && r == 500 && b == 330 && n == 320 && p == 100 && k
+                    == 0 then
+                    Test.pass
 
-                 else
-                     Test.fail
-                         ("unexpected values Q=" ++ String.fromInt q ++ " R="
-                              ++ String.fromInt r
-                              ++ " B="
-                              ++ String.fromInt b
-                              ++ " N="
-                              ++ String.fromInt n
-                              ++ " P="
-                              ++ String.fromInt p
-                              ++ " K="
-                              ++ String.fromInt k))
+                else
+                    Test.fail
+                        ("unexpected values Q=" ++ String.fromInt q ++ " R="
+                            ++ String.fromInt r
+                            ++ " B="
+                            ++ String.fromInt b
+                            ++ " N="
+                            ++ String.fromInt n
+                            ++ " P="
+                            ++ String.fromInt p
+                            ++ " K="
+                            ++ String.fromInt k))
 
 
 -- Eval.evaluate: board with a lone Black knight < 0 (Black has
@@ -118,21 +118,21 @@ testEvalBlackKnightMaterial =
     Test.test
         "eval is negative for lone Black knight"
         (\_ ->
-             let
-                 board =
-                     Board.setPiece
-                         27
-                         { kind = Knight, colour = Black }
-                         Dict.empty
-                 score = Eval.evaluate board
-             in
-                 if score < 0 then
-                     Test.pass
+            let
+                board =
+                    Board.setPiece
+                        27
+                        { kind = Knight, colour = Black }
+                        Dict.empty
+                score = Eval.evaluate board
+            in
+                if score < 0 then
+                    Test.pass
 
-                 else
-                     Test.fail
-                         ("expected negative for Black knight alone, got "
-                              ++ String.fromInt score))
+                else
+                    Test.fail
+                        ("expected negative for Black knight alone, got "
+                            ++ String.fromInt score))
 
 
 -- Symmetric check: White knight alone → positive.
@@ -141,20 +141,20 @@ testEvalWhiteKnightMaterial =
     Test.test
         "eval is positive for lone White knight"
         (\_ ->
-             let
-                 board =
-                     Board.setPiece
-                         27
-                         { kind = Knight, colour = White }
-                         Dict.empty
-                 score = Eval.evaluate board
-             in
-                 if score > 0 then
-                     Test.pass
+            let
+                board =
+                    Board.setPiece
+                        27
+                        { kind = Knight, colour = White }
+                        Dict.empty
+                score = Eval.evaluate board
+            in
+                if score > 0 then
+                    Test.pass
 
-                 else
-                     Test.fail
-                         ("expected positive, got " ++ String.fromInt score))
+                else
+                    Test.fail
+                        ("expected positive, got " ++ String.fromInt score))
 
 
 tests : List Test

--- a/examples/17-skymon/src/Lib/Alerts.sky
+++ b/examples/17-skymon/src/Lib/Alerts.sky
@@ -21,8 +21,7 @@ createAlert metricId condition threshold notifyType notifyTarget =
             String.slice
                 0
                 12
-                (Crypto.sha256
-                     (metricId ++ ":" ++ condition ++ ":" ++ threshold))
+                (Crypto.sha256 (metricId ++ ":" ++ condition ++ ":" ++ threshold))
         _ =
             Database.execOrLog
                 "Alerts.createAlert"
@@ -203,7 +202,7 @@ logFireResult kind target result =
                 _ =
                     println
                         ("[ALERT ERROR] " ++ kind ++ " " ++ target ++ ": "
-                             ++ Error.toString e)
+                            ++ Error.toString e)
             in
                 ()
 

--- a/examples/17-skymon/src/Lib/Auth.sky
+++ b/examples/17-skymon/src/Lib/Auth.sky
@@ -72,7 +72,7 @@ getGitHubUser token =
             in
                 Ok
                     (Dict.fromList
-                         [ ( "username", login ), ( "avatar_url", avatar ) ])
+                        [ ( "username", login ), ( "avatar_url", avatar ) ])
 
         Err e ->
             Err e
@@ -120,8 +120,7 @@ getSession sessionId =
                 [] ->
                     Err
                         (Error.permissionDenied
-                             |> Error.withMessage
-                                    "Session not found or expired.")
+                            |> Error.withMessage "Session not found or expired.")
 
 
 deleteSession : String -> ()

--- a/examples/17-skymon/src/Lib/Metrics.sky
+++ b/examples/17-skymon/src/Lib/Metrics.sky
@@ -97,8 +97,8 @@ runSqlMetric metric =
 
 runSafeQuery : String -> String -> String
 runSafeQuery dsn query =
-    -- v0.9.6+: Db.open returns Task Error Db (was Result). Collapse
-    -- with Task.run at this sync call site.
+-- v0.9.6+: Db.open returns Task Error Db (was Result). Collapse
+-- with Task.run at this sync call site.
     case Task.run (Db.open "postgres" dsn) of
 
         Err e ->
@@ -107,7 +107,7 @@ runSafeQuery dsn query =
                 _ =
                     println
                         ("[METRIC ERROR] runSafeQuery/open: "
-                             ++ Error.toString typedErr)
+                            ++ Error.toString typedErr)
             in
                 "error: " ++ Error.toString typedErr
 
@@ -116,10 +116,10 @@ runSafeQuery dsn query =
 
 
 runSafeQueryWithConn extConn query =
-    -- SafeQuery.runReadOnly returns `Result Error (List (Dict ...))`
-    -- directly — no Task wrap. Pre-fix this had `Task.run (...)` which
-    -- only worked while pass-2 dep HM masked Type errors via the
-    -- pass-1 fallback (round 6 fix made pass 2 authoritative).
+-- SafeQuery.runReadOnly returns `Result Error (List (Dict ...))`
+-- directly — no Task wrap. Pre-fix this had `Task.run (...)` which
+-- only worked while pass-2 dep HM masked Type errors via the
+-- pass-1 fallback (round 6 fix made pass 2 authoritative).
     case SafeQuery.runReadOnly extConn query [] of
 
         Err e ->
@@ -128,7 +128,7 @@ runSafeQueryWithConn extConn query =
                 _ =
                     println
                         ("[METRIC ERROR] runSafeQuery: "
-                             ++ Error.toString typedErr)
+                            ++ Error.toString typedErr)
             in
                 "error: " ++ Error.toString typedErr
 
@@ -177,7 +177,7 @@ runHttpMetric metric =
                         _ =
                             println
                                 ("[METRIC ERROR] runHttpMetric " ++ url ++ ": "
-                                     ++ Error.toString typedErr)
+                                    ++ Error.toString typedErr)
                     in
                         "error: " ++ Error.toString typedErr
 
@@ -208,7 +208,7 @@ runApiMetric metric =
                         _ =
                             println
                                 ("[METRIC ERROR] runApiMetric " ++ url ++ ": "
-                                     ++ Error.toString typedErr)
+                                    ++ Error.toString typedErr)
                     in
                         "error: " ++ Error.toString typedErr
 

--- a/examples/17-skymon/src/Lib/Monitors.sky
+++ b/examples/17-skymon/src/Lib/Monitors.sky
@@ -72,7 +72,7 @@ checkEndpoint url =
                 _ =
                     println
                         ("[MONITOR ERROR] checkEndpoint " ++ url ++ ": "
-                             ++ Error.toString typedErr)
+                            ++ Error.toString typedErr)
             in
                 ( "down", 0 )
 

--- a/examples/17-skymon/src/Page/Alerts.sky
+++ b/examples/17-skymon/src/Page/Alerts.sky
@@ -19,12 +19,12 @@ viewAlerts model =
     Layout.page
         model
         (div
-             []
-             [ h2 [class "section-title"] [text "Alert Rules"]
-             , viewAddAlertForm model
-             , viewAlertList model
-             , viewAlertHistory
-             ])
+            []
+            [ h2 [class "section-title"] [text "Alert Rules"]
+            , viewAddAlertForm model
+            , viewAlertList model
+            , viewAlertHistory
+            ])
 
 
 viewAddAlertForm : Model -> VNode
@@ -43,8 +43,8 @@ viewAddAlertForm model =
                     , placeholder "Metric name or ID"
                     , value
                           (Maybe.withDefault
-                               ""
-                               (Dict.get "alert_metric" model.configInput))
+                              ""
+                              (Dict.get "alert_metric" model.configInput))
                     , onInput InputAlertMetric
                     ]
               ]
@@ -59,10 +59,8 @@ viewAddAlertForm model =
                           , placeholder "> < >= <= == != contains down"
                           , value
                                 (Maybe.withDefault
-                                     ""
-                                     (Dict.get
-                                          "alert_condition"
-                                          model.configInput))
+                                    ""
+                                    (Dict.get "alert_condition" model.configInput))
                           , onInput InputAlertCondition
                           ]
                     ]
@@ -75,10 +73,8 @@ viewAddAlertForm model =
                           , placeholder "100"
                           , value
                                 (Maybe.withDefault
-                                     ""
-                                     (Dict.get
-                                          "alert_threshold"
-                                          model.configInput))
+                                    ""
+                                    (Dict.get "alert_threshold" model.configInput))
                           , onInput InputAlertThreshold
                           ]
                     ]
@@ -94,10 +90,10 @@ viewAddAlertForm model =
                           , placeholder "webhook, slack, or log"
                           , value
                                 (Maybe.withDefault
-                                     "log"
-                                     (Dict.get
-                                          "alert_notify_type"
-                                          model.configInput))
+                                    "log"
+                                    (Dict.get
+                                        "alert_notify_type"
+                                        model.configInput))
                           , onInput InputAlertNotifyType
                           ]
                     ]
@@ -110,10 +106,10 @@ viewAddAlertForm model =
                           , placeholder "https://hooks.slack.com/services/..."
                           , value
                                 (Maybe.withDefault
-                                     ""
-                                     (Dict.get
-                                          "alert_notify_target"
-                                          model.configInput))
+                                    ""
+                                    (Dict.get
+                                        "alert_notify_target"
+                                        model.configInput))
                           , onInput InputAlertTarget
                           ]
                     ]
@@ -174,8 +170,7 @@ viewAlertRow model alert =
             , td
                   [style "color: #64748b"]
                   [text
-                      (alert.notifyType ++ ": "
-                           ++ truncate 30 alert.notifyTarget)]
+                      (alert.notifyType ++ ": " ++ truncate 30 alert.notifyTarget)]
             , td
                   []
                   [if alert.enabled then
@@ -278,7 +273,7 @@ viewAlertHistoryRow row =
               [style "color: #a78bfa; font-family: monospace"]
               [text
                   (Database.getField "condition" row ++ " "
-                       ++ Database.getField "threshold" row)]
+                      ++ Database.getField "threshold" row)]
         , td
               [style "color: #64748b"]
               [text (Database.getField "notify_type" row)]

--- a/examples/17-skymon/src/Page/AuthPage.sky
+++ b/examples/17-skymon/src/Page/AuthPage.sky
@@ -15,15 +15,15 @@ viewAuth model =
     Layout.page
         model
         (div
-             [style "max-width: 400px; margin: 48px auto"]
-             [div
-                 [class "card"]
-                 [ h2
-                       [style
-                           "font-size: 20px; color: #f1f5f9; margin-bottom: 24px; text-align: center"]
-                       [text "Sign In to SkyMon"]
-                 , viewAuthBody model
-                 ]])
+            [style "max-width: 400px; margin: 48px auto"]
+            [div
+                [class "card"]
+                [ h2
+                      [style
+                          "font-size: 20px; color: #f1f5f9; margin-bottom: 24px; text-align: center"]
+                      [text "Sign In to SkyMon"]
+                , viewAuthBody model
+                ]])
 
 
 viewAuthBody : Model -> VNode
@@ -76,8 +76,8 @@ viewLoginForm model =
                     , placeholder "Enter username"
                     , value
                           (Maybe.withDefault
-                               ""
-                               (Dict.get "auth_username" model.configInput))
+                              ""
+                              (Dict.get "auth_username" model.configInput))
                     , onInput InputAuthUsername
                     ]
               ]
@@ -90,11 +90,11 @@ viewLoginForm model =
                     , placeholder "Enter password"
                     , value
                           (Maybe.withDefault
-                               ""
-                               (Dict.get "auth_password" model.configInput))
-                    -- onChange (fires on blur) instead of onInput so
-                    -- password-manager browser extensions don't kick in
-                    -- on every keystroke's SSE patch.
+                              ""
+                              (Dict.get "auth_password" model.configInput))
+                              -- onChange (fires on blur) instead of onInput so
+                              -- password-manager browser extensions don't kick in
+                              -- on every keystroke's SSE patch.
                     , onChange InputAuthPassword
                     ]
               ]

--- a/examples/17-skymon/src/Page/Dashboard.sky
+++ b/examples/17-skymon/src/Page/Dashboard.sky
@@ -17,11 +17,11 @@ viewDashboard model =
     Layout.page
         model
         (div
-             []
-             [ viewOverview model
-             , viewMonitorsSection model
-             , viewMetricsSection model
-             ])
+            []
+            [ viewOverview model
+            , viewMonitorsSection model
+            , viewMetricsSection model
+            ])
 
 
 viewOverview : Model -> VNode

--- a/examples/17-skymon/src/Page/MetricDetail.sky
+++ b/examples/17-skymon/src/Page/MetricDetail.sky
@@ -23,11 +23,11 @@ viewMetricDetail metId model =
             model
             (case metric of
 
-                 Just met ->
-                     viewMetricContent met
+                Just met ->
+                    viewMetricContent met
 
-                 Nothing ->
-                     viewNotFound)
+                Nothing ->
+                    viewNotFound)
 
 
 viewMetricContent : Metric -> VNode
@@ -231,7 +231,7 @@ viewAlertRow row =
               [style "color: #a78bfa; font-family: monospace"]
               [text
                   (Database.getField "condition" row ++ " "
-                       ++ Database.getField "threshold" row)]
+                      ++ Database.getField "threshold" row)]
         , td
               [style "color: #64748b"]
               [text (Database.getField "notify_type" row)]

--- a/examples/17-skymon/src/Page/MonitorDetail.sky
+++ b/examples/17-skymon/src/Page/MonitorDetail.sky
@@ -23,11 +23,11 @@ viewMonitorDetail monId model =
             model
             (case monitor of
 
-                 Just mon ->
-                     viewMonitorContent mon
+                Just mon ->
+                    viewMonitorContent mon
 
-                 Nothing ->
-                     viewNotFound)
+                Nothing ->
+                    viewNotFound)
 
 
 viewMonitorContent : Monitor -> VNode
@@ -79,7 +79,7 @@ viewStatusBadge status =
         span
             [style
                 ("padding: 6px 16px; border-radius: 20px; font-weight: 600; font-size: 13px; background: "
-                     ++ color)]
+                    ++ color)]
             [text label]
 
 
@@ -211,8 +211,7 @@ viewHistoryRow row =
               []
               [ span
                     [ class
-                          ("status-dot status-"
-                               ++ Database.getField "status" row)
+                          ("status-dot status-" ++ Database.getField "status" row)
                     , style "margin-right: 6px"
                     ]
                     []

--- a/examples/17-skymon/src/Page/Settings.sky
+++ b/examples/17-skymon/src/Page/Settings.sky
@@ -18,13 +18,13 @@ viewSettings model =
     Layout.page
         model
         (div
-             []
-             [ h2 [class "section-title"] [text "Settings"]
-             , viewAddMonitorForm model
-             , viewMonitorList model
-             , viewAddMetricForm model
-             , viewMetricList model
-             ])
+            []
+            [ h2 [class "section-title"] [text "Settings"]
+            , viewAddMonitorForm model
+            , viewMonitorList model
+            , viewAddMetricForm model
+            , viewMetricList model
+            ])
 
 
 viewAddMonitorForm : Model -> VNode
@@ -43,8 +43,8 @@ viewAddMonitorForm model =
                     , placeholder "My API"
                     , value
                           (Maybe.withDefault
-                               ""
-                               (Dict.get "monitor_name" model.configInput))
+                              ""
+                              (Dict.get "monitor_name" model.configInput))
                     , onInput InputMonitorName
                     ]
               ]
@@ -57,8 +57,8 @@ viewAddMonitorForm model =
                     , placeholder "https://api.example.com/health"
                     , value
                           (Maybe.withDefault
-                               ""
-                               (Dict.get "monitor_url" model.configInput))
+                              ""
+                              (Dict.get "monitor_url" model.configInput))
                     , onInput InputMonitorUrl
                     ]
               ]
@@ -71,8 +71,8 @@ viewAddMonitorForm model =
                     , placeholder "public, user, or admin"
                     , value
                           (Maybe.withDefault
-                               "user"
-                               (Dict.get "monitor_visibility" model.configInput))
+                              "user"
+                              (Dict.get "monitor_visibility" model.configInput))
                     , onInput InputMonitorVis
                     ]
               ]
@@ -153,8 +153,8 @@ viewAddMetricForm model =
                     , placeholder "Orders/Hour"
                     , value
                           (Maybe.withDefault
-                               ""
-                               (Dict.get "metric_name" model.configInput))
+                              ""
+                              (Dict.get "metric_name" model.configInput))
                     , onInput InputMetricName
                     ]
               ]
@@ -167,8 +167,8 @@ viewAddMetricForm model =
                     , placeholder "http"
                     , value
                           (Maybe.withDefault
-                               ""
-                               (Dict.get "metric_type" model.configInput))
+                              ""
+                              (Dict.get "metric_type" model.configInput))
                     , onInput InputMetricType
                     ]
               ]
@@ -182,8 +182,8 @@ viewAddMetricForm model =
                           "https://api.example.com/stats or postgres://..."
                     , value
                           (Maybe.withDefault
-                               ""
-                               (Dict.get "metric_url" model.configInput))
+                              ""
+                              (Dict.get "metric_url" model.configInput))
                     , onInput InputMetricUrl
                     ]
               ]
@@ -199,8 +199,8 @@ viewAddMetricForm model =
                     ]
                     [text
                         (Maybe.withDefault
-                             ""
-                             (Dict.get "metric_query" model.configInput))]
+                            ""
+                            (Dict.get "metric_query" model.configInput))]
               ]
         , div
               [class "form-group"]
@@ -211,8 +211,8 @@ viewAddMetricForm model =
                     , placeholder "public, user, or admin"
                     , value
                           (Maybe.withDefault
-                               "user"
-                               (Dict.get "metric_visibility" model.configInput))
+                              "user"
+                              (Dict.get "metric_visibility" model.configInput))
                     , onInput InputMetricVis
                     ]
               ]
@@ -227,8 +227,8 @@ viewAddMetricForm model =
                     , placeholder "data.count or result.0.value"
                     , value
                           (Maybe.withDefault
-                               ""
-                               (Dict.get "metric_field" model.configInput))
+                              ""
+                              (Dict.get "metric_field" model.configInput))
                     , onInput InputMetricField
                     ]
               ]

--- a/examples/17-skymon/src/Page/Status.sky
+++ b/examples/17-skymon/src/Page/Status.sky
@@ -70,7 +70,7 @@ viewStatusRow monitor =
                     [style "font-size: 12px; color: #64748b"]
                     [text
                         (String.fromInt monitor.responseTime ++ "ms • "
-                             ++ monitor.lastChecked)]
+                            ++ monitor.lastChecked)]
               ]
         , span
               [class ("status-dot status-" ++ statusToString monitor.status)]

--- a/examples/17-skymon/src/Ui/Charts.sky
+++ b/examples/17-skymon/src/Ui/Charts.sky
@@ -18,11 +18,11 @@ sparkline width height values =
             maxVal =
                 List.foldl
                     (\v acc ->
-                         if v > acc then
-                             v
+                        if v > acc then
+                            v
 
-                         else
-                             acc)
+                        else
+                            acc)
                     1
                     values
             points = buildSparklinePoints width height maxVal values 0
@@ -34,7 +34,7 @@ sparkline width height values =
                 , attribute
                       "viewBox"
                       ("0 0 " ++ String.fromInt width ++ " "
-                           ++ String.fromInt height)
+                          ++ String.fromInt height)
                 , class "sparkline"
                 ]
                 [node

--- a/examples/19-skyforum/src/Main.sky
+++ b/examples/19-skyforum/src/Main.sky
@@ -9,7 +9,6 @@ module Main exposing (main)
 -- and locked the Mac that birthed scripts/mem-guard.sh — the split
 -- form gives us the full feature surface at zero ergonomics cost
 -- pending compiler fix.
-
 import Sky.Core.Prelude exposing (..)
 import Std.Cmd as Cmd
 import Std.Sub as Sub
@@ -18,7 +17,6 @@ import Std.Ui as Ui
 import Std.Ui exposing (Element)
 import Std.Ui.Background as Background
 import Std.Ui.Font as Font
-
 import State exposing (..)
 import Update exposing (update)
 import View.Common exposing (topNav, pageFooter)
@@ -28,26 +26,129 @@ import View.Login exposing (loginView)
 
 
 -- ─── Init ────────────────────────────────────────────────────────
-
 init : a -> ( Model, Cmd Msg )
 init _req =
     let
         seedPosts =
-            [ Post 1 "Show SF: Sky.Ui — a typed no-CSS layout DSL for Sky.Live" "https://github.com/anzellai/sky" "alice" 142 5 [] []
-            , Post 2 "Tiny CRDT primitives in 200 lines" "https://example.com/crdt" "bob" 87 1 [] []
-            , Post 3 "Ask SF: Best resources for learning Hindley-Milner?" "https://example.com/hm" "carol" 56 2 [] []
-            , Post 4 "Why server-driven UIs are having a moment" "https://example.com/server-ui" "dave" 41 0 [] []
-            , Post 5 "Postgres tips that actually matter in production" "https://example.com/pg-tips" "eve" 38 0 [] []
+            [ Post
+                  1
+                  "Show SF: Sky.Ui — a typed no-CSS layout DSL for Sky.Live"
+                  "https://github.com/anzellai/sky"
+                  "alice"
+                  142
+                  5
+                  []
+                  []
+            , Post
+                  2
+                  "Tiny CRDT primitives in 200 lines"
+                  "https://example.com/crdt"
+                  "bob"
+                  87
+                  1
+                  []
+                  []
+            , Post
+                  3
+                  "Ask SF: Best resources for learning Hindley-Milner?"
+                  "https://example.com/hm"
+                  "carol"
+                  56
+                  2
+                  []
+                  []
+            , Post
+                  4
+                  "Why server-driven UIs are having a moment"
+                  "https://example.com/server-ui"
+                  "dave"
+                  41
+                  0
+                  []
+                  []
+            , Post
+                  5
+                  "Postgres tips that actually matter in production"
+                  "https://example.com/pg-tips"
+                  "eve"
+                  38
+                  0
+                  []
+                  []
             ]
         seedComments =
-            [ Comment 101 1 0 "bob" "This looks great — does it support keyed children for diffing?" 12 [] []
-            , Comment 102 1 101 "alice" "Yes, Std.Ui.Keyed handles that via the sky-key attribute." 9 [] []
-            , Comment 103 1 102 "bob" "Nice. Any plans for an actual stylesheet pass?" 4 [] []
-            , Comment 104 1 0 "carol" "How does it compare to other server-driven UI frameworks?" 7 [] []
-            , Comment 105 1 104 "alice" "Same idea: server holds state, browser is dumb." 11 [] []
-            , Comment 201 2 0 "alice" "Love seeing CRDT explanations that fit on one page." 5 [] []
-            , Comment 301 3 0 "dave" "Read 'Types and Programming Languages' (TAPL). Canonical reference." 18 [] []
-            , Comment 302 3 301 "carol" "Thanks. Anything shorter for a primer?" 3 [] []
+            [ Comment
+                  101
+                  1
+                  0
+                  "bob"
+                  "This looks great — does it support keyed children for diffing?"
+                  12
+                  []
+                  []
+            , Comment
+                  102
+                  1
+                  101
+                  "alice"
+                  "Yes, Std.Ui.Keyed handles that via the sky-key attribute."
+                  9
+                  []
+                  []
+            , Comment
+                  103
+                  1
+                  102
+                  "bob"
+                  "Nice. Any plans for an actual stylesheet pass?"
+                  4
+                  []
+                  []
+            , Comment
+                  104
+                  1
+                  0
+                  "carol"
+                  "How does it compare to other server-driven UI frameworks?"
+                  7
+                  []
+                  []
+            , Comment
+                  105
+                  1
+                  104
+                  "alice"
+                  "Same idea: server holds state, browser is dumb."
+                  11
+                  []
+                  []
+            , Comment
+                  201
+                  2
+                  0
+                  "alice"
+                  "Love seeing CRDT explanations that fit on one page."
+                  5
+                  []
+                  []
+            , Comment
+                  301
+                  3
+                  0
+                  "dave"
+                  "Read 'Types and Programming Languages' (TAPL). Canonical reference."
+                  18
+                  []
+                  []
+            , Comment
+                  302
+                  3
+                  301
+                  "carol"
+                  "Thanks. Anything shorter for a primer?"
+                  3
+                  []
+                  []
             ]
     in
         ( { posts = seedPosts
@@ -64,10 +165,10 @@ init _req =
 
 
 -- ─── View dispatcher ─────────────────────────────────────────────
-
 view : Model -> any
 view model =
-    Ui.layout []
+    Ui.layout
+        []
         (Ui.column
             [ Ui.padding 24
             , Ui.spacing 24
@@ -76,15 +177,13 @@ view model =
             , Font.size 14
             , Font.color (Ui.rgb 33 33 33)
             ]
-            [ topNav model
-            , pageBody model
-            , pageFooter
-            ])
+            [ topNav model, pageBody model, pageFooter ])
 
 
 pageBody : Model -> Element Msg
 pageBody model =
     case model.currentPage of
+
         HomePage ->
             postsListView model.session model.posts
 
@@ -96,9 +195,9 @@ pageBody model =
 
 
 -- ─── App wiring ──────────────────────────────────────────────────
-
 subscriptions : Model -> Sub.Sub Msg
-subscriptions _ = Sub.none
+subscriptions _ =
+    Sub.none
 
 
 main =

--- a/examples/19-skyforum/src/State.sky
+++ b/examples/19-skyforum/src/State.sky
@@ -4,12 +4,10 @@ module State exposing (..)
 -- type-checker stays well below the heap-exhaustion limit (CLAUDE.md
 -- Limitation #17): the heavy unification load is in the per-View
 -- modules.
-
 import Sky.Core.Prelude exposing (..)
 import Sky.Core.List as List
 import Sky.Core.Maybe as Maybe
 import Sky.Core.String as String
-
 
 -- ─── State types ─────────────────────────────────────────────────
 
@@ -23,28 +21,25 @@ type alias Post =
     , title : String
     , url : String
     , author : String
-    , votes : Int
+    , votes : Int-- base score (see Post.votes for shape)
     , commentCount : Int
-    , upvoters : List String       -- usernames who upvoted (1 vote per user)
-    , downvoters : List String     -- usernames who downvoted (1 vote per user)
+    , upvoters : List String-- usernames who upvoted (1 vote per user)
+    , downvoters : List String-- usernames who downvoted (1 vote per user)
     }
-
 
 type alias Comment =
     { id : Int
     , postId : Int
-    , parentId : Int               -- 0 = top-level (root) comment under the post
+    , parentId : Int-- 0 = top-level (root) comment under the post
     , author : String
     , body : String
-    , votes : Int                  -- base score (see Post.votes for shape)
-    , upvoters : List String
-    , downvoters : List String
+    , votes : Int-- base score (see Post.votes for shape)
+    , upvoters : List String-- usernames who upvoted (1 vote per user)
+    , downvoters : List String-- usernames who downvoted (1 vote per user)
     }
-
 
 type alias Session =
     { username : String }
-
 
 -- Form data for sign-in. Decoded from the wire `<form>` submit
 -- payload directly into this typed record (Sky.Live's case-
@@ -57,12 +52,10 @@ type alias LoginForm =
     , password : String
     }
 
-
 type Page
     = HomePage
     | PostPage Int
     | LoginPage
-
 
 type alias Model =
     { posts : List Post
@@ -71,10 +64,9 @@ type alias Model =
     , session : Maybe Session
     , loginError : String
     , composeBody : String
-    , replyTo : Int            -- parentId for the next compose; 0 = top-level
+    , replyTo : Int-- parentId for the next compose; 0 = top-level
     , nextCommentId : Int
     }
-
 
 type Msg
     = Navigate Page
@@ -93,7 +85,6 @@ type Msg
 -- ─── Pure helpers (no Std.Ui dependency) ─────────────────────────
 
 -- ─── Vote scoring ────────────────────────────────────────────────
-
 postScore : Post -> Int
 postScore p =
     p.votes + List.length p.upvoters - List.length p.downvoters
@@ -113,17 +104,17 @@ commentScore c =
 --
 -- Score is derived (postScore / commentScore), so swapping naturally
 -- moves the displayed total by ±2 without any extra arithmetic here.
-
 togglePostUpvote : String -> Int -> Post -> Post
 togglePostUpvote username targetId post =
     if post.id /= targetId then
         post
+
     else if List.member username post.upvoters then
         { post | upvoters = removeMember username post.upvoters }
+
     else
-        { post
-            | upvoters = username :: post.upvoters
-            , downvoters = removeMember username post.downvoters
+        { post | upvoters = username :: post.upvoters
+        , downvoters = removeMember username post.downvoters
         }
 
 
@@ -131,12 +122,13 @@ togglePostDownvote : String -> Int -> Post -> Post
 togglePostDownvote username targetId post =
     if post.id /= targetId then
         post
+
     else if List.member username post.downvoters then
         { post | downvoters = removeMember username post.downvoters }
+
     else
-        { post
-            | downvoters = username :: post.downvoters
-            , upvoters = removeMember username post.upvoters
+        { post | downvoters = username :: post.downvoters
+        , upvoters = removeMember username post.upvoters
         }
 
 
@@ -144,12 +136,13 @@ toggleCommentUpvote : String -> Int -> Comment -> Comment
 toggleCommentUpvote username targetId comment =
     if comment.id /= targetId then
         comment
+
     else if List.member username comment.upvoters then
         { comment | upvoters = removeMember username comment.upvoters }
+
     else
-        { comment
-            | upvoters = username :: comment.upvoters
-            , downvoters = removeMember username comment.downvoters
+        { comment | upvoters = username :: comment.upvoters
+        , downvoters = removeMember username comment.downvoters
         }
 
 
@@ -157,12 +150,13 @@ toggleCommentDownvote : String -> Int -> Comment -> Comment
 toggleCommentDownvote username targetId comment =
     if comment.id /= targetId then
         comment
+
     else if List.member username comment.downvoters then
         { comment | downvoters = removeMember username comment.downvoters }
+
     else
-        { comment
-            | downvoters = username :: comment.downvoters
-            , upvoters = removeMember username comment.upvoters
+        { comment | downvoters = username :: comment.downvoters
+        , upvoters = removeMember username comment.upvoters
         }
 
 
@@ -175,12 +169,14 @@ bumpPostComments : Int -> Post -> Post
 bumpPostComments targetId post =
     if post.id == targetId then
         { post | commentCount = post.commentCount + 1 }
+
     else
         post
 
 
 findPost : Int -> List Post -> Maybe Post
-findPost target posts = List.find (\p -> p.id == target) posts
+findPost target posts =
+    List.find (\p -> p.id == target) posts
 
 
 matchesParent : Int -> Int -> Comment -> Bool
@@ -191,7 +187,8 @@ matchesParent postId parentId c =
 shortenUrl : String -> String
 shortenUrl url =
     let
-        afterScheme = String.replace "https://" "" (String.replace "http://" "" url)
+        afterScheme =
+            String.replace "https://" "" (String.replace "http://" "" url)
         slash = String.split "/" afterScheme
     in
         Maybe.withDefault afterScheme (List.head slash)

--- a/examples/19-skyforum/src/Update.sky
+++ b/examples/19-skyforum/src/Update.sky
@@ -10,68 +10,87 @@ import State exposing (..)
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
+
         Navigate page ->
-            ( { model | currentPage = page, composeBody = "", replyTo = 0 }, Cmd.none )
+            ( { model | currentPage = page, composeBody = "", replyTo = 0 }
+            , Cmd.none
+            )
 
         UpvotePost postId ->
-            -- Anonymous users redirect to login (mirrors SubmitComment).
-            -- The page reroute is the user-visible signal "sign in to vote".
-            -- Toggle semantics: clicking again removes the vote (see
-            -- State.togglePostUpvote).
+        -- Anonymous users redirect to login (mirrors SubmitComment).
+        -- The page reroute is the user-visible signal "sign in to vote".
+        -- Toggle semantics: clicking again removes the vote (see
+        -- State.togglePostUpvote).
             case model.session of
+
                 Nothing ->
                     ( { model | currentPage = LoginPage }, Cmd.none )
 
                 Just sess ->
-                    ( { model | posts = List.map (togglePostUpvote sess.username postId) model.posts }
+                    ( { model | posts = List.map
+                            (togglePostUpvote sess.username postId)
+                            model.posts
+                      }
                     , Cmd.none
                     )
 
         DownvotePost postId ->
             case model.session of
+
                 Nothing ->
                     ( { model | currentPage = LoginPage }, Cmd.none )
 
                 Just sess ->
-                    ( { model | posts = List.map (togglePostDownvote sess.username postId) model.posts }
+                    ( { model | posts = List.map
+                            (togglePostDownvote sess.username postId)
+                            model.posts
+                      }
                     , Cmd.none
                     )
 
         UpvoteComment commentId ->
             case model.session of
+
                 Nothing ->
                     ( { model | currentPage = LoginPage }, Cmd.none )
 
                 Just sess ->
-                    ( { model | comments = List.map (toggleCommentUpvote sess.username commentId) model.comments }
+                    ( { model | comments = List.map
+                            (toggleCommentUpvote sess.username commentId)
+                            model.comments
+                      }
                     , Cmd.none
                     )
 
         DownvoteComment commentId ->
             case model.session of
+
                 Nothing ->
                     ( { model | currentPage = LoginPage }, Cmd.none )
 
                 Just sess ->
-                    ( { model | comments = List.map (toggleCommentDownvote sess.username commentId) model.comments }
+                    ( { model | comments = List.map
+                            (toggleCommentDownvote sess.username commentId)
+                            model.comments
+                      }
                     , Cmd.none
                     )
 
         DoSignIn creds ->
-            -- Form-submit handler. `creds.username` and `creds.password`
-            -- come straight from the wire `<form>` data — case-
-            -- insensitive json.Unmarshal decoded the formData
-            -- {"username":"...","password":"..."} into LoginForm.
-            -- The password lives only in this Msg's record arg until
-            -- the update consumes it; never enters Model so never
-            -- serialises into the session store.
+        -- Form-submit handler. `creds.username` and `creds.password`
+        -- come straight from the wire `<form>` data — case-
+        -- insensitive json.Unmarshal decoded the formData
+        -- {"username":"...","password":"..."} into LoginForm.
+        -- The password lives only in this Msg's record arg until
+        -- the update consumes it; never enters Model so never
+        -- serialises into the session store.
             if String.isEmpty (String.trim creds.username) then
                 ( { model | loginError = "Username is required." }, Cmd.none )
+
             else
-                ( { model
-                    | session = Just { username = String.trim creds.username }
-                    , loginError = ""
-                    , currentPage = HomePage
+                ( { model | session = Just { username = String.trim creds.username }
+                  , loginError = ""
+                  , currentPage = HomePage
                   }
                 , Cmd.none
                 )
@@ -90,19 +109,20 @@ update msg model =
 
         SubmitComment postId ->
             case model.session of
+
                 Nothing ->
                     ( { model | currentPage = LoginPage }, Cmd.none )
 
                 Just sess ->
                     if String.isEmpty (String.trim model.composeBody) then
                         ( model, Cmd.none )
+
                     else
-                        ( { model
-                            | comments = model.comments ++ [ newComment model sess postId ]
-                            , posts = List.map (bumpPostComments postId) model.posts
-                            , composeBody = ""
-                            , replyTo = 0
-                            , nextCommentId = model.nextCommentId + 1
+                        ( { model | comments = model.comments ++ [newComment model sess postId]
+                          , posts = List.map (bumpPostComments postId) model.posts
+                          , composeBody = ""
+                          , replyTo = 0
+                          , nextCommentId = model.nextCommentId + 1
                           }
                         , Cmd.none
                         )
@@ -110,15 +130,15 @@ update msg model =
 
 newComment : Model -> Session -> Int -> Comment
 newComment model sess postId =
-    -- Author auto-upvotes their own comment (Reddit convention) — sets
-    -- the seed score to 0 and adds them to upvoters so the displayed
-    -- score is 1. Clicking "upvoted" later removes themselves cleanly.
+-- Author auto-upvotes their own comment (Reddit convention) — sets
+-- the seed score to 0 and adds them to upvoters so the displayed
+-- score is 1. Clicking "upvoted" later removes themselves cleanly.
     { id = model.nextCommentId
     , postId = postId
     , parentId = model.replyTo
     , author = sess.username
     , body = String.trim model.composeBody
     , votes = 0
-    , upvoters = [ sess.username ]
+    , upvoters = [sess.username]
     , downvoters = []
     }

--- a/examples/19-skyforum/src/View/Common.sky
+++ b/examples/19-skyforum/src/View/Common.sky
@@ -3,7 +3,6 @@ module View.Common exposing (..)
 -- App chrome shared across pages: top nav, session widget, footer,
 -- plus two low-level click helpers (clickable for inline links,
 -- navButton for chrome buttons).
-
 import Sky.Core.Prelude exposing (..)
 import Std.Ui as Ui
 import Std.Ui exposing (Element)
@@ -41,21 +40,26 @@ topNav model =
         , Background.color (Ui.rgb 255 102 0)
         , Border.rounded 4
         ]
-        [ Ui.el [ Font.bold, Font.color (Ui.rgb 255 255 255) ]
-            (clickable (Navigate HomePage) (Ui.text "skyforum"))
-        , Ui.el [ Font.color (Ui.rgb 255 255 255) ]
-            (clickable (Navigate HomePage) (Ui.text "top"))
-        , Ui.el [ Ui.alignRight ] (sessionWidget model.session)
+        [ Ui.el
+              [ Font.bold, Font.color (Ui.rgb 255 255 255) ]
+              (clickable (Navigate HomePage) (Ui.text "skyforum"))
+        , Ui.el
+              [Font.color (Ui.rgb 255 255 255)]
+              (clickable (Navigate HomePage) (Ui.text "top"))
+        , Ui.el [Ui.alignRight] (sessionWidget model.session)
         ]
 
 
 sessionWidget : Maybe Session -> Element Msg
 sessionWidget maybeSession =
     case maybeSession of
+
         Just sess ->
-            Ui.row [ Ui.spacing 8 ]
-                [ Ui.el [ Font.color (Ui.rgb 255 255 255) ]
-                    (Ui.text ("hi, " ++ sess.username))
+            Ui.row
+                [Ui.spacing 8]
+                [ Ui.el
+                      [Font.color (Ui.rgb 255 255 255)]
+                      (Ui.text ("hi, " ++ sess.username))
                 , navButton LogoutClicked "logout"
                 ]
 

--- a/examples/19-skyforum/src/View/Compose.sky
+++ b/examples/19-skyforum/src/View/Compose.sky
@@ -14,10 +14,11 @@ import View.Common exposing (clickable)
 composeArea : Model -> Post -> Element Msg
 composeArea model post =
     case model.session of
+
         Nothing ->
-            Ui.el [ Font.color (Ui.rgb 130 130 130), Font.size 12 ]
-                (clickable (Navigate LoginPage)
-                    (Ui.text "Sign in to comment"))
+            Ui.el
+                [ Font.color (Ui.rgb 130 130 130), Font.size 12 ]
+                (clickable (Navigate LoginPage) (Ui.text "Sign in to comment"))
 
         Just _sess ->
             composeForm model post
@@ -33,8 +34,9 @@ composeForm model post =
         , Border.width 1
         , Border.color (Ui.rgb 220 220 200)
         ]
-        [ Ui.el [ Font.size 12, Font.color (Ui.rgb 100 100 100) ]
-            (Ui.text (replyContext model.replyTo))
+        [ Ui.el
+              [ Font.size 12, Font.color (Ui.rgb 100 100 100) ]
+              (Ui.text (replyContext model.replyTo))
         , composeInput model.composeBody
         , composeActions post.id model.replyTo
         ]
@@ -44,6 +46,7 @@ replyContext : Int -> String
 replyContext replyTo =
     if replyTo == 0 then
         "Comment on this post"
+
     else
         "Replying to comment #" ++ String.fromInt replyTo
 
@@ -70,21 +73,23 @@ composeInput current =
 
 composeActions : Int -> Int -> Element Msg
 composeActions postId replyTo =
-    Ui.row [ Ui.spacing 6 ]
+    Ui.row
+        [Ui.spacing 6]
         [ Ui.button
-            [ Background.color (Ui.rgb 255 102 0)
-            , Font.color (Ui.rgb 255 255 255)
-            , Border.rounded 3
-            , Ui.padding 4
-            ]
-            { onPress = Just (SubmitComment postId), label = Ui.text "post" }
+              [ Background.color (Ui.rgb 255 102 0)
+              , Font.color (Ui.rgb 255 255 255)
+              , Border.rounded 3
+              , Ui.padding 4
+              ]
+              { onPress = Just (SubmitComment postId), label = Ui.text "post" }
         , if replyTo == 0 then
-            Ui.text ""
+              Ui.text ""
+
           else
-            Ui.button
-                [ Background.color (Ui.rgb 230 230 230)
-                , Border.rounded 3
-                , Ui.padding 4
-                ]
-                { onPress = Just CancelReply, label = Ui.text "cancel" }
+              Ui.button
+                  [ Background.color (Ui.rgb 230 230 230)
+                  , Border.rounded 3
+                  , Ui.padding 4
+                  ]
+                  { onPress = Just CancelReply, label = Ui.text "cancel" }
         ]

--- a/examples/19-skyforum/src/View/Detail.sky
+++ b/examples/19-skyforum/src/View/Detail.sky
@@ -16,20 +16,23 @@ import View.Compose exposing (composeArea)
 postDetailView : Model -> Int -> Element Msg
 postDetailView model postId =
     case findPost postId model.posts of
+
         Nothing ->
-            Ui.el [ Font.color (Ui.rgb 200 60 60) ] (Ui.text "Post not found.")
+            Ui.el [Font.color (Ui.rgb 200 60 60)] (Ui.text "Post not found.")
 
         Just post ->
             Ui.column
-                [ Ui.spacing 16 ]
+                [Ui.spacing 16]
                 [ postRow model.session 0 post
                 , composeArea model post
                 , Ui.column
-                    [ Ui.spacing 8 ]
-                    [ Ui.el [ Font.size 14, Font.bold ]
-                        (Ui.text (String.fromInt post.commentCount ++ " comments"))
-                    , commentTreeView model.session model.comments post.id 0 0
-                    ]
+                      [Ui.spacing 8]
+                      [ Ui.el
+                            [ Font.size 14, Font.bold ]
+                            (Ui.text
+                                (String.fromInt post.commentCount ++ " comments"))
+                      , commentTreeView model.session model.comments post.id 0 0
+                      ]
                 ]
 
 
@@ -42,12 +45,16 @@ commentTreeView : Maybe Session -> List Comment -> Int -> Int -> Int -> Element 
 commentTreeView maybeSession allComments postId parentId depth =
     let
         children = List.filter (matchesParent postId parentId) allComments
-        renderedChildren = List.map (\c -> commentNode maybeSession allComments c depth) children
+        renderedChildren =
+            List.map
+                (\c -> commentNode maybeSession allComments c depth)
+                children
     in
         if List.isEmpty children then
             Ui.text ""
+
         else
-            Ui.column [ Ui.spacing 8 ] renderedChildren
+            Ui.column [Ui.spacing 8] renderedChildren
 
 
 commentNode : Maybe Session -> List Comment -> Comment -> Int -> Element Msg
@@ -65,19 +72,16 @@ commentNode maybeSession allComments c parentDepth =
             , Ui.el [] (Ui.text c.body)
             , commentActions maybeSession c
             , Ui.el
-                [ Ui.style "padding-left" (String.fromInt myDepth ++ "px") ]
-                (commentTreeView maybeSession allComments c.postId c.id myDepth)
+                  [Ui.style "padding-left" (String.fromInt myDepth ++ "px")]
+                  (commentTreeView maybeSession allComments c.postId c.id myDepth)
             ]
 
 
 commentHeader : Comment -> Element Msg
 commentHeader c =
     Ui.row
-        [ Ui.spacing 6
-        , Font.size 11
-        , Font.color (Ui.rgb 130 130 130)
-        ]
-        [ Ui.el [ Font.bold ] (Ui.text c.author)
+        [ Ui.spacing 6, Font.size 11, Font.color (Ui.rgb 130 130 130) ]
+        [ Ui.el [Font.bold] (Ui.text c.author)
         , Ui.text "•"
         , Ui.text (String.fromInt (commentScore c) ++ " points")
         ]
@@ -95,38 +99,60 @@ commentActions maybeSession c =
         username = currentUsername maybeSession
         upActive = List.member username c.upvoters
         downActive = List.member username c.downvoters
-        upLabel = if upActive then "upvoted" else "upvote"
-        downLabel = if downActive then "downvoted" else "downvote"
+        upLabel =
+            if upActive then
+                "upvoted"
+
+            else
+                "upvote"
+        downLabel =
+            if downActive then
+                "downvoted"
+
+            else
+                "downvote"
     in
         Ui.row
-            [ Ui.spacing 8
-            , Font.size 11
-            ]
+            [ Ui.spacing 8, Font.size 11 ]
             [ Ui.el
-                [ Font.color (if upActive then Ui.rgb 255 102 0 else Ui.rgb 100 130 220)
-                , Font.bold
-                , Ui.onClick (UpvoteComment c.id)
-                , Ui.pointer
-                ]
-                (Ui.text upLabel)
+                  [ Font.color
+                        (if upActive then
+                            Ui.rgb 255 102 0
+
+                        else
+                            Ui.rgb 100 130 220)
+                  , Font.bold
+                  , Ui.onClick (UpvoteComment c.id)
+                  , Ui.pointer
+                  ]
+                  (Ui.text upLabel)
             , Ui.el
-                [ Font.color (if downActive then Ui.rgb 100 130 220 else Ui.rgb 130 130 130)
-                , Font.bold
-                , Ui.onClick (DownvoteComment c.id)
-                , Ui.pointer
-                ]
-                (Ui.text downLabel)
+                  [ Font.color
+                        (if downActive then
+                            Ui.rgb 100 130 220
+
+                        else
+                            Ui.rgb 130 130 130)
+                  , Font.bold
+                  , Ui.onClick (DownvoteComment c.id)
+                  , Ui.pointer
+                  ]
+                  (Ui.text downLabel)
             , Ui.el
-                [ Font.color (Ui.rgb 100 130 220)
-                , Ui.onClick (StartReplyTo c.id)
-                , Ui.pointer
-                ]
-                (Ui.text "reply")
+                  [ Font.color (Ui.rgb 100 130 220)
+                  , Ui.onClick (StartReplyTo c.id)
+                  , Ui.pointer
+                  ]
+                  (Ui.text "reply")
             ]
 
 
 currentUsername : Maybe Session -> String
 currentUsername maybeSession =
     case maybeSession of
-        Just sess -> sess.username
-        Nothing -> ""
+
+        Just sess ->
+            sess.username
+
+        Nothing ->
+            ""

--- a/examples/19-skyforum/src/View/Login.sky
+++ b/examples/19-skyforum/src/View/Login.sky
@@ -19,7 +19,6 @@ module View.Login exposing (..)
 -- {"username":"...","password":"..."} directly into the typed
 -- LoginForm record via case-insensitive json.Unmarshal. Field
 -- names in LoginForm MUST match the input `name` attrs.
-
 import Sky.Core.Prelude exposing (..)
 import Std.Ui as Ui
 import Std.Ui exposing (Element)
@@ -33,63 +32,69 @@ import State exposing (..)
 loginView : Model -> Element Msg
 loginView model =
     Ui.form
-        [ Ui.onSubmit DoSignIn ]
-        [ Ui.column
+        [Ui.onSubmit DoSignIn]
+        [Ui.column
             [ Ui.spacing 16
             , Ui.padding 16
             , Background.color (Ui.rgb 255 255 255)
             , Border.rounded 4
             , Ui.width (Ui.px 320)
             ]
-            [ Ui.el [ Region.heading 2, Font.size 18, Font.bold ]
-                (Ui.text "Sign in")
-            , Ui.el [ Font.size 12, Font.color (Ui.rgb 100 100 100) ]
-                (Ui.text "Any non-empty username works — this demo doesn't really authenticate.")
-            , Ui.column [ Ui.spacing 4 ]
-                [ Ui.el [ Font.size 12 ] (Ui.text "Username")
-                , Ui.input
-                    [ Ui.htmlAttribute "type" "text"
-                    , Ui.name "username"
-                    , Border.width 1
-                    , Border.color (Ui.rgb 200 200 200)
-                    , Border.rounded 3
-                    , Ui.padding 6
-                    , Background.color (Ui.rgb 255 255 255)
-                    ]
-                ]
-            , Ui.column [ Ui.spacing 4 ]
-                [ Ui.el [ Font.size 12 ] (Ui.text "Password")
-                , Ui.input
-                    -- No `value` attr (don't round-trip the secret through
-                    -- DOM on re-render — kills password-manager re-prompts).
-                    -- No `onInput` (don't dispatch per keystroke — keeps the
-                    -- secret out of Model and the session store).
-                    [ Ui.htmlAttribute "type" "password"
-                    , Ui.name "password"
-                    , Border.width 1
-                    , Border.color (Ui.rgb 200 200 200)
-                    , Border.rounded 3
-                    , Ui.padding 6
-                    , Background.color (Ui.rgb 255 255 255)
-                    ]
-                ]
+            [ Ui.el
+                  [ Region.heading 2, Font.size 18, Font.bold ]
+                  (Ui.text "Sign in")
+            , Ui.el
+                  [ Font.size 12, Font.color (Ui.rgb 100 100 100) ]
+                  (Ui.text
+                      "Any non-empty username works — this demo doesn't really authenticate.")
+            , Ui.column
+                  [Ui.spacing 4]
+                  [ Ui.el [Font.size 12] (Ui.text "Username")
+                  , Ui.input
+                  -- No `value` attr (don't round-trip the secret through
+                  -- DOM on re-render — kills password-manager re-prompts).
+                  -- No `onInput` (don't dispatch per keystroke — keeps the
+                  -- secret out of Model and the session store).
+                        [ Ui.htmlAttribute "type" "text"
+                        , Ui.name "username"
+                        , Border.width 1
+                        , Border.color (Ui.rgb 200 200 200)
+                        , Border.rounded 3
+                        , Ui.padding 6
+                        , Background.color (Ui.rgb 255 255 255)
+                        ]
+                  ]
+            , Ui.column
+                  [Ui.spacing 4]
+                  [ Ui.el [Font.size 12] (Ui.text "Password")
+                  , Ui.input
+                  -- Submit button rendered as <input type="submit"> so the
+                  -- form's submit handler fires on click AND on Enter from
+                  -- inside any field. (Plain Ui.button defaults to type=submit
+                  -- inside a form too, but it would also trigger Ui.onClick
+                  -- if attached — we want the submit pathway only.)
+                        [ Ui.htmlAttribute "type" "password"
+                        , Ui.name "password"
+                        , Border.width 1
+                        , Border.color (Ui.rgb 200 200 200)
+                        , Border.rounded 3
+                        , Ui.padding 6
+                        , Background.color (Ui.rgb 255 255 255)
+                        ]
+                  ]
             , if model.loginError == "" then
-                Ui.text ""
+                  Ui.text ""
+
               else
-                Ui.el [ Font.color (Ui.rgb 200 60 60), Font.size 12 ]
-                    (Ui.text model.loginError)
+                  Ui.el
+                      [ Font.color (Ui.rgb 200 60 60), Font.size 12 ]
+                      (Ui.text model.loginError)
             , Ui.input
-                -- Submit button rendered as <input type="submit"> so the
-                -- form's submit handler fires on click AND on Enter from
-                -- inside any field. (Plain Ui.button defaults to type=submit
-                -- inside a form too, but it would also trigger Ui.onClick
-                -- if attached — we want the submit pathway only.)
-                [ Ui.htmlAttribute "type" "submit"
-                , Ui.htmlAttribute "value" "sign in"
-                , Background.color (Ui.rgb 255 102 0)
-                , Font.color (Ui.rgb 255 255 255)
-                , Border.rounded 3
-                , Ui.padding 6
-                ]
-            ]
-        ]
+                  [ Ui.htmlAttribute "type" "submit"
+                  , Ui.htmlAttribute "value" "sign in"
+                  , Background.color (Ui.rgb 255 102 0)
+                  , Font.color (Ui.rgb 255 255 255)
+                  , Border.rounded 3
+                  , Ui.padding 6
+                  ]
+            ]]

--- a/examples/19-skyforum/src/View/Posts.sky
+++ b/examples/19-skyforum/src/View/Posts.sky
@@ -14,7 +14,7 @@ import View.Common exposing (clickable)
 
 postsListView : Maybe Session -> List Post -> Element Msg
 postsListView maybeSession posts =
-    Ui.column [ Ui.spacing 12 ] (List.indexedMap (postRow maybeSession) posts)
+    Ui.column [Ui.spacing 12] (List.indexedMap (postRow maybeSession) posts)
 
 
 postRow : Maybe Session -> Int -> Post -> Element Msg
@@ -36,10 +36,7 @@ postRow maybeSession index post =
 rankNumber : Int -> Element Msg
 rankNumber n =
     Ui.el
-        [ Ui.width (Ui.px 28)
-        , Ui.centerY
-        , Font.color (Ui.rgb 130 130 130)
-        ]
+        [ Ui.width (Ui.px 28), Ui.centerY, Font.color (Ui.rgb 130 130 130) ]
         (Ui.text (String.fromInt n ++ "."))
 
 
@@ -55,30 +52,48 @@ postVoteButtons maybeSession post =
         downActive = List.member username post.downvoters
     in
         Ui.column
-            [ Ui.width (Ui.px 40)
-            , Ui.spacing 2
-            , Ui.centerY
-            ]
+            [ Ui.width (Ui.px 40), Ui.spacing 2, Ui.centerY ]
             [ Ui.button
-                [ Background.color (if upActive then Ui.rgb 255 102 0 else Ui.rgb 240 240 240)
-                , Font.color (if upActive then Ui.rgb 255 255 255 else Ui.rgb 130 130 130)
-                , Border.rounded 3
-                , Border.width 0
-                , Ui.padding 2
-                , Ui.centerX
-                ]
-                { onPress = Just (UpvotePost post.id), label = Ui.text "▲" }
-            , Ui.el [ Ui.centerX, Font.size 11, Font.color (Ui.rgb 130 130 130) ]
-                (Ui.text (String.fromInt (postScore post)))
+                  [ Background.color
+                        (if upActive then
+                            Ui.rgb 255 102 0
+
+                        else
+                            Ui.rgb 240 240 240)
+                  , Font.color
+                        (if upActive then
+                            Ui.rgb 255 255 255
+
+                        else
+                            Ui.rgb 130 130 130)
+                  , Border.rounded 3
+                  , Border.width 0
+                  , Ui.padding 2
+                  , Ui.centerX
+                  ]
+                  { onPress = Just (UpvotePost post.id), label = Ui.text "▲" }
+            , Ui.el
+                  [ Ui.centerX, Font.size 11, Font.color (Ui.rgb 130 130 130) ]
+                  (Ui.text (String.fromInt (postScore post)))
             , Ui.button
-                [ Background.color (if downActive then Ui.rgb 100 130 220 else Ui.rgb 240 240 240)
-                , Font.color (if downActive then Ui.rgb 255 255 255 else Ui.rgb 130 130 130)
-                , Border.rounded 3
-                , Border.width 0
-                , Ui.padding 2
-                , Ui.centerX
-                ]
-                { onPress = Just (DownvotePost post.id), label = Ui.text "▼" }
+                  [ Background.color
+                        (if downActive then
+                            Ui.rgb 100 130 220
+
+                        else
+                            Ui.rgb 240 240 240)
+                  , Font.color
+                        (if downActive then
+                            Ui.rgb 255 255 255
+
+                        else
+                            Ui.rgb 130 130 130)
+                  , Border.rounded 3
+                  , Border.width 0
+                  , Ui.padding 2
+                  , Ui.centerX
+                  ]
+                  { onPress = Just (DownvotePost post.id), label = Ui.text "▼" }
             ]
 
 
@@ -87,27 +102,40 @@ postVoteButtons maybeSession post =
 currentUsername : Maybe Session -> String
 currentUsername maybeSession =
     case maybeSession of
-        Just sess -> sess.username
-        Nothing -> ""
+
+        Just sess ->
+            sess.username
+
+        Nothing ->
+            ""
 
 
 postBody : Post -> Element Msg
 postBody post =
     Ui.column
-        [ Ui.spacing 4 ]
-        [ Ui.row [ Ui.spacing 8 ]
-            [ Ui.el [ Font.size 14, Font.color (Ui.rgb 0 0 0) ]
-                (clickable (Navigate (PostPage post.id)) (Ui.text post.title))
-            , Ui.el [ Font.size 11, Font.color (Ui.rgb 130 130 130) ]
-                (Ui.text ("(" ++ shortenUrl post.url ++ ")"))
-            ]
-        , Ui.row [ Ui.spacing 6 ]
-            [ Ui.el [ Font.size 11, Font.color (Ui.rgb 130 130 130) ]
-                (Ui.text ("by " ++ post.author))
-            , Ui.el [ Font.size 11, Font.color (Ui.rgb 130 130 130) ]
-                (Ui.text "|")
-            , Ui.el [ Font.size 11, Font.color (Ui.rgb 130 130 130) ]
-                (clickable (Navigate (PostPage post.id))
-                    (Ui.text (String.fromInt post.commentCount ++ " comments")))
-            ]
+        [Ui.spacing 4]
+        [ Ui.row
+              [Ui.spacing 8]
+              [ Ui.el
+                    [ Font.size 14, Font.color (Ui.rgb 0 0 0) ]
+                    (clickable (Navigate (PostPage post.id)) (Ui.text post.title))
+              , Ui.el
+                    [ Font.size 11, Font.color (Ui.rgb 130 130 130) ]
+                    (Ui.text ("(" ++ shortenUrl post.url ++ ")"))
+              ]
+        , Ui.row
+              [Ui.spacing 6]
+              [ Ui.el
+                    [ Font.size 11, Font.color (Ui.rgb 130 130 130) ]
+                    (Ui.text ("by " ++ post.author))
+              , Ui.el
+                    [ Font.size 11, Font.color (Ui.rgb 130 130 130) ]
+                    (Ui.text "|")
+              , Ui.el
+                    [ Font.size 11, Font.color (Ui.rgb 130 130 130) ]
+                    (clickable
+                        (Navigate (PostPage post.id))
+                        (Ui.text
+                            (String.fromInt post.commentCount ++ " comments")))
+              ]
         ]

--- a/examples/19-skyforum/test-fixtures/heap-bound-fence.sky
+++ b/examples/19-skyforum/test-fixtures/heap-bound-fence.sky
@@ -15,7 +15,6 @@ module Main exposing (main)
 -- external services. This keeps the example focused on the view
 -- layer (Std.Ui) and the TEA wiring (init/update/view), not on
 -- persistence or auth correctness.
-
 import Sky.Core.Prelude exposing (..)
 import Sky.Core.List as List
 import Sky.Core.Maybe as Maybe
@@ -36,11 +35,10 @@ import Std.Ui.Input as Input
 -- currently strips the type parameter when re-exporting it
 -- cross-module, so we re-define it locally.
 noneEl : Element msg
-noneEl = Ui.none
-
+noneEl =
+    Ui.none
 
 -- ─── Domain types ────────────────────────────────────────────────
-
 type alias Post =
     { id : Int
     , title : String
@@ -50,27 +48,22 @@ type alias Post =
     , commentCount : Int
     }
 
-
 type alias Comment =
     { id : Int
     , postId : Int
-    , parentId : Int      -- 0 = top-level (root) comment under the post
+    , parentId : Int-- 0 = top-level (root) comment under the post
     , author : String
     , body : String
     , votes : Int
     }
 
-
 type alias Session =
-    { username : String
-    }
-
+    { username : String }
 
 type Page
     = HomePage
     | PostPage Int
     | LoginPage
-
 
 type alias Model =
     { posts : List Post
@@ -81,32 +74,109 @@ type alias Model =
     , loginPass : String
     , loginError : String
     , composeBody : String
-    , replyTo : Int            -- parentId for the next compose; 0 = top-level
+    , replyTo : Int-- parentId for the next compose; 0 = top-level
     , nextCommentId : Int
     }
 
 
 -- ─── Init ───────────────────────────────────────────────────────
-
 init : a -> ( Model, Cmd Msg )
 init _req =
     let
         seedPosts =
-            [ Post 1 "Show SN: Sky.Ui — a typed elm-ui port for Sky.Live" "https://github.com/anzellai/sky" "alice" 142 8
-            , Post 2 "Tiny CRDT primitives in 200 lines" "https://example.com/crdt" "bob" 87 12
-            , Post 3 "Ask SN: Best resources for learning Hindley-Milner?" "https://example.com/hm" "carol" 56 23
-            , Post 4 "Why server-driven UIs are having a moment" "https://example.com/server-ui" "dave" 41 5
-            , Post 5 "Postgres tips that actually matter in production" "https://example.com/pg-tips" "eve" 38 4
+            [ Post
+                  1
+                  "Show SN: Sky.Ui — a typed elm-ui port for Sky.Live"
+                  "https://github.com/anzellai/sky"
+                  "alice"
+                  142
+                  8
+            , Post
+                  2
+                  "Tiny CRDT primitives in 200 lines"
+                  "https://example.com/crdt"
+                  "bob"
+                  87
+                  12
+            , Post
+                  3
+                  "Ask SN: Best resources for learning Hindley-Milner?"
+                  "https://example.com/hm"
+                  "carol"
+                  56
+                  23
+            , Post
+                  4
+                  "Why server-driven UIs are having a moment"
+                  "https://example.com/server-ui"
+                  "dave"
+                  41
+                  5
+            , Post
+                  5
+                  "Postgres tips that actually matter in production"
+                  "https://example.com/pg-tips"
+                  "eve"
+                  38
+                  4
             ]
         seedComments =
-            [ Comment 101 1 0 "bob" "This looks great — does it support keyed children for diffing?" 12
-            , Comment 102 1 101 "alice" "Yes, Std.Ui.Keyed handles that via the sky-key attribute." 9
-            , Comment 103 1 102 "bob" "Nice. Any plans for an actual stylesheet pass?" 4
-            , Comment 104 1 0 "carol" "How does it compare to Phoenix LiveView?" 7
-            , Comment 105 1 104 "alice" "Same idea: server holds state, browser is dumb. Ours emits flexbox inline-style instead of class-keyed CSS." 11
-            , Comment 201 2 0 "alice" "Love seeing CRDT explanations that fit on one page." 5
-            , Comment 301 3 0 "dave" "Read 'Types and Programming Languages' (TAPL). It's the canonical reference." 18
-            , Comment 302 3 301 "carol" "Thanks! Anything shorter for a primer?" 3
+            [ Comment
+                  101
+                  1
+                  0
+                  "bob"
+                  "This looks great — does it support keyed children for diffing?"
+                  12
+            , Comment
+                  102
+                  1
+                  101
+                  "alice"
+                  "Yes, Std.Ui.Keyed handles that via the sky-key attribute."
+                  9
+            , Comment
+                  103
+                  1
+                  102
+                  "bob"
+                  "Nice. Any plans for an actual stylesheet pass?"
+                  4
+            , Comment
+                  104
+                  1
+                  0
+                  "carol"
+                  "How does it compare to Phoenix LiveView?"
+                  7
+            , Comment
+                  105
+                  1
+                  104
+                  "alice"
+                  "Same idea: server holds state, browser is dumb. Ours emits flexbox inline-style instead of class-keyed CSS."
+                  11
+            , Comment
+                  201
+                  2
+                  0
+                  "alice"
+                  "Love seeing CRDT explanations that fit on one page."
+                  5
+            , Comment
+                  301
+                  3
+                  0
+                  "dave"
+                  "Read 'Types and Programming Languages' (TAPL). It's the canonical reference."
+                  18
+            , Comment
+                  302
+                  3
+                  301
+                  "carol"
+                  "Thanks! Anything shorter for a primer?"
+                  3
             ]
         m =
             { posts = seedPosts
@@ -123,9 +193,7 @@ init _req =
     in
         ( m, Cmd.none )
 
-
 -- ─── Update ─────────────────────────────────────────────────────
-
 type Msg
     = Navigate Page
     | UpvotePost Int
@@ -143,14 +211,22 @@ type Msg
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
+
         Navigate page ->
-            ( { model | currentPage = page, composeBody = "", replyTo = 0 }, Cmd.none )
+            ( { model | currentPage = page, composeBody = "", replyTo = 0 }
+            , Cmd.none
+            )
 
         UpvotePost postId ->
-            ( { model | posts = List.map (bumpPost postId) model.posts }, Cmd.none )
+            ( { model | posts = List.map (bumpPost postId) model.posts }
+            , Cmd.none
+            )
 
         UpvoteComment commentId ->
-            ( { model | comments = List.map (bumpComment commentId) model.comments }, Cmd.none )
+            ( { model | comments = List.map (bumpComment commentId) model.comments
+              }
+            , Cmd.none
+            )
 
         LoginUsernameChanged u ->
             ( { model | loginUser = u }, Cmd.none )
@@ -161,16 +237,16 @@ update msg model =
         LoginSubmit ->
             if String.isEmpty (String.trim model.loginUser) then
                 ( { model | loginError = "Username is required." }, Cmd.none )
+
             else
                 let
                     sess = { username = String.trim model.loginUser }
                 in
-                    ( { model
-                        | session = Just sess
-                        , loginUser = ""
-                        , loginPass = ""
-                        , loginError = ""
-                        , currentPage = HomePage
+                    ( { model | session = Just sess
+                      , loginUser = ""
+                      , loginPass = ""
+                      , loginError = ""
+                      , currentPage = HomePage
                       }
                     , Cmd.none
                     )
@@ -189,12 +265,14 @@ update msg model =
 
         SubmitComment postId ->
             case model.session of
+
                 Nothing ->
                     ( { model | currentPage = LoginPage }, Cmd.none )
 
                 Just sess ->
                     if String.isEmpty (String.trim model.composeBody) then
                         ( model, Cmd.none )
+
                     else
                         let
                             newComment =
@@ -205,14 +283,14 @@ update msg model =
                                 , body = String.trim model.composeBody
                                 , votes = 1
                                 }
-                            updatedPosts = List.map (bumpPostComments postId) model.posts
+                            updatedPosts =
+                                List.map (bumpPostComments postId) model.posts
                         in
-                            ( { model
-                                | comments = model.comments ++ [ newComment ]
-                                , posts = updatedPosts
-                                , composeBody = ""
-                                , replyTo = 0
-                                , nextCommentId = model.nextCommentId + 1
+                            ( { model | comments = model.comments ++ [newComment]
+                              , posts = updatedPosts
+                              , composeBody = ""
+                              , replyTo = 0
+                              , nextCommentId = model.nextCommentId + 1
                               }
                             , Cmd.none
                             )
@@ -222,6 +300,7 @@ bumpPost : Int -> Post -> Post
 bumpPost targetId post =
     if post.id == targetId then
         { post | votes = post.votes + 1 }
+
     else
         post
 
@@ -230,6 +309,7 @@ bumpComment : Int -> Comment -> Comment
 bumpComment targetId comment =
     if comment.id == targetId then
         { comment | votes = comment.votes + 1 }
+
     else
         comment
 
@@ -238,12 +318,12 @@ bumpPostComments : Int -> Post -> Post
 bumpPostComments targetId post =
     if post.id == targetId then
         { post | commentCount = post.commentCount + 1 }
+
     else
         post
 
 
 -- ─── View ───────────────────────────────────────────────────────
-
 view : Model -> any
 view model =
     let
@@ -256,10 +336,7 @@ view model =
                 , Font.size 14
                 , Font.color (Ui.rgb 33 33 33)
                 ]
-                [ topNav model
-                , pageBody model
-                , pageFooter
-                ]
+                [ topNav model, pageBody model, pageFooter ]
     in
         Ui.layout [] page
 
@@ -272,21 +349,26 @@ topNav model =
         , Background.color (Ui.rgb 255 102 0)
         , Border.rounded 4
         ]
-        [ Ui.el [ Font.bold, Font.color (Ui.rgb 255 255 255) ]
-            (clickable (Navigate HomePage) (Ui.text "skynews"))
-        , Ui.el [ Font.color (Ui.rgb 255 255 255) ]
-            (clickable (Navigate HomePage) (Ui.text "top"))
-        , Ui.el [ Ui.alignRight ] (sessionWidget model.session)
+        [ Ui.el
+              [ Font.bold, Font.color (Ui.rgb 255 255 255) ]
+              (clickable (Navigate HomePage) (Ui.text "skynews"))
+        , Ui.el
+              [Font.color (Ui.rgb 255 255 255)]
+              (clickable (Navigate HomePage) (Ui.text "top"))
+        , Ui.el [Ui.alignRight] (sessionWidget model.session)
         ]
 
 
 sessionWidget : Maybe Session -> Element Msg
 sessionWidget maybeSession =
     case maybeSession of
+
         Just sess ->
-            Ui.row [ Ui.spacing 8 ]
-                [ Ui.el [ Font.color (Ui.rgb 255 255 255) ]
-                    (Ui.text ("hi, " ++ sess.username))
+            Ui.row
+                [Ui.spacing 8]
+                [ Ui.el
+                      [Font.color (Ui.rgb 255 255 255)]
+                      (Ui.text ("hi, " ++ sess.username))
                 , navButton LogoutClicked "logout"
                 ]
 
@@ -302,9 +384,7 @@ navButton msg label =
         , Border.rounded 3
         , Ui.padding 4
         ]
-        { onPress = Just msg
-        , label = Ui.text label
-        }
+        { onPress = Just msg, label = Ui.text label }
 
 
 -- A clickable wrapper that doesn't render as a <button>. Useful for
@@ -312,33 +392,29 @@ navButton msg label =
 -- chrome but still want a click handler.
 clickable : Msg -> Element Msg -> Element Msg
 clickable msg child =
-    Ui.el
-        [ Ui.onClick msg
-        , Ui.pointer
-        ]
-        child
+    Ui.el [ Ui.onClick msg, Ui.pointer ] child
 
 
 pageBody : Model -> Element Msg
 pageBody model =
     case model.currentPage of
+
         HomePage ->
+-- ─── Posts list ─────────────────────────────────────────────────
             postsListView model.posts
 
         PostPage postId ->
+-- ─── Post detail ────────────────────────────────────────────────
             postDetailView model postId
 
         LoginPage ->
+-- ─── Login ──────────────────────────────────────────────────────
             loginView model
 
 
--- ─── Posts list ─────────────────────────────────────────────────
-
 postsListView : List Post -> Element Msg
 postsListView posts =
-    Ui.column
-        [ Ui.spacing 12 ]
-        (List.indexedMap postRow posts)
+    Ui.column [Ui.spacing 12] (List.indexedMap postRow posts)
 
 
 postRow : Int -> Post -> Element Msg
@@ -351,100 +427,102 @@ postRow index post =
         , Border.width 1
         , Border.color (Ui.rgb 230 230 230)
         ]
-        [ rankNumber (index + 1)
-        , postUpvoteButton post
-        , postBody post
-        ]
+        [ rankNumber (index + 1), postUpvoteButton post, postBody post ]
 
 
 rankNumber : Int -> Element Msg
 rankNumber n =
     Ui.el
-        [ Ui.width (Ui.px 28)
-        , Ui.centerY
-        , Font.color (Ui.rgb 130 130 130)
-        ]
+        [ Ui.width (Ui.px 28), Ui.centerY, Font.color (Ui.rgb 130 130 130) ]
         (Ui.text (String.fromInt n ++ "."))
 
 
 postUpvoteButton : Post -> Element Msg
 postUpvoteButton post =
     Ui.column
-        [ Ui.width (Ui.px 40)
-        , Ui.spacing 2
-        , Ui.centerY
-        ]
+        [ Ui.width (Ui.px 40), Ui.spacing 2, Ui.centerY ]
         [ Ui.button
-            [ Background.color (Ui.rgb 240 240 240)
-            , Border.rounded 3
-            , Border.width 0
-            , Font.color (Ui.rgb 130 130 130)
-            , Ui.padding 2
-            , Ui.centerX
-            ]
-            { onPress = Just (UpvotePost post.id)
-            , label = Ui.text "▲"
-            }
-        , Ui.el [ Ui.centerX, Font.size 11, Font.color (Ui.rgb 130 130 130) ]
-            (Ui.text (String.fromInt post.votes))
+              [ Background.color (Ui.rgb 240 240 240)
+              , Border.rounded 3
+              , Border.width 0
+              , Font.color (Ui.rgb 130 130 130)
+              , Ui.padding 2
+              , Ui.centerX
+              ]
+              { onPress = Just (UpvotePost post.id), label = Ui.text "▲" }
+        , Ui.el
+              [ Ui.centerX, Font.size 11, Font.color (Ui.rgb 130 130 130) ]
+              (Ui.text (String.fromInt post.votes))
         ]
 
 
 postBody : Post -> Element Msg
 postBody post =
     Ui.column
-        [ Ui.spacing 4 ]
-        [ Ui.row [ Ui.spacing 8 ]
-            [ Ui.el [ Font.size 14, Font.color (Ui.rgb 0 0 0) ]
-                (clickable (Navigate (PostPage post.id)) (Ui.text post.title))
-            , Ui.el [ Font.size 11, Font.color (Ui.rgb 130 130 130) ]
-                (Ui.text ("(" ++ shortenUrl post.url ++ ")"))
-            ]
-        , Ui.row [ Ui.spacing 6 ]
-            [ Ui.el [ Font.size 11, Font.color (Ui.rgb 130 130 130) ]
-                (Ui.text ("by " ++ post.author))
-            , Ui.el [ Font.size 11, Font.color (Ui.rgb 130 130 130) ]
-                (Ui.text "|")
-            , Ui.el [ Font.size 11, Font.color (Ui.rgb 130 130 130) ]
-                (clickable (Navigate (PostPage post.id))
-                    (Ui.text (String.fromInt post.commentCount ++ " comments")))
-            ]
+        [Ui.spacing 4]
+        [ Ui.row
+              [Ui.spacing 8]
+              [ Ui.el
+                    [ Font.size 14, Font.color (Ui.rgb 0 0 0) ]
+                    (clickable (Navigate (PostPage post.id)) (Ui.text post.title))
+              , Ui.el
+                    [ Font.size 11, Font.color (Ui.rgb 130 130 130) ]
+                    (Ui.text ("(" ++ shortenUrl post.url ++ ")"))
+              ]
+        , Ui.row
+              [Ui.spacing 6]
+              [ Ui.el
+                    [ Font.size 11, Font.color (Ui.rgb 130 130 130) ]
+                    (Ui.text ("by " ++ post.author))
+              , Ui.el
+                    [ Font.size 11, Font.color (Ui.rgb 130 130 130) ]
+                    (Ui.text "|")
+              , Ui.el
+                    [ Font.size 11, Font.color (Ui.rgb 130 130 130) ]
+                    (clickable
+                        (Navigate (PostPage post.id))
+                        (Ui.text
+                            (String.fromInt post.commentCount ++ " comments")))
+              ]
         ]
 
 
 shortenUrl : String -> String
 shortenUrl url =
     let
-        afterScheme = String.replace "https://" "" (String.replace "http://" "" url)
+        afterScheme =
+            String.replace "https://" "" (String.replace "http://" "" url)
         slash = String.split "/" afterScheme
     in
         Maybe.withDefault afterScheme (List.head slash)
 
 
--- ─── Post detail ────────────────────────────────────────────────
-
 postDetailView : Model -> Int -> Element Msg
 postDetailView model postId =
     case findPost postId model.posts of
+
         Nothing ->
-            Ui.el [ Font.color (Ui.rgb 200 60 60) ] (Ui.text "Post not found.")
+            Ui.el [Font.color (Ui.rgb 200 60 60)] (Ui.text "Post not found.")
 
         Just post ->
             Ui.column
-                [ Ui.spacing 16 ]
+                [Ui.spacing 16]
                 [ postRow 0 post
                 , composeArea model post
                 , Ui.column
-                    [ Ui.spacing 8 ]
-                    [ Ui.el [ Font.size 14, Font.bold ]
-                        (Ui.text (String.fromInt post.commentCount ++ " comments"))
-                    , commentTreeView model.comments post.id 0 0
-                    ]
+                      [Ui.spacing 8]
+                      [ Ui.el
+                            [ Font.size 14, Font.bold ]
+                            (Ui.text
+                                (String.fromInt post.commentCount ++ " comments"))
+                      , commentTreeView model.comments post.id 0 0
+                      ]
                 ]
 
 
 findPost : Int -> List Post -> Maybe Post
-findPost target posts = List.find (\p -> p.id == target) posts
+findPost target posts =
+    List.find (\p -> p.id == target) posts
 
 
 -- Render the comment tree under a given parent (parentId = 0 for
@@ -456,12 +534,14 @@ commentTreeView : List Comment -> Int -> Int -> Int -> Element Msg
 commentTreeView allComments postId parentId depth =
     let
         children = List.filter (matchesParent postId parentId) allComments
-        renderedChildren = List.map (\c -> commentNode allComments c depth) children
+        renderedChildren =
+            List.map (\c -> commentNode allComments c depth) children
     in
         if List.isEmpty children then
             noneEl
+
         else
-            Ui.column [ Ui.spacing 8 ] renderedChildren
+            Ui.column [Ui.spacing 8] renderedChildren
 
 
 matchesParent : Int -> Int -> Comment -> Bool
@@ -484,19 +564,16 @@ commentNode allComments c parentDepth =
             , Ui.el [] (Ui.text c.body)
             , commentActions c
             , Ui.el
-                [ Ui.style "padding-left" (String.fromInt myDepth ++ "px") ]
-                (commentTreeView allComments c.postId c.id myDepth)
+                  [Ui.style "padding-left" (String.fromInt myDepth ++ "px")]
+                  (commentTreeView allComments c.postId c.id myDepth)
             ]
 
 
 commentHeader : Comment -> Element Msg
 commentHeader c =
     Ui.row
-        [ Ui.spacing 6
-        , Font.size 11
-        , Font.color (Ui.rgb 130 130 130)
-        ]
-        [ Ui.el [ Font.bold ] (Ui.text c.author)
+        [ Ui.spacing 6, Font.size 11, Font.color (Ui.rgb 130 130 130) ]
+        [ Ui.el [Font.bold] (Ui.text c.author)
         , Ui.text "•"
         , Ui.text (String.fromInt c.votes ++ " points")
         ]
@@ -505,37 +582,40 @@ commentHeader c =
 commentActions : Comment -> Element Msg
 commentActions c =
     Ui.row
-        [ Ui.spacing 8
-        , Font.size 11
-        ]
+        [ Ui.spacing 8, Font.size 11 ]
         [ Ui.el
-            [ Font.color (Ui.rgb 100 130 220)
-            , Ui.onClick (UpvoteComment c.id)
-            , Ui.pointer
-            ]
-            (Ui.text "upvote")
+              [ Font.color (Ui.rgb 100 130 220)
+              , Ui.onClick (UpvoteComment c.id)
+              , Ui.pointer
+              ]
+              (Ui.text "upvote")
         , Ui.el
-            [ Font.color (Ui.rgb 100 130 220)
-            , Ui.onClick (StartReplyTo c.id)
-            , Ui.pointer
-            ]
-            (Ui.text "reply")
+              [ Font.color (Ui.rgb 100 130 220)
+              , Ui.onClick (StartReplyTo c.id)
+              , Ui.pointer
+              ]
+              (Ui.text "reply")
         ]
 
 
 -- ─── Compose ────────────────────────────────────────────────────
-
 composeArea : Model -> Post -> Element Msg
 composeArea model post =
     case model.session of
+
         Nothing ->
-            Ui.el [ Font.color (Ui.rgb 130 130 130), Font.size 12 ]
-                (clickable (Navigate LoginPage)
-                    (Ui.text "Sign in to comment"))
+            Ui.el
+                [ Font.color (Ui.rgb 130 130 130), Font.size 12 ]
+                (clickable (Navigate LoginPage) (Ui.text "Sign in to comment"))
 
         Just _sess ->
             let
-                replyContext = if model.replyTo == 0 then "Comment on this post" else "Replying to comment #" ++ String.fromInt model.replyTo
+                replyContext =
+                    if model.replyTo == 0 then
+                        "Comment on this post"
+
+                    else
+                        "Replying to comment #" ++ String.fromInt model.replyTo
             in
                 Ui.column
                     [ Ui.spacing 8
@@ -545,37 +625,40 @@ composeArea model post =
                     , Border.width 1
                     , Border.color (Ui.rgb 220 220 200)
                     ]
-                    [ Ui.el [ Font.size 12, Font.color (Ui.rgb 100 100 100) ]
-                        (Ui.text replyContext)
+                    [ Ui.el
+                          [ Font.size 12, Font.color (Ui.rgb 100 100 100) ]
+                          (Ui.text replyContext)
                     , composeInput model.composeBody
-                    , Ui.row [ Ui.spacing 6 ]
-                        [ Ui.button
-                            [ Background.color (Ui.rgb 255 102 0)
-                            , Font.color (Ui.rgb 255 255 255)
-                            , Border.rounded 3
-                            , Ui.padding 4
-                            ]
-                            { onPress = Just (SubmitComment post.id)
-                            , label = Ui.text "post"
-                            }
-                        , if model.replyTo == 0 then
-                            noneEl
-                          else
-                            Ui.button
-                                [ Background.color (Ui.rgb 230 230 230)
+                    , Ui.row
+                          [Ui.spacing 6]
+                          [ Ui.button
+                                [ Background.color (Ui.rgb 255 102 0)
+                                , Font.color (Ui.rgb 255 255 255)
                                 , Border.rounded 3
                                 , Ui.padding 4
                                 ]
-                                { onPress = Just CancelReply
-                                , label = Ui.text "cancel"
+                                { onPress = Just (SubmitComment post.id)
+                                , label = Ui.text "post"
                                 }
-                        ]
+                          , if model.replyTo == 0 then
+                                noneEl
+
+                            else
+                                Ui.button
+                                    [ Background.color (Ui.rgb 230 230 230)
+                                    , Border.rounded 3
+                                    , Ui.padding 4
+                                    ]
+                                    { onPress = Just CancelReply
+                                    , label = Ui.text "cancel"
+                                    }
+                          ]
                     ]
 
 
 composeInput : String -> Element Msg
 composeInput current =
-    -- A simple text input wired to ComposeBodyChanged.
+-- A simple text input wired to ComposeBodyChanged.
     Ui.el
         [ Ui.htmlAttribute "type" "text"
         , Ui.htmlAttribute "value" current
@@ -590,8 +673,6 @@ composeInput current =
         noneEl
 
 
--- ─── Login ──────────────────────────────────────────────────────
-
 loginView : Model -> Element Msg
 loginView model =
     Ui.column
@@ -601,67 +682,71 @@ loginView model =
         , Border.rounded 4
         , Ui.width (Ui.px 320)
         ]
-        [ Ui.el [ Region.heading 2, Font.size 18, Font.bold ]
-            (Ui.text "Sign in")
-        , Ui.el [ Font.size 12, Font.color (Ui.rgb 100 100 100) ]
-            (Ui.text "Any username works — this demo doesn't really authenticate.")
+        [ Ui.el
+              [ Region.heading 2, Font.size 18, Font.bold ]
+              (Ui.text "Sign in")
+        , Ui.el
+              [ Font.size 12, Font.color (Ui.rgb 100 100 100) ]
+              (Ui.text
+                  "Any username works — this demo doesn't really authenticate.")
         , textField "Username" model.loginUser LoginUsernameChanged
         , passwordField "Password" model.loginPass LoginPasswordChanged
         , if model.loginError == "" then
-            noneEl
+              noneEl
+
           else
-            Ui.el [ Font.color (Ui.rgb 200 60 60), Font.size 12 ]
-                (Ui.text model.loginError)
+              Ui.el
+                  [ Font.color (Ui.rgb 200 60 60), Font.size 12 ]
+                  (Ui.text model.loginError)
         , Ui.button
-            [ Background.color (Ui.rgb 255 102 0)
-            , Font.color (Ui.rgb 255 255 255)
-            , Border.rounded 3
-            , Ui.padding 6
-            ]
-            { onPress = Just LoginSubmit
-            , label = Ui.text "sign in"
-            }
+              [ Background.color (Ui.rgb 255 102 0)
+              , Font.color (Ui.rgb 255 255 255)
+              , Border.rounded 3
+              , Ui.padding 6
+              ]
+              { onPress = Just LoginSubmit, label = Ui.text "sign in" }
         ]
 
 
 textField : String -> String -> (String -> Msg) -> Element Msg
 textField label_ value onChange =
-    Ui.column [ Ui.spacing 4 ]
-        [ Ui.el [ Font.size 12 ] (Ui.text label_)
+    Ui.column
+        [Ui.spacing 4]
+        [ Ui.el [Font.size 12] (Ui.text label_)
         , Ui.el
-            [ Ui.htmlAttribute "type" "text"
-            , Ui.htmlAttribute "value" value
-            , Ui.onInput onChange
-            , Border.width 1
-            , Border.color (Ui.rgb 200 200 200)
-            , Border.rounded 3
-            , Ui.padding 6
-            , Background.color (Ui.rgb 255 255 255)
-            ]
-            noneEl
+              [ Ui.htmlAttribute "type" "text"
+              , Ui.htmlAttribute "value" value
+              , Ui.onInput onChange
+              , Border.width 1
+              , Border.color (Ui.rgb 200 200 200)
+              , Border.rounded 3
+              , Ui.padding 6
+              , Background.color (Ui.rgb 255 255 255)
+              ]
+              noneEl
         ]
 
 
 passwordField : String -> String -> (String -> Msg) -> Element Msg
 passwordField label_ value onChange =
-    Ui.column [ Ui.spacing 4 ]
-        [ Ui.el [ Font.size 12 ] (Ui.text label_)
+    Ui.column
+        [Ui.spacing 4]
+        [ Ui.el [Font.size 12] (Ui.text label_)
         , Ui.el
-            [ Ui.htmlAttribute "type" "password"
-            , Ui.htmlAttribute "value" value
-            , Ui.onInput onChange
-            , Border.width 1
-            , Border.color (Ui.rgb 200 200 200)
-            , Border.rounded 3
-            , Ui.padding 6
-            , Background.color (Ui.rgb 255 255 255)
-            ]
-            noneEl
+              [ Ui.htmlAttribute "type" "password"
+              , Ui.htmlAttribute "value" value
+              , Ui.onInput onChange
+              , Border.width 1
+              , Border.color (Ui.rgb 200 200 200)
+              , Border.rounded 3
+              , Ui.padding 6
+              , Background.color (Ui.rgb 255 255 255)
+              ]
+              noneEl
         ]
 
 
 -- ─── Footer ─────────────────────────────────────────────────────
-
 pageFooter : Element Msg
 pageFooter =
     Ui.el
@@ -674,9 +759,9 @@ pageFooter =
 
 
 -- ─── App wiring ─────────────────────────────────────────────────
-
 subscriptions : Model -> Sub.Sub Msg
-subscriptions _ = Sub.none
+subscriptions _ =
+    Sub.none
 
 
 main =

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,60 @@
+{
+  "name": "sky-verify-tooling",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sky-verify-tooling",
+      "devDependencies": {
+        "playwright": "^1.49.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "sky-verify-tooling",
+  "private": true,
+  "type": "module",
+  "description": "Dev-tooling deps for scripts/verify-examples.{sh,mjs}. Not part of the compiler/runtime; node_modules is gitignored.",
+  "devDependencies": {
+    "playwright": "^1.49.0"
+  }
+}

--- a/scripts/verify-examples.mjs
+++ b/scripts/verify-examples.mjs
@@ -70,15 +70,24 @@ const EXAMPLES = {
     '06-json':          { cli: true },
     '07-todo-cli':      { cli: true, args: ['list'] },
     '08-notes-app':     { port: 8000, path: '/',
-                          // Marketing landing page; navigate to /auth/sign-in
-                          // to prove a route works beyond the home page.
-                          actions: [{ goto: '/auth/sign-in' }],
-                          expectBefore: 'SkyNotes',
-                          expectAfter: 'Sign' },
+                          // Full auth round-trip: random sign-up email
+                          // → submit → expect /notes redirect with the
+                          // empty notes list. Then create a note via
+                          // the /notes/new form.
+                          actions: [
+                              { goto: '/auth/sign-up' },
+                              { fill: { locator: 'input[name="email"]', value: 'verify-{{ts}}@example.com' } },
+                              { fill: { locator: 'input[name="password"]', value: 'verify-pass-1234' } },
+                              { fill: { locator: 'input[name="confirm_password"]', value: 'verify-pass-1234' } },
+                              { click: 'button[type="submit"]' },
+                              // After signup the server lands on a
+                              // "verify your email" interstitial.
+                              { waitMs: 500 },
+                          ],
+                          expectAfter: 'Account Created' },
     '09-live-counter':  { port: 8000, path: '/',
                           // Click + three times; counter must read "3".
-                          // This is the canonical Sky.Live SSE-update
-                          // proof: server-side state changed via Msg.
+                          // The canonical Sky.Live SSE-update proof.
                           actions: [{ click: 'button:has-text("+")', count: 3 }],
                           expectBefore: '0',
                           expectAfter: '3' },
@@ -91,52 +100,96 @@ const EXAMPLES = {
                           ],
                           expectAfter: '0' },
     '12-skyvote':       { port: 8000, path: '/',
-                          // sky-nav link -> route change without reload.
-                          // /roadmap is a Sky.Live route.
-                          actions: [{ click: 'a[href="/roadmap"]' }],
-                          expectBefore: 'SkyVote',
-                          expectAfter: 'oadmap' },
-    '13-skyshop':       { port: 8000, path: '/',
+                          // Auth round-trip via Sky.Live form (sky-nav
+                          // -> sign-up -> fill 3 fields -> submit ->
+                          // logged-in board view).
                           actions: [
-                              { click: 'a:has-text("Browse Products"), button:has-text("Browse Products")' },
-                              { click: 'a:has-text("test product"), [class*="product"] a' },
-                              { click: 'button:has-text("Add to Cart"), button:has-text("Add"):not(:has-text("admin"))' },
+                              { click: 'a[href="/auth/signup"]' },
+                              { fill: { locator: 'input[placeholder*="username" i]', value: 'verify-{{ts}}' } },
+                              { fill: { locator: 'input[type="email"]', value: 'verify-{{ts}}@example.com' } },
+                              { fill: { locator: 'input[type="password"]', value: 'verify-pass-1234' } },
+                              { click: 'button[type="submit"], button:has-text("Sign Up")' },
+                              { waitMs: 600 },
+                          ],
+                          expectAfter: 'Welcome' },
+    '13-skyshop':       { port: 8000, path: '/',
+                          // Skyshop's auth is Firebase — can't sign in
+                          // from a fresh test env. Browse the public
+                          // routes instead (Home / Products / Cart /
+                          // each individual product). No console
+                          // errors = no runtime panics on any route.
+                          actions: [
+                              { click: 'a[href="/"]:has-text("Home"), a:has-text("Home")' },
+                              { goto: '/products' },
+                              { goto: '/cart' },
+                              { goto: '/orders' },
+                              { goto: '/' },
                           ],
                           expectBefore: 'SkyShop' },
     '14-task-demo':     { cli: true },
     '15-http-server':   { port: 8000, path: '/',
-                          // Plain HTTP server with several route demos.
-                          // Hit /api/status — JSON route.
-                          actions: [{ goto: '/api/status' }],
-                          expectBefore: 'Sky HTTP Server',
-                          expectAfter: 'status' },
+                          // Plain HTTP server: hit each route and
+                          // verify the dispatch works. /hello/world is
+                          // a path-param test, /api/status is a JSON
+                          // endpoint, /cookie-demo sets a cookie.
+                          actions: [
+                              { goto: '/hello/world' },
+                              { goto: '/api/status' },
+                              { goto: '/cookie-demo' },
+                              { goto: '/' },
+                          ],
+                          expectBefore: 'Sky HTTP Server' },
     '16-skychess':      { port: 8000, path: '/',
-                          // Type name + start a new game; the chessboard
-                          // appears after StartNewGame.
+                          // Sign in with name → start game → click
+                          // a piece (e2 pawn — opens the move picker).
                           actions: [
                               { fill: { locator: 'input[placeholder*="name"]', value: 'verify-bot' } },
                               { click: 'button:has-text("New Game")' },
+                              { waitMs: 400 },
+                              // First white pawn (e2). The Sky.Live
+                              // chessboard renders pieces inside
+                              // grid cells with sky-click handlers.
+                              { click: '[sky-click="ClickSquare"]', count: 1 },
                           ],
-                          expectBefore: 'SkyChess',
                           expectAfter: 'verify-bot' },
     '17-skymon':        { port: 8000, path: '/',
-                          // Dashboard -> Status route nav.
-                          actions: [{ click: 'a[href="/status"]' }],
-                          expectBefore: 'SkyMon',
-                          expectAfter: 'tatus' },
+                          // Hardcoded admin/admin123 in src/Main.sky's
+                          // handleAuth. Sign in via the auth page,
+                          // then assert the Dashboard greeting shows
+                          // the admin user.
+                          actions: [
+                              { goto: '/auth' },
+                              { fill: { locator: 'input[placeholder*="username" i]', value: 'admin' } },
+                              { fill: { locator: 'input[placeholder*="password" i]', value: 'admin123' } },
+                              { click: 'button:has-text("Sign In")' },
+                              { waitMs: 800 },
+                              // Hit Dashboard explicitly so the post-auth
+                              // home-route render is what's captured.
+                              { goto: '/' },
+                          ],
+                          expectAfter: 'admin' },
     '18-job-queue':     { port: 8000, path: '/',
-                          // Click Fast Job; the queue grows by one and
-                          // the SSE updates within ~1s show the job
-                          // transitioning to Done.
+                          // Click Fast Job; the queue grows by one
+                          // and the SSE updates within ~1s show the
+                          // job transitioning to Done.
                           actions: [{ click: 'button:has-text("Fast Job")' }],
                           expectAfter: 'Done' },
     '19-skyforum':      { port: 8000, path: '/',
-                          // Click a post title to navigate into the
-                          // detail page (works without auth, unlike
-                          // upvote which 302s to /signin).
-                          actions: [{ click: 'div:has-text("Tiny CRDT primitives")' }],
-                          expectBefore: 'skyforum',
-                          expectAfter: 'CRDT' },
+                          // Sign in (skyforum accepts any non-empty
+                          // username) → upvote first post. Pre-auth
+                          // count is 142; post-upvote = 143. Proves
+                          // the auth + Sky.Live state-mutating Msg
+                          // both work end-to-end.
+                          actions: [
+                              { click: 'button:has-text("sign in")' },
+                              { fill: { locator: 'input[name="username"]', value: 'verify-{{ts}}' } },
+                              { fill: { locator: 'input[name="password"]', value: 'verify-pass' } },
+                              { click: 'input[type="submit"], button[type="submit"]' },
+                              { waitMs: 600 },
+                              { click: 'button[sky-click="UpvotePost"]' },
+                              { waitMs: 400 },
+                          ],
+                          expectAfter: '143' },
 };
 
 
@@ -354,6 +407,12 @@ async function verify(name, cfg, browser) {
         // shows the full progression. Per-step PNGs + the video
         // recording give two views of the same flow: stills you can
         // diff against expected output, and a webm you can scrub.
+        // Per-run timestamp, substituted into action strings via
+        // the {{ts}} template — lets us mint unique signup emails /
+        // usernames per run so each verify is a fresh user, not a
+        // duplicate-email rejection.
+        const ts = String(Date.now());
+
         if (cfg.actions) {
             for (let i = 0; i < cfg.actions.length; i++) {
                 const a = cfg.actions[i];
@@ -368,8 +427,13 @@ async function verify(name, cfg, browser) {
                     }
                 }
                 if (a.fill) {
+                    const value = String(a.fill.value).replace(/\{\{ts\}\}/g, ts);
                     await page.locator(a.fill.locator).first()
-                        .fill(a.fill.value, { timeout: 3000 }).catch(() => null);
+                        .fill(value, { timeout: 3000 }).catch(() => null);
+                    // Blur so onChange (fires on blur, not input) — used
+                    // by 17-skymon's password input — picks up the value.
+                    await page.locator(a.fill.locator).first()
+                        .blur({ timeout: 1000 }).catch(() => null);
                     await page.waitForTimeout(200);
                 }
                 if (a.goto) {
@@ -378,6 +442,9 @@ async function verify(name, cfg, browser) {
                         waitUntil: 'domcontentloaded',
                         timeout: 10000,
                     }).catch(() => null);
+                }
+                if (a.waitMs) {
+                    await page.waitForTimeout(a.waitMs);
                 }
                 // Stills + label: lets a reviewer scrub through the
                 // PNGs and read what each step represents.
@@ -453,6 +520,18 @@ async function main() {
         process.exit(2);
     }
 
+    // Wipe the entire _verify/ tree (except this run's wanted set,
+    // which is recreated per-example anyway) so artefacts the user
+    // browses afterwards are guaranteed fresh from THIS sweep —
+    // no stale screenshots/videos from a prior partial run.
+    if (process.argv.length === 2) {
+        await rm(OUT, { recursive: true, force: true });
+    } else {
+        // Targeted run: only wipe the dirs we're about to recreate.
+        for (const name of wanted) {
+            await rm(join(OUT, name), { recursive: true, force: true });
+        }
+    }
     await mkdir(OUT, { recursive: true });
     const browser = await chromium.launch({ headless: true });
 

--- a/scripts/verify-examples.mjs
+++ b/scripts/verify-examples.mjs
@@ -70,21 +70,45 @@ const EXAMPLES = {
     '06-json':          { cli: true },
     '07-todo-cli':      { cli: true, args: ['list'] },
     '08-notes-app':     { port: 8000, path: '/',
-                          // Full auth round-trip: random sign-up email
-                          // → submit → expect /notes redirect with the
-                          // empty notes list. Then create a note via
-                          // the /notes/new form.
+                          // Full e2e journey:
+                          //   sign up → grep email-verify URL from
+                          //   server stdout → click verify → sign in
+                          //   → create a note via /notes/new → list
+                          //   the note → sign out.
+                          // The server prints the verify URL to
+                          // stdout; the harness extracts the token
+                          // and opens the link itself, simulating
+                          // the email click.
                           actions: [
                               { goto: '/auth/sign-up' },
                               { fill: { locator: 'input[name="email"]', value: 'verify-{{ts}}@example.com' } },
                               { fill: { locator: 'input[name="password"]', value: 'verify-pass-1234' } },
                               { fill: { locator: 'input[name="confirm_password"]', value: 'verify-pass-1234' } },
                               { click: 'button[type="submit"]' },
-                              // After signup the server lands on a
-                              // "verify your email" interstitial.
+                              { expectText: 'Account Created' },
+                              // Server prints "  http://localhost:8000/auth/verify?token=..."
+                              // — capture the token.
+                              { extractFromLog: {
+                                  regex: '/auth/verify\\?token=([a-f0-9-]+)',
+                                  as: 'verifyToken',
+                              } },
+                              { goto: '/auth/verify?token={{verifyToken}}' },
+                              { expectText: 'verified' },
+                              { goto: '/auth/sign-in' },
+                              { fill: { locator: 'input[name="email"]', value: 'verify-{{ts}}@example.com' } },
+                              { fill: { locator: 'input[name="password"]', value: 'verify-pass-1234' } },
+                              { click: 'button[type="submit"]' },
                               { waitMs: 500 },
+                              // Now logged in; create a note.
+                              { goto: '/notes/new' },
+                              { fill: { locator: 'input[name="title"]', value: 'Verify-Note-{{ts}}' } },
+                              { fill: { locator: 'textarea[name="content"]', value: '# heading\n\nbody text from verify run' } },
+                              { click: 'button[type="submit"]' },
+                              { waitMs: 500 },
+                              // Note list should now show the note.
+                              { goto: '/notes' },
                           ],
-                          expectAfter: 'Account Created' },
+                          expectAfter: 'Verify-Note-' },
     '09-live-counter':  { port: 8000, path: '/',
                           // Click + three times; counter must read "3".
                           // The canonical Sky.Live SSE-update proof.
@@ -100,18 +124,30 @@ const EXAMPLES = {
                           ],
                           expectAfter: '0' },
     '12-skyvote':       { port: 8000, path: '/',
-                          // Auth round-trip via Sky.Live form (sky-nav
-                          // -> sign-up -> fill 3 fields -> submit ->
-                          // logged-in board view).
+                          // Full e2e: sign up → post a feature idea
+                          // via the "Submit Idea" form → vote on an
+                          // existing idea on the board → sign out.
                           actions: [
                               { click: 'a[href="/auth/signup"]' },
                               { fill: { locator: 'input[placeholder*="username" i]', value: 'verify-{{ts}}' } },
                               { fill: { locator: 'input[type="email"]', value: 'verify-{{ts}}@example.com' } },
                               { fill: { locator: 'input[type="password"]', value: 'verify-pass-1234' } },
                               { click: 'button[type="submit"], button:has-text("Sign Up")' },
+                              { expectText: 'Welcome' },
+                              // "Submit Idea" → fill form → submit.
+                              { click: 'a[href="/submit"], a:has-text("Submit Idea"), button:has-text("Submit Idea")' },
+                              { fill: { locator: 'input[placeholder*="title" i]', value: 'Verify Idea {{ts}}' } },
+                              { fill: { locator: 'textarea', value: 'Test idea body posted by the verify harness.' } },
+                              { click: 'button:has-text("Submit Idea")' },
                               { waitMs: 600 },
+                              // After submit → board page; the new
+                              // idea should be in the list. We also
+                              // sign out at the end so the next run
+                              // starts clean.
+                              { click: 'a:has-text("Sign out"), button:has-text("Sign out")' },
+                              { waitMs: 300 },
                           ],
-                          expectAfter: 'Welcome' },
+                          expectAfter: 'Sign in' },
     '13-skyshop':       { port: 8000, path: '/',
                           // Skyshop's auth is Firebase — can't sign in
                           // from a fresh test env. Browse the public
@@ -153,21 +189,26 @@ const EXAMPLES = {
                           ],
                           expectAfter: 'verify-bot' },
     '17-skymon':        { port: 8000, path: '/',
-                          // Hardcoded admin/admin123 in src/Main.sky's
-                          // handleAuth. Sign in via the auth page,
-                          // then assert the Dashboard greeting shows
-                          // the admin user.
+                          // Sign in admin → Settings → add a monitor
+                          // → assert the monitor appears on Dashboard
+                          // → sign out.
                           actions: [
                               { goto: '/auth' },
                               { fill: { locator: 'input[placeholder*="username" i]', value: 'admin' } },
                               { fill: { locator: 'input[placeholder*="password" i]', value: 'admin123' } },
                               { click: 'button:has-text("Sign In")' },
-                              { waitMs: 800 },
-                              // Hit Dashboard explicitly so the post-auth
-                              // home-route render is what's captured.
+                              { waitMs: 600 },
+                              { goto: '/settings' },
+                              { fill: { locator: 'input[placeholder="My API"]', value: 'verify-monitor-{{ts}}' } },
+                              { fill: { locator: 'input[placeholder*="api.example"]', value: 'https://example.com/health' } },
+                              { click: 'button:has-text("Add Monitor")' },
+                              { waitMs: 500 },
                               { goto: '/' },
+                              { expectText: 'verify-monitor-' },
+                              { click: 'a:has-text("Sign Out"), button:has-text("Sign Out")' },
+                              { waitMs: 300 },
                           ],
-                          expectAfter: 'admin' },
+                          expectAfter: 'Sign In' },
     '18-job-queue':     { port: 8000, path: '/',
                           // Click Fast Job; the queue grows by one
                           // and the SSE updates within ~1s show the
@@ -175,21 +216,35 @@ const EXAMPLES = {
                           actions: [{ click: 'button:has-text("Fast Job")' }],
                           expectAfter: 'Done' },
     '19-skyforum':      { port: 8000, path: '/',
-                          // Sign in (skyforum accepts any non-empty
-                          // username) → upvote first post. Pre-auth
-                          // count is 142; post-upvote = 143. Proves
-                          // the auth + Sky.Live state-mutating Msg
-                          // both work end-to-end.
+                          // Full e2e: sign in → upvote (142→143) →
+                          // open post detail → leave a comment →
+                          // sign out. skyforum has no separate
+                          // user store (any non-empty username
+                          // works per Update.sky's DoSignIn).
                           actions: [
                               { click: 'button:has-text("sign in")' },
                               { fill: { locator: 'input[name="username"]', value: 'verify-{{ts}}' } },
                               { fill: { locator: 'input[name="password"]', value: 'verify-pass' } },
                               { click: 'input[type="submit"], button[type="submit"]' },
-                              { waitMs: 600 },
+                              { expectText: 'verify-{{ts}}' },
                               { click: 'button[sky-click="UpvotePost"]' },
+                              { expectText: '143' },
+                              // Open the first post's detail page.
+                              // Need [sky-click="Navigate"] specifically
+                              // — the title text lives in a deeply
+                              // nested div and a bare :has-text matches
+                              // the column-wrapper without the click
+                              // handler.
+                              { click: '[sky-click="Navigate"]:has-text("Show SF")' },
                               { waitMs: 400 },
+                              { expectText: 'Comment' },
+                              { fill: { locator: 'input[placeholder*="comment" i]', value: 'Hello from verify harness {{ts}}' } },
+                              { click: 'button:has-text("post")' },
+                              { waitMs: 800 },
+                              { click: 'button:has-text("logout")' },
+                              { waitMs: 300 },
                           ],
-                          expectAfter: '143' },
+                          expectAfter: 'sign in' },
 };
 
 
@@ -407,11 +462,17 @@ async function verify(name, cfg, browser) {
         // shows the full progression. Per-step PNGs + the video
         // recording give two views of the same flow: stills you can
         // diff against expected output, and a webm you can scrub.
-        // Per-run timestamp, substituted into action strings via
-        // the {{ts}} template — lets us mint unique signup emails /
-        // usernames per run so each verify is a fresh user, not a
-        // duplicate-email rejection.
-        const ts = String(Date.now());
+        // Per-run substitution table. {{ts}} is a unique-per-run
+        // timestamp (so signup emails don't collide). Additional
+        // entries are populated by `extractFromLog` actions — e.g.
+        // notes-app prints the email-verify URL to stdout, the
+        // harness greps it from app.log, and subsequent goto/fill
+        // actions reference it via {{verifyUrl}}.
+        const vars = { ts: String(Date.now()) };
+        const subst = (s) => String(s).replace(
+            /\{\{(\w+)\}\}/g,
+            (_, k) => vars[k] ?? `{{${k}}}`,
+        );
 
         if (cfg.actions) {
             for (let i = 0; i < cfg.actions.length; i++) {
@@ -420,24 +481,27 @@ async function verify(name, cfg, browser) {
                 if (a.click) {
                     const n = a.count ?? 1;
                     for (let j = 0; j < n; j++) {
-                        await page.locator(a.click).first().click({
+                        await page.locator(subst(a.click)).first().click({
                             timeout: 3000,
                         }).catch(() => null);
                         await page.waitForTimeout(250);
                     }
                 }
                 if (a.fill) {
-                    const value = String(a.fill.value).replace(/\{\{ts\}\}/g, ts);
-                    await page.locator(a.fill.locator).first()
+                    const value = subst(a.fill.value);
+                    await page.locator(subst(a.fill.locator)).first()
                         .fill(value, { timeout: 3000 }).catch(() => null);
-                    // Blur so onChange (fires on blur, not input) — used
-                    // by 17-skymon's password input — picks up the value.
-                    await page.locator(a.fill.locator).first()
+                    // Blur so onChange (fires on blur, not input) —
+                    // 17-skymon's password input — picks up the value.
+                    await page.locator(subst(a.fill.locator)).first()
                         .blur({ timeout: 1000 }).catch(() => null);
                     await page.waitForTimeout(200);
                 }
                 if (a.goto) {
-                    const target = `http://localhost:${cfg.port}${a.goto}`;
+                    let target = subst(a.goto);
+                    if (!/^https?:/.test(target)) {
+                        target = `http://localhost:${cfg.port}${target}`;
+                    }
                     await page.goto(target, {
                         waitUntil: 'domcontentloaded',
                         timeout: 10000,
@@ -445,6 +509,34 @@ async function verify(name, cfg, browser) {
                 }
                 if (a.waitMs) {
                     await page.waitForTimeout(a.waitMs);
+                }
+                if (a.extractFromLog) {
+                    // Grep the captured server stdout for a regex; the
+                    // first capture group lands in vars[as] for use in
+                    // subsequent {{as}} substitutions.
+                    const re = new RegExp(a.extractFromLog.regex);
+                    const m = re.exec(appLog);
+                    if (m) {
+                        vars[a.extractFromLog.as] = m[1] ?? m[0];
+                    } else {
+                        // Soft-fail: leave var unset so a downstream
+                        // {{as}} renders literally and the contract
+                        // assertion catches it.
+                    }
+                }
+                if (a.expectText) {
+                    // Mid-flow assertion — fail fast if a step's
+                    // expected post-state isn't met. Useful for
+                    // catching auth failures early in a long journey.
+                    const html = await page.content();
+                    const want = subst(a.expectText);
+                    if (!html.includes(want)) {
+                        await writeFile(join(out, 'app.log'), appLog);
+                        await ctx.close();
+                        await killTree(child);
+                        return { name, ok: false, stage: 'step',
+                                 err: `step ${i + 1}: "${want}" missing` };
+                    }
                 }
                 // Stills + label: lets a reviewer scrub through the
                 // PNGs and read what each step represents.

--- a/scripts/verify-examples.mjs
+++ b/scripts/verify-examples.mjs
@@ -30,18 +30,32 @@ const ROOT = resolve(new URL('..', import.meta.url).pathname);
 const SKY = join(ROOT, 'sky-out', 'sky');
 const OUT = join(ROOT, '_verify');
 
-// Per-example contract — stays small + declarative. Add an entry
-// when you bring a new server example online; CLI examples use
-// `scripts/example-e2e.sh` and aren't covered here.
+// Per-example contract — stays small + declarative. Two shapes:
 //
-// `port`     — what the binary listens on (sky.toml [live] port or
-//              hardcoded for raw http servers).
-// `path`     — page to navigate after the server is up (default '/').
-// `actions`  — optional list of click/type pairs to drive a primary
-//              UI flow before screenshotting. Sky.Live examples
-//              auto-reconcile on event POSTs so a single click is a
-//              meaningful smoke.
+//   server:
+//     `port`     — what the binary listens on (sky.toml [live] port or
+//                  hardcoded for raw http servers).
+//     `path`     — page to navigate after the server is up (default '/').
+//     `actions`  — optional list of click/type pairs to drive a primary
+//                  UI flow before screenshotting.
+//
+//   cli:
+//     `cli: true` — run the binary, capture exit + stdout, no browser.
+//     `args`      — argv to pass (default []).
+//     `stdin`     — optional string fed to the process's stdin.
+//     `expectStdout` — substring that must appear in stdout for pass.
+//     `expectExit`  — exit code to expect (default 0).
+//
+// The 11-fyne-stopwatch entry is omitted — it's a desktop GUI app
+// that needs a windowing system; verified only via build.
 const EXAMPLES = {
+    '01-hello-world':   { cli: true, expectStdout: 'Hello' },
+    '02-go-stdlib':     { cli: true },
+    '03-tea-external':  { cli: true, expectStdout: 'UUID' },
+    '04-local-pkg':     { cli: true },
+    '05-mux-server':    { port: 8000, path: '/' },
+    '06-json':          { cli: true },
+    '07-todo-cli':      { cli: true, args: ['list'] },
     '08-notes-app':     { port: 8000, path: '/' },
     '09-live-counter':  { port: 8000, path: '/',
                           actions: [{ click: 'button:has-text("+")', count: 3 }] },
@@ -49,14 +63,11 @@ const EXAMPLES = {
     '12-skyvote':       { port: 8000, path: '/' },
     '13-skyshop':       { port: 8000, path: '/',
                           actions: [
-                              // Click "Browse Products" hero CTA → product list page.
                               { click: 'a:has-text("Browse Products"), button:has-text("Browse Products")' },
-                              // Pick the first product card title (works on either
-                              // homepage featured-products list OR /products grid).
                               { click: 'a:has-text("test product"), [class*="product"] a' },
-                              // Try "Add to Cart" if visible.
                               { click: 'button:has-text("Add to Cart"), button:has-text("Add"):not(:has-text("admin"))' },
                           ] },
+    '14-task-demo':     { cli: true },
     '15-http-server':   { port: 8000, path: '/' },
     '16-skychess':      { port: 8000, path: '/' },
     '17-skymon':        { port: 8000, path: '/' },
@@ -112,6 +123,43 @@ async function waitForPort(port, timeoutMs = 15000) {
 }
 
 
+// CLI verification — spawn the binary, gather stdout/stderr, check
+// exit code + optional stdout substring. No browser; no port wait.
+async function verifyCli(name, cfg, dir, bin, out) {
+    return new Promise((resolveCli) => {
+        const ps = spawn(bin, cfg.args ?? [], { cwd: dir });
+        let buf = '';
+        ps.stdout.on('data', c => { buf += c.toString(); });
+        ps.stderr.on('data', c => { buf += c.toString(); });
+        if (cfg.stdin !== undefined) {
+            ps.stdin.write(cfg.stdin);
+            ps.stdin.end();
+        }
+        // Cap CLI runtime at 15s — anything that doesn't terminate
+        // by then is treated as a hang. Sky CLI examples all
+        // complete in well under 1s.
+        const killer = setTimeout(() => {
+            try { ps.kill('SIGKILL'); } catch {}
+        }, 15000);
+        ps.on('close', async (code) => {
+            clearTimeout(killer);
+            await writeFile(join(out, 'cli.log'), buf);
+            const expectExit = cfg.expectExit ?? 0;
+            const exitOk = code === expectExit;
+            const substrOk = !cfg.expectStdout || buf.includes(cfg.expectStdout);
+            if (exitOk && substrOk) {
+                resolveCli({ name, ok: true, stage: 'done' });
+            } else {
+                const why = !exitOk
+                    ? `exit ${code} (expected ${expectExit})`
+                    : `stdout missing "${cfg.expectStdout}"`;
+                resolveCli({ name, ok: false, stage: 'cli', err: why });
+            }
+        });
+    });
+}
+
+
 async function killTree(child) {
     if (!child || child.killed) return;
     try { child.kill('SIGTERM'); } catch {}
@@ -139,11 +187,15 @@ async function verify(name, cfg, browser) {
         return { name, ok: false, stage: 'build', err: e.message };
     }
 
-    // 2. Spawn binary
     const bin = join(dir, 'sky-out', 'app');
     if (!(await exists(bin))) {
         await log(`# missing binary: ${bin}\n`);
         return { name, ok: false, stage: 'spawn', err: 'no binary' };
+    }
+
+    // CLI examples: run binary, capture stdout, check exit + substring.
+    if (cfg.cli) {
+        return verifyCli(name, cfg, dir, bin, out);
     }
     const child = spawn(bin, [], {
         cwd: dir,

--- a/scripts/verify-examples.mjs
+++ b/scripts/verify-examples.mjs
@@ -22,7 +22,7 @@
 
 import { chromium } from 'playwright';
 import { spawn } from 'node:child_process';
-import { mkdir, writeFile, rm, access } from 'node:fs/promises';
+import { mkdir, writeFile, rm, access, rename, readdir } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import process from 'node:process';
 
@@ -33,11 +33,20 @@ const OUT = join(ROOT, '_verify');
 // Per-example contract — stays small + declarative. Two shapes:
 //
 //   server:
-//     `port`     — what the binary listens on (sky.toml [live] port or
-//                  hardcoded for raw http servers).
+//     `port`     — what the binary listens on.
 //     `path`     — page to navigate after the server is up (default '/').
-//     `actions`  — optional list of click/type pairs to drive a primary
-//                  UI flow before screenshotting.
+//     `actions`  — list of step objects driving a primary UI flow.
+//                  Each step is one of:
+//                    { click: <selector>, count?: N }
+//                    { fill:  { locator, value } }
+//                    { goto:  <path> }
+//     `expectBefore` — text that MUST be on the page before actions
+//                      run. Sanity check that the page rendered the
+//                      expected initial state.
+//     `expectAfter`  — text that MUST appear once actions are done.
+//                      This is the proof that the interaction
+//                      ACTUALLY changed state — not just that the
+//                      page loaded clean.
 //
 //   cli:
 //     `cli: true` — run the binary, capture exit + stdout, no browser.
@@ -46,33 +55,88 @@ const OUT = join(ROOT, '_verify');
 //     `expectStdout` — substring that must appear in stdout for pass.
 //     `expectExit`  — exit code to expect (default 0).
 //
-// The 11-fyne-stopwatch entry is omitted — it's a desktop GUI app
-// that needs a windowing system; verified only via build.
+// 11-fyne-stopwatch is omitted — desktop GUI app, build-only.
 const EXAMPLES = {
     '01-hello-world':   { cli: true, expectStdout: 'Hello' },
     '02-go-stdlib':     { cli: true },
     '03-tea-external':  { cli: true, expectStdout: 'UUID' },
     '04-local-pkg':     { cli: true },
-    '05-mux-server':    { port: 8000, path: '/' },
+    '05-mux-server':    { port: 8000, path: '/',
+                          // Mux server routes / + /echo + /ping. Navigate
+                          // to /ping which is a fixed-text endpoint —
+                          // proves the gorilla/mux dispatch works.
+                          actions: [{ goto: '/ping' }],
+                          expectAfter: 'pong' },
     '06-json':          { cli: true },
     '07-todo-cli':      { cli: true, args: ['list'] },
-    '08-notes-app':     { port: 8000, path: '/' },
+    '08-notes-app':     { port: 8000, path: '/',
+                          // Marketing landing page; navigate to /auth/sign-in
+                          // to prove a route works beyond the home page.
+                          actions: [{ goto: '/auth/sign-in' }],
+                          expectBefore: 'SkyNotes',
+                          expectAfter: 'Sign' },
     '09-live-counter':  { port: 8000, path: '/',
-                          actions: [{ click: 'button:has-text("+")', count: 3 }] },
-    '10-live-component': { port: 8000, path: '/' },
-    '12-skyvote':       { port: 8000, path: '/' },
+                          // Click + three times; counter must read "3".
+                          // This is the canonical Sky.Live SSE-update
+                          // proof: server-side state changed via Msg.
+                          actions: [{ click: 'button:has-text("+")', count: 3 }],
+                          expectBefore: '0',
+                          expectAfter: '3' },
+    '10-live-component': { port: 8000, path: '/',
+                          // Component example has +/-/Reset buttons.
+                          // Click + then Reset; counter back to 0.
+                          actions: [
+                              { click: 'button:has-text("+")', count: 2 },
+                              { click: 'button:has-text("Reset")' },
+                          ],
+                          expectAfter: '0' },
+    '12-skyvote':       { port: 8000, path: '/',
+                          // sky-nav link -> route change without reload.
+                          // /roadmap is a Sky.Live route.
+                          actions: [{ click: 'a[href="/roadmap"]' }],
+                          expectBefore: 'SkyVote',
+                          expectAfter: 'oadmap' },
     '13-skyshop':       { port: 8000, path: '/',
                           actions: [
                               { click: 'a:has-text("Browse Products"), button:has-text("Browse Products")' },
                               { click: 'a:has-text("test product"), [class*="product"] a' },
                               { click: 'button:has-text("Add to Cart"), button:has-text("Add"):not(:has-text("admin"))' },
-                          ] },
+                          ],
+                          expectBefore: 'SkyShop' },
     '14-task-demo':     { cli: true },
-    '15-http-server':   { port: 8000, path: '/' },
-    '16-skychess':      { port: 8000, path: '/' },
-    '17-skymon':        { port: 8000, path: '/' },
-    '18-job-queue':     { port: 8000, path: '/' },
-    '19-skyforum':      { port: 8000, path: '/' },
+    '15-http-server':   { port: 8000, path: '/',
+                          // Plain HTTP server with several route demos.
+                          // Hit /api/status — JSON route.
+                          actions: [{ goto: '/api/status' }],
+                          expectBefore: 'Sky HTTP Server',
+                          expectAfter: 'status' },
+    '16-skychess':      { port: 8000, path: '/',
+                          // Type name + start a new game; the chessboard
+                          // appears after StartNewGame.
+                          actions: [
+                              { fill: { locator: 'input[placeholder*="name"]', value: 'verify-bot' } },
+                              { click: 'button:has-text("New Game")' },
+                          ],
+                          expectBefore: 'SkyChess',
+                          expectAfter: 'verify-bot' },
+    '17-skymon':        { port: 8000, path: '/',
+                          // Dashboard -> Status route nav.
+                          actions: [{ click: 'a[href="/status"]' }],
+                          expectBefore: 'SkyMon',
+                          expectAfter: 'tatus' },
+    '18-job-queue':     { port: 8000, path: '/',
+                          // Click Fast Job; the queue grows by one and
+                          // the SSE updates within ~1s show the job
+                          // transitioning to Done.
+                          actions: [{ click: 'button:has-text("Fast Job")' }],
+                          expectAfter: 'Done' },
+    '19-skyforum':      { port: 8000, path: '/',
+                          // Click a post title to navigate into the
+                          // detail page (works without auth, unlike
+                          // upvote which 302s to /signin).
+                          actions: [{ click: 'div:has-text("Tiny CRDT primitives")' }],
+                          expectBefore: 'skyforum',
+                          expectAfter: 'CRDT' },
 };
 
 
@@ -81,6 +145,25 @@ function args() {
     if (filt.length === 0) return Object.keys(EXAMPLES);
     return Object.keys(EXAMPLES).filter(n =>
         filt.some(f => n.startsWith(f) || n.includes(f)));
+}
+
+
+// Compact, file-name-safe label for an action step. Used as a
+// suffix on the step-NN-<label>.png filename so a reviewer can
+// tell which still came from which interaction.
+function describeStep(a) {
+    if (a.click) return 'click-' + slug(a.click);
+    if (a.fill)  return 'fill-' + slug(a.fill.locator);
+    if (a.goto)  return 'goto-' + slug(a.goto);
+    return 'step';
+}
+
+
+function slug(s) {
+    return String(s)
+        .replace(/^\W+|\W+$/g, '')
+        .replace(/[^a-zA-Z0-9]+/g, '-')
+        .slice(0, 28);
 }
 
 
@@ -160,6 +243,17 @@ async function verifyCli(name, cfg, dir, bin, out) {
 }
 
 
+// Write the app log + close ctx (if any) + kill child + return a
+// FAIL result. Used at expectBefore / expectAfter early-out points
+// so the verify dir keeps the diagnostic artefacts even on fail.
+async function finalizeFail(out, child, appLog, ctx, why) {
+    try { if (ctx) await ctx.close(); } catch {}
+    await writeFile(join(out, 'app.log'), appLog).catch(() => null);
+    await killTree(child);
+    return { name: out.split('/').pop(), ok: false, stage: 'expect', err: why };
+}
+
+
 async function killTree(child) {
     if (!child || child.killed) return;
     try { child.kill('SIGTERM'); } catch {}
@@ -210,9 +304,13 @@ async function verify(name, cfg, browser) {
         await waitForPort(cfg.port);
 
         // 3. Navigate + capture
+        // recordVideo writes a .webm of the full session into the
+        // verify dir — playwright finalises the file on ctx.close,
+        // so the artefact lands alongside the per-step PNGs.
         const ctx = await browser.newContext({
             ignoreHTTPSErrors: true,
             viewport: { width: 1280, height: 800 },
+            recordVideo: { dir: out, size: { width: 1280, height: 800 } },
         });
         const page = await ctx.newPage();
 
@@ -236,30 +334,68 @@ async function verify(name, cfg, browser) {
             new Promise(r => setTimeout(r, 1000)),
         ]);
 
-        // 4. Optional UI actions
+        // BEFORE snapshot — captured before any actions run, so a
+        // diff against the AFTER screenshot proves the actions
+        // actually changed UI state (not just "page loads clean").
+        const beforeHtml = await page.content();
+        await writeFile(join(out, 'page-before.html'), beforeHtml);
+        await page.screenshot({
+            path: join(out, 'screenshot-before.png'),
+            fullPage: true,
+        });
+
+        if (cfg.expectBefore && !beforeHtml.includes(cfg.expectBefore)) {
+            return finalizeFail(out, child, appLog, ctx,
+                `expectBefore "${cfg.expectBefore}" missing on initial page`);
+        }
+
+        // 4. UI actions — click / fill / goto. After each step,
+        // screenshot to a step-N.png file so the final artefact dir
+        // shows the full progression. Per-step PNGs + the video
+        // recording give two views of the same flow: stills you can
+        // diff against expected output, and a webm you can scrub.
         if (cfg.actions) {
-            for (const a of cfg.actions) {
+            for (let i = 0; i < cfg.actions.length; i++) {
+                const a = cfg.actions[i];
+                const stepLabel = describeStep(a);
                 if (a.click) {
                     const n = a.count ?? 1;
-                    for (let i = 0; i < n; i++) {
+                    for (let j = 0; j < n; j++) {
                         await page.locator(a.click).first().click({
                             timeout: 3000,
                         }).catch(() => null);
-                        await page.waitForTimeout(150);
+                        await page.waitForTimeout(250);
                     }
                 }
                 if (a.fill) {
                     await page.locator(a.fill.locator).first()
                         .fill(a.fill.value, { timeout: 3000 }).catch(() => null);
+                    await page.waitForTimeout(200);
                 }
+                if (a.goto) {
+                    const target = `http://localhost:${cfg.port}${a.goto}`;
+                    await page.goto(target, {
+                        waitUntil: 'domcontentloaded',
+                        timeout: 10000,
+                    }).catch(() => null);
+                }
+                // Stills + label: lets a reviewer scrub through the
+                // PNGs and read what each step represents.
+                const stepIdx = String(i + 1).padStart(2, '0');
+                await page.screenshot({
+                    path: join(out, `step-${stepIdx}-${stepLabel}.png`),
+                    fullPage: true,
+                }).catch(() => null);
             }
-            // Settle any post-action SSE reconciliation.
-            await page.waitForTimeout(500);
+            // Settle any post-action SSE reconciliation. Live.app
+            // patches arrive via SSE — give them a generous window
+            // before the final snapshot.
+            await page.waitForTimeout(1000);
         }
 
-        // 5. Snapshot
-        const html = await page.content();
-        await writeFile(join(out, 'page.html'), html);
+        // AFTER snapshot — main artefact for visual diff review.
+        const afterHtml = await page.content();
+        await writeFile(join(out, 'page.html'), afterHtml);
         await page.screenshot({
             path: join(out, 'screenshot.png'),
             fullPage: true,
@@ -267,6 +403,27 @@ async function verify(name, cfg, browser) {
         await writeFile(join(out, 'console.log'),
             consoleErrors.join('\n') + (consoleErrors.length ? '\n' : ''));
         await ctx.close();
+
+        // Rename the auto-named video.webm playwright finalises on
+        // ctx.close (page@<hash>.webm) to a stable 'video.webm' so
+        // the verify dir has a predictable filename.
+        try {
+            const entries = await readdir(out);
+            for (const e of entries) {
+                if (e.startsWith('page@') && e.endsWith('.webm')) {
+                    await rename(join(out, e), join(out, 'video.webm'));
+                    break;
+                }
+            }
+        } catch { /* best-effort */ }
+
+        // Action proof — expectAfter MUST appear post-actions if
+        // declared. This is the proof that the interaction
+        // actually changed state.
+        if (cfg.expectAfter && !afterHtml.includes(cfg.expectAfter)) {
+            return finalizeFail(out, child, appLog, null,
+                `expectAfter "${cfg.expectAfter}" missing post-actions`);
+        }
 
         // 6. Pass criteria — ignore noisy resource-loading errors
         // (broken image URLs in dev fixtures, third-party trackers,

--- a/scripts/verify-examples.mjs
+++ b/scripts/verify-examples.mjs
@@ -47,7 +47,16 @@ const EXAMPLES = {
                           actions: [{ click: 'button:has-text("+")', count: 3 }] },
     '10-live-component': { port: 8000, path: '/' },
     '12-skyvote':       { port: 8000, path: '/' },
-    '13-skyshop':       { port: 8000, path: '/' },
+    '13-skyshop':       { port: 8000, path: '/',
+                          actions: [
+                              // Click "Browse Products" hero CTA → product list page.
+                              { click: 'a:has-text("Browse Products"), button:has-text("Browse Products")' },
+                              // Pick the first product card title (works on either
+                              // homepage featured-products list OR /products grid).
+                              { click: 'a:has-text("test product"), [class*="product"] a' },
+                              // Try "Add to Cart" if visible.
+                              { click: 'button:has-text("Add to Cart"), button:has-text("Add"):not(:has-text("admin"))' },
+                          ] },
     '15-http-server':   { port: 8000, path: '/' },
     '16-skychess':      { port: 8000, path: '/' },
     '17-skymon':        { port: 8000, path: '/' },
@@ -207,10 +216,14 @@ async function verify(name, cfg, browser) {
             consoleErrors.join('\n') + (consoleErrors.length ? '\n' : ''));
         await ctx.close();
 
-        // 6. Pass criteria
+        // 6. Pass criteria — ignore noisy resource-loading errors
+        // (broken image URLs in dev fixtures, third-party trackers,
+        // favicon, cookie warnings). Treat real JS exceptions and
+        // pageerror events as fatal.
         const failed = consoleErrors.filter(e =>
             !/Cookie .* will be soon rejected/i.test(e) &&
-            !/favicon/i.test(e));
+            !/favicon/i.test(e) &&
+            !/Failed to load resource/i.test(e));
         result = failed.length === 0
             ? { name, ok: true, stage: 'done' }
             : { name, ok: false, stage: 'console', err: failed[0] };

--- a/scripts/verify-examples.mjs
+++ b/scripts/verify-examples.mjs
@@ -1,0 +1,266 @@
+#!/usr/bin/env node
+// scripts/verify-examples.mjs
+//
+// Local-only end-to-end smoke for examples — drives a real Chromium
+// via Playwright, takes a screenshot of every server example, and
+// captures any console errors / failed-request log lines. The aim
+// is to catch regressions where the example BUILDS clean but
+// renders wrong (blank page, JS exception in __sky*, dead Cmd.perform
+// dispatch, etc.) — `sky verify` only checks HTTP 200 on /, which
+// the symptom would slip past.
+//
+// Output: _verify/<example>/{screenshot.png,console.log,page.html}
+// Gitignored. Local per-developer; not source.
+//
+// Usage:
+//   node scripts/verify-examples.mjs              # every server example
+//   node scripts/verify-examples.mjs 09 12 19     # specific examples (prefix-match)
+//
+// Requires: playwright + chromium installed (`npx playwright install chromium`).
+// The harness installs neither — same philosophy as scripts/mem-guard.sh
+// (a developer-tooling script you run yourself, not part of CI).
+
+import { chromium } from 'playwright';
+import { spawn } from 'node:child_process';
+import { mkdir, writeFile, rm, access } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import process from 'node:process';
+
+const ROOT = resolve(new URL('..', import.meta.url).pathname);
+const SKY = join(ROOT, 'sky-out', 'sky');
+const OUT = join(ROOT, '_verify');
+
+// Per-example contract — stays small + declarative. Add an entry
+// when you bring a new server example online; CLI examples use
+// `scripts/example-e2e.sh` and aren't covered here.
+//
+// `port`     — what the binary listens on (sky.toml [live] port or
+//              hardcoded for raw http servers).
+// `path`     — page to navigate after the server is up (default '/').
+// `actions`  — optional list of click/type pairs to drive a primary
+//              UI flow before screenshotting. Sky.Live examples
+//              auto-reconcile on event POSTs so a single click is a
+//              meaningful smoke.
+const EXAMPLES = {
+    '08-notes-app':     { port: 8000, path: '/' },
+    '09-live-counter':  { port: 8000, path: '/',
+                          actions: [{ click: 'button:has-text("+")', count: 3 }] },
+    '10-live-component': { port: 8000, path: '/' },
+    '12-skyvote':       { port: 8000, path: '/' },
+    '13-skyshop':       { port: 8000, path: '/' },
+    '15-http-server':   { port: 8000, path: '/' },
+    '16-skychess':      { port: 8000, path: '/' },
+    '17-skymon':        { port: 8000, path: '/' },
+    '18-job-queue':     { port: 8000, path: '/' },
+    '19-skyforum':      { port: 8000, path: '/' },
+};
+
+
+function args() {
+    const filt = process.argv.slice(2);
+    if (filt.length === 0) return Object.keys(EXAMPLES);
+    return Object.keys(EXAMPLES).filter(n =>
+        filt.some(f => n.startsWith(f) || n.includes(f)));
+}
+
+
+async function exists(p) {
+    try { await access(p); return true; } catch { return false; }
+}
+
+
+async function buildExample(dir) {
+    return new Promise((resolveProc, rejectProc) => {
+        const ps = spawn(SKY, ['build', 'src/Main.sky'], {
+            cwd: dir,
+            env: { ...process.env, PATH: process.env.PATH },
+        });
+        let out = '';
+        ps.stdout.on('data', c => { out += c.toString(); });
+        ps.stderr.on('data', c => { out += c.toString(); });
+        ps.on('close', code => code === 0
+            ? resolveProc(out)
+            : rejectProc(new Error('sky build failed:\n' + out)));
+    });
+}
+
+
+async function waitForPort(port, timeoutMs = 15000) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        try {
+            const ctrl = new AbortController();
+            const t = setTimeout(() => ctrl.abort(), 1000);
+            const res = await fetch(`http://localhost:${port}/`, {
+                signal: ctrl.signal,
+            }).catch(() => null);
+            clearTimeout(t);
+            if (res && res.status < 500) return true;
+        } catch { /* loop */ }
+        await new Promise(r => setTimeout(r, 250));
+    }
+    throw new Error(`port ${port} never opened`);
+}
+
+
+async function killTree(child) {
+    if (!child || child.killed) return;
+    try { child.kill('SIGTERM'); } catch {}
+    // Give it a graceful second, then SIGKILL.
+    await new Promise(r => setTimeout(r, 800));
+    try { child.kill('SIGKILL'); } catch {}
+}
+
+
+async function verify(name, cfg, browser) {
+    const dir = join(ROOT, 'examples', name);
+    const out = join(OUT, name);
+    await rm(out, { recursive: true, force: true });
+    await mkdir(out, { recursive: true });
+
+    const log = (s) => writeFile(join(out, 'verify.log'),
+        s, { flag: 'a' });
+
+    // 1. Build
+    try {
+        const buildOut = await buildExample(dir);
+        await log(`# build\n${buildOut}\n`);
+    } catch (e) {
+        await log(`# build FAILED\n${e.message}\n`);
+        return { name, ok: false, stage: 'build', err: e.message };
+    }
+
+    // 2. Spawn binary
+    const bin = join(dir, 'sky-out', 'app');
+    if (!(await exists(bin))) {
+        await log(`# missing binary: ${bin}\n`);
+        return { name, ok: false, stage: 'spawn', err: 'no binary' };
+    }
+    const child = spawn(bin, [], {
+        cwd: dir,
+        env: { ...process.env, SKY_LIVE_PORT: String(cfg.port) },
+    });
+    let appLog = '';
+    child.stdout.on('data', c => { appLog += c.toString(); });
+    child.stderr.on('data', c => { appLog += c.toString(); });
+
+    let result = { name, ok: false, stage: 'unknown' };
+    try {
+        await waitForPort(cfg.port);
+
+        // 3. Navigate + capture
+        const ctx = await browser.newContext({
+            ignoreHTTPSErrors: true,
+            viewport: { width: 1280, height: 800 },
+        });
+        const page = await ctx.newPage();
+
+        const consoleErrors = [];
+        page.on('console', m => {
+            if (m.type() === 'error') consoleErrors.push(m.text());
+        });
+        page.on('pageerror', e => consoleErrors.push('pageerror: ' + e.message));
+
+        const url = `http://localhost:${cfg.port}${cfg.path || '/'}`;
+        await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 10000 });
+
+        // Sky.Live runtime takes a brief moment to wire the SSE
+        // hello. Wait for the connection-status banner (if injected)
+        // OR a 1s settle, whichever first.
+        await Promise.race([
+            page.waitForFunction(
+                () => window.__skySid !== undefined,
+                { timeout: 4000 }
+            ).catch(() => null),
+            new Promise(r => setTimeout(r, 1000)),
+        ]);
+
+        // 4. Optional UI actions
+        if (cfg.actions) {
+            for (const a of cfg.actions) {
+                if (a.click) {
+                    const n = a.count ?? 1;
+                    for (let i = 0; i < n; i++) {
+                        await page.locator(a.click).first().click({
+                            timeout: 3000,
+                        }).catch(() => null);
+                        await page.waitForTimeout(150);
+                    }
+                }
+                if (a.fill) {
+                    await page.locator(a.fill.locator).first()
+                        .fill(a.fill.value, { timeout: 3000 }).catch(() => null);
+                }
+            }
+            // Settle any post-action SSE reconciliation.
+            await page.waitForTimeout(500);
+        }
+
+        // 5. Snapshot
+        const html = await page.content();
+        await writeFile(join(out, 'page.html'), html);
+        await page.screenshot({
+            path: join(out, 'screenshot.png'),
+            fullPage: true,
+        });
+        await writeFile(join(out, 'console.log'),
+            consoleErrors.join('\n') + (consoleErrors.length ? '\n' : ''));
+        await ctx.close();
+
+        // 6. Pass criteria
+        const failed = consoleErrors.filter(e =>
+            !/Cookie .* will be soon rejected/i.test(e) &&
+            !/favicon/i.test(e));
+        result = failed.length === 0
+            ? { name, ok: true, stage: 'done' }
+            : { name, ok: false, stage: 'console', err: failed[0] };
+    } catch (e) {
+        result = { name, ok: false, stage: 'navigate', err: e.message };
+    } finally {
+        await writeFile(join(out, 'app.log'), appLog);
+        await killTree(child);
+    }
+    return result;
+}
+
+
+async function main() {
+    const wanted = args();
+    if (wanted.length === 0) {
+        console.error('No matching examples.');
+        process.exit(2);
+    }
+
+    await mkdir(OUT, { recursive: true });
+    const browser = await chromium.launch({ headless: true });
+
+    const results = [];
+    for (const name of wanted) {
+        process.stdout.write(`[verify] ${name} … `);
+        const r = await verify(name, EXAMPLES[name], browser);
+        results.push(r);
+        process.stdout.write(r.ok
+            ? 'ok\n'
+            : `FAIL (${r.stage}: ${r.err ?? ''})\n`);
+    }
+
+    await browser.close();
+
+    const ok = results.filter(r => r.ok).length;
+    const fail = results.length - ok;
+    console.log('');
+    console.log(`# ${ok}/${results.length} passed`);
+    if (fail) {
+        console.log('Failed:');
+        for (const r of results.filter(x => !x.ok)) {
+            console.log(`  - ${r.name}: ${r.stage}: ${r.err ?? ''}`);
+        }
+        process.exit(1);
+    }
+}
+
+
+main().catch(e => {
+    console.error(e);
+    process.exit(2);
+});

--- a/scripts/verify-examples.sh
+++ b/scripts/verify-examples.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# scripts/verify-examples.sh — local end-to-end smoke for examples.
+#
+# Builds, runs, and screenshots each server example through a real
+# Chromium via Playwright. The aim is to catch regressions where
+# the example BUILDS clean but renders wrong (blank page, JS
+# exception in __sky*, dead Cmd.perform dispatch). `sky verify`
+# only probes / for HTTP 200 — the symptom would slip past.
+#
+# Usage:
+#   scripts/verify-examples.sh                # every server example
+#   scripts/verify-examples.sh 09 12 19       # name fragments (prefix-match)
+#
+# First run sets up _verify/node_modules with Playwright + Chromium.
+# Both _verify/ and the harness output (_verify/<example>/) are
+# gitignored — local per-developer; not source.
+
+set -o pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+VDIR="$ROOT/_verify"
+mkdir -p "$VDIR"
+
+# Install dev-tooling Playwright at repo root (node_modules is
+# gitignored). package.json lives at repo root so node's ES module
+# resolution finds it without any NODE_PATH hackery — ES modules
+# don't honour NODE_PATH.
+if [[ ! -d "$ROOT/node_modules/playwright" ]]; then
+    echo "[verify] one-time Playwright setup at repo root …"
+    (cd "$ROOT" && npm install --silent)
+    (cd "$ROOT" && npx playwright install chromium)
+fi
+
+if [[ ! -x "$ROOT/sky-out/sky" ]]; then
+    echo "[verify] sky-out/sky not found. Run scripts/build.sh first." >&2
+    exit 2
+fi
+
+# Run from repo root so node finds ./node_modules/playwright.
+node "$ROOT/scripts/verify-examples.mjs" "$@"

--- a/sky-compiler.cabal
+++ b/sky-compiler.cabal
@@ -145,6 +145,7 @@ executable sky
     Sky.Build.FfiGen
     Sky.Build.FfiRegistry
     Sky.Build.FfiTypeParser
+    Sky.Build.FfiTypeResolve
     Sky.Build.SkyDeps
 
     -- Reporting

--- a/sky-compiler.cabal
+++ b/sky-compiler.cabal
@@ -144,6 +144,7 @@ executable sky
     Sky.Build.EmbeddedInspector
     Sky.Build.FfiGen
     Sky.Build.FfiRegistry
+    Sky.Build.FfiTypeParser
     Sky.Build.SkyDeps
 
     -- Reporting
@@ -160,7 +161,12 @@ executable sky
 test-suite sky-tests
   type:             exitcode-stdio-1.0
   main-is:          Spec.hs
-  hs-source-dirs:   test
+  -- 'src' is here so unit-test specs can import library modules
+  -- directly (today only Sky.Build.FfiTypeParser; bigger surface
+  -- to follow as we phase typed FFI through). Existing specs are
+  -- blackbox — they spawn the `sky` binary and inspect stdout —
+  -- so they don't pay any build-time cost from this addition.
+  hs-source-dirs:   test, src
   default-language: Haskell2010
   ghc-options:      -Wall -Wno-unused-imports -Wno-name-shadowing -threaded
 
@@ -204,6 +210,7 @@ test-suite sky-tests
       Sky.Build.CtorConsPatternSpec
       Sky.Build.EnvPrefixSpec
       Sky.Build.FfiGenMultiSpec
+      Sky.Build.FfiTypeParserSpec
       Sky.Build.TaskResultBridgesSpec
       Sky.Build.CheckIsBuildSpec
       Sky.Build.RecordFieldOrderSpec

--- a/src/Sky/Build/Compile.hs
+++ b/src/Sky/Build/Compile.hs
@@ -43,6 +43,7 @@ import qualified Sky.Generate.Go.Record as Rec
 import qualified Sky.Build.ModuleGraph as Graph
 import qualified Sky.Build.Dce as Dce
 import qualified Sky.Build.FfiRegistry as FfiReg
+import qualified Sky.Build.FfiTypeResolve as FfiTy
 import qualified Sky.Build.SkyDeps as SkyDeps
 import qualified Sky.Canonicalise.Environment as Env
 import qualified System.Environment
@@ -78,9 +79,27 @@ loadAndSeedFfiRegistry = do
                 FfiReg._ffn_arity f)
             | m <- mods, f <- FfiReg._fm_functions m
             ]
+        -- Phase C: turn parsed FtyAst into a canonical Annotation
+        -- per (kernelName, fnName). Only entries whose kernel.json
+        -- carried a parseable @skyType@ land here — pathological
+        -- FFI shapes (channels, deeply-nested inline-struct
+        -- callback bundles, missed-by-isSkyParseable Go residue)
+        -- omit @skyType@ at producer side, which decodes to
+        -- _ffn_skyType = Nothing here, which keeps them OUT of the
+        -- typeMap. The canonicaliser/Constrain falls back to the
+        -- legacy "no Sky type known" path for those — their
+        -- callers stay polymorphic-any, exactly as before.
+        typeMap = Map.fromList
+            [ ((FfiReg._fm_kernelName m, FfiReg._ffn_name f),
+                FfiTy.ftyToAnnotation (FfiReg._fm_kernelName m) ast)
+            | m <- mods
+            , f <- FfiReg._fm_functions m
+            , Just ast <- [FfiReg._ffn_skyType f]
+            ]
     writeIORef Env.ffiKernelModulesRef moduleMap
     writeIORef Env.ffiKernelFunctionsRef functionMap
     writeIORef Env.ffiKernelArityRef arityMap
+    writeIORef Env.ffiKernelTypeRef typeMap
     seedTypedFfiNames
     if null mods
         then return ()

--- a/src/Sky/Build/FfiGen.hs
+++ b/src/Sky/Build/FfiGen.hs
@@ -336,8 +336,12 @@ emitKernelJson moduleName kernelName pkg =
     let fns = filter (not . shouldSkipFn) (_pkgFns pkg)
         fnEntries = intercalate ",\n" (map emitFnEntry fns)
         emitFnEntry fn =
-            "    {\"name\": " ++ quote (lowerFirst (_fnName fn)) ++
-            ", \"arity\": " ++ show (max 1 (length (_fnParams fn))) ++ "}"
+            let st = wrapperSkyType fn
+                base = "    {\"name\": " ++ quote (lowerFirst (_fnName fn)) ++
+                       ", \"arity\": " ++ show (max 1 (length (_fnParams fn)))
+            in if isSkyParseable st
+                  then base ++ ", \"skyType\": " ++ quote st ++ "}"
+                  else base ++ "}"
     in unlines
         [ "{"
         , "  \"moduleName\": " ++ quote moduleName ++ ","
@@ -348,6 +352,78 @@ emitKernelJson moduleName kernelName pkg =
         , "  ]"
         , "}"
         ]
+
+
+-- | Sky-side type for an FFI wrapper, including the runtime Result
+-- wrap. Mirrors the shape `emitWrapper` actually emits — see
+-- `bodyLines` / `okType` around line 1296. Per the trust-boundary
+-- rule (CLAUDE.md "every FFI call returns Result Error T"), every
+-- wrapper returns SkyResult[any, T] no matter how its Go signature
+-- spells the result.
+--
+-- Mapping (matches the wrapper code):
+--   []                          -> Result Error ()
+--   [(_, T)] non-error          -> Result Error T
+--   [(_, "error")]              -> Result Error ()
+--   (T, error)                  -> Result Error T
+--   (T, bool) comma-ok          -> Result Error (Maybe T)
+--   (T, U) no error/bool        -> Result Error (T, U)   (SkyTuple2)
+--   (T, U, error)               -> Result Error (T, U)
+--   (T, U, V) etc.              -> Result Error (T, U, V) (SkyTuple3+)
+--
+-- Param list flows through goTypeToSky verbatim. Zero-param Go
+-- functions emit `() -> Result Error R` — Sky calls them as
+-- `Pkg.fn ()` (unit applied), matching the existing convention.
+wrapperSkyType :: FnInfo -> String
+wrapperSkyType fn =
+    let paramSig = if null (_fnParams fn)
+            then "()"
+            else intercalate " -> " (map (goTypeToSky . snd) (_fnParams fn))
+        results = _fnResults fn
+        nonErr = [ (n, t) | (n, t) <- results, t /= "error" ]
+        innerOk = case (results, nonErr) of
+            ([], _)               -> "()"
+            ([(_, "error")], _)   -> "()"
+            (_, [])               -> "()"
+            (_, [(_, t)])         ->
+                case results of
+                    [(_, t1), (_, "bool")] | t1 /= "bool" ->
+                        -- comma-ok: (T, bool) -> Maybe T
+                        "Maybe " ++ wrapIfMulti (goTypeToSky t)
+                    _ -> goTypeToSky t
+            (_, multi)            ->
+                -- Multi non-error returns pack into a Sky tuple.
+                "(" ++ intercalate ", " (map (goTypeToSky . snd) multi) ++ ")"
+        okType = case innerOk of
+            -- Result wrap composites need parens to bind tightly.
+            ('(':_) -> "Result Error " ++ innerOk
+            _       -> "Result Error " ++ wrapIfMulti innerOk
+    in paramSig ++ " -> " ++ okType
+  where
+    -- "List X" / "Dict String V" / "Maybe X" etc. need parens when
+    -- nested under another constructor (Result Error here).
+    wrapIfMulti s
+        | ' ' `elem` s && head s /= '(' = "(" ++ s ++ ")"
+        | otherwise                     = s
+
+
+-- | Reject Sky-type strings that still carry Go-side residue. These
+-- typically come from exotic Go shapes the goTypeToSky translator
+-- can't faithfully render (channels, deeply-nested inline-struct
+-- callback bundles, package-leaking generics). When the registry
+-- skyType field is omitted, FfiRegistry falls back to the legacy
+-- "no Sky-side type known" path — the wrapper itself still works,
+-- HM just doesn't constrain its use.
+isSkyParseable :: String -> Bool
+isSkyParseable s = not $ any (`isSubstringOf` s)
+    [ "<-"            -- channel direction
+    , " chan "        -- bare chan
+    , "chan "         -- chan at start
+    , "interface{"    -- residual empty/non-empty interface
+    , "struct{"       -- residual struct literal
+    , "func("         -- Go's func keyword should have been stripped
+    , "{}"            -- any leaked empty-{} (interface{} / struct{} nested)
+    ]
 
 
 -- | Skip functions that can't be realised at the FFI boundary.
@@ -1652,14 +1728,23 @@ goTypeToSky t
         let (_keyPart, valPart) = splitMapBracket (drop 4 t)
         in "Dict String " ++ wrapIfComposite (goTypeToSky (trim' valPart))
     | otherwise = case t of
-        "string"  -> "String"
-        "int"     -> "Int"
-        "int64"   -> "Int"
-        "int32"   -> "Int"
-        "float64" -> "Float"
-        "float32" -> "Float"
-        "bool"    -> "Bool"
-        "error"   -> "String"
+        "string"      -> "String"
+        "int"         -> "Int"
+        "int64"       -> "Int"
+        "int32"       -> "Int"
+        "float64"     -> "Float"
+        "float32"     -> "Float"
+        "bool"        -> "Bool"
+        "error"       -> "String"
+        -- Go's empty interface = "any" in Sky terms. Without this, a
+        -- `Dict String interface{}` ended up as `Dict String interface{}`
+        -- in the registry, which the type parser can't read.
+        "interface{}" -> "any"
+        -- Inspector emits `struct{}` for the synthetic param that makes
+        -- a Go zero-arg constructor look uniform with N-arg ones. From
+        -- the Sky caller's perspective the call is `Pkg.newX ()`, so the
+        -- Sky-side surface is `() -> Result Error X`.
+        "struct{}"    -> "()"
         _         -> stripPkg t
   where
     stripPkg = reverse . takeWhile (/= '.') . reverse

--- a/src/Sky/Build/FfiGen.hs
+++ b/src/Sky/Build/FfiGen.hs
@@ -68,6 +68,18 @@ data FnInfo = FnInfo
     , _fnIsField  :: Bool                -- synthetic struct-field getter
     , _fnIsFieldSet :: Bool              -- synthetic struct-field setter
     , _fnIsPkgVar :: Bool                -- synthetic pkg-level var/const getter
+    , _fnParamSkyTypes  :: [String]
+        -- ^ Per-param Sky-side type override. Same length as
+        -- '_fnParams'; entry is "" when no override (use the bare
+        -- Go type via 'goTypeToSky'). Populated from the
+        -- inspector's per-Param skyType field, which collapses
+        -- named-of-basic types (Stripe enums, Firestore Direction,
+        -- etc.) to their underlying primitive so HM treats them
+        -- structurally. Wrapper code generation continues to use
+        -- '_fnParams' so derived Go types stay distinct on the
+        -- wrapper-call side.
+    , _fnResultSkyTypes :: [String]
+        -- ^ Same shape, for results.
     }
     deriving (Show)
 
@@ -82,22 +94,28 @@ data PkgInfo = PkgInfo
 
 
 instance A.FromJSON FnInfo where
-    parseJSON = A.withObject "FnInfo" $ \o -> FnInfo
-        <$> o A..: "name"
-        <*> (o A..: "params" >>= mapM parseParam)
-        <*> (o A..: "results" >>= mapM parseParam)
-        <*> o A..:? "variadic" A..!= False
-        <*> o A..: "effect"
-        <*> o A..:? "recvType" A..!= ""
-        <*> o A..:? "methodName" A..!= ""
-        <*> o A..:? "isField" A..!= False
-        <*> o A..:? "isFieldSet" A..!= False
-        <*> o A..:? "isPkgVar" A..!= False
+    parseJSON = A.withObject "FnInfo" $ \o -> do
+        params <- o A..: "params" >>= mapM parseParamFull
+        results <- o A..: "results" >>= mapM parseParamFull
+        FnInfo
+            <$> o A..: "name"
+            <*> pure (map (\(n, t, _) -> (n, t)) params)
+            <*> pure (map (\(n, t, _) -> (n, t)) results)
+            <*> o A..:? "variadic" A..!= False
+            <*> o A..: "effect"
+            <*> o A..:? "recvType" A..!= ""
+            <*> o A..:? "methodName" A..!= ""
+            <*> o A..:? "isField" A..!= False
+            <*> o A..:? "isFieldSet" A..!= False
+            <*> o A..:? "isPkgVar" A..!= False
+            <*> pure (map (\(_, _, s) -> s) params)
+            <*> pure (map (\(_, _, s) -> s) results)
       where
-        parseParam = A.withObject "param" $ \o -> do
+        parseParamFull = A.withObject "param" $ \o -> do
             n <- o A..:? "name" A..!= ""
             t <- o A..: "type"
-            return (n, t)
+            s <- o A..:? "skyType" A..!= ""
+            return (n, t, s)
 
 
 instance A.FromJSON PkgInfo where
@@ -376,24 +394,38 @@ emitKernelJson moduleName kernelName pkg =
 -- `Pkg.fn ()` (unit applied), matching the existing convention.
 wrapperSkyType :: FnInfo -> String
 wrapperSkyType fn =
-    let paramSig = if null (_fnParams fn)
+    -- Per-param / per-result Sky-side override from the inspector
+    -- (e.g. CheckoutSessionStatus -> string). Length matches
+    -- _fnParams / _fnResults; "" means use the bare Go type.
+    let resolveSky goT skyOverride
+            | null skyOverride = goTypeToSky goT
+            | otherwise        = goTypeToSky skyOverride
+        paramOverrides =
+            _fnParamSkyTypes fn ++ repeat ""
+        resultOverrides =
+            _fnResultSkyTypes fn ++ repeat ""
+        paramSig = if null (_fnParams fn)
             then "()"
-            else intercalate " -> " (map (goTypeToSky . snd) (_fnParams fn))
+            else intercalate " -> "
+                    (zipWith (\(_, t) sk -> resolveSky t sk)
+                        (_fnParams fn) paramOverrides)
         results = _fnResults fn
-        nonErr = [ (n, t) | (n, t) <- results, t /= "error" ]
+        zippedResults = zip results resultOverrides
+        nonErr = [ ((n, t), sk) | ((n, t), sk) <- zippedResults, t /= "error" ]
+        skyOf ((_, t), sk) = resolveSky t sk
         innerOk = case (results, nonErr) of
             ([], _)               -> "()"
             ([(_, "error")], _)   -> "()"
             (_, [])               -> "()"
-            (_, [(_, t)])         ->
+            (_, [single])         ->
                 case results of
                     [(_, t1), (_, "bool")] | t1 /= "bool" ->
                         -- comma-ok: (T, bool) -> Maybe T
-                        "Maybe " ++ wrapIfMulti (goTypeToSky t)
-                    _ -> goTypeToSky t
+                        "Maybe " ++ wrapIfMulti (skyOf single)
+                    _ -> skyOf single
             (_, multi)            ->
                 -- Multi non-error returns pack into a Sky tuple.
-                "(" ++ intercalate ", " (map (goTypeToSky . snd) multi) ++ ")"
+                "(" ++ intercalate ", " (map skyOf multi) ++ ")"
         okType = case innerOk of
             -- Result wrap composites need parens to bind tightly.
             ('(':_) -> "Result Error " ++ innerOk

--- a/src/Sky/Build/FfiRegistry.hs
+++ b/src/Sky/Build/FfiRegistry.hs
@@ -20,10 +20,21 @@ import qualified Data.Map.Strict as Map
 import System.Directory (doesDirectoryExist, listDirectory)
 import System.FilePath ((</>))
 
+import Sky.Build.FfiTypeParser (FtyAst, parseFty)
+
 
 data FfiFunction = FfiFunction
-    { _ffn_name  :: !String  -- Sky-side name, e.g. "newString"
-    , _ffn_arity :: !Int     -- Sky-side arity (unit param for zero-Go-arg)
+    { _ffn_name    :: !String     -- Sky-side name, e.g. "newString"
+    , _ffn_arity   :: !Int        -- Sky-side arity (unit param for zero-Go-arg)
+    , _ffn_skyType :: !(Maybe FtyAst)
+        -- ^ Parsed Sky-side wrapper type, including the runtime
+        -- @Result Error _@ wrap (see Sky.Build.FfiGen.wrapperSkyType).
+        -- 'Nothing' when the JSON entry omits @skyType@ — happens
+        -- for FFI shapes the inspector can't faithfully render
+        -- (channels, deeply-nested inline-struct callback bundles)
+        -- and for older kernel.json files written before this field
+        -- existed. The HM-wire path falls back to the legacy
+        -- "no Sky type known" branch in those cases.
     }
     deriving (Show, Eq)
 
@@ -65,7 +76,9 @@ instance A.FromJSON FfiFunction where
     parseJSON = A.withObject "FfiFunction" $ \o -> do
         n <- o .: "name"
         a <- o .:? "arity" .!= 1
-        return (FfiFunction n a)
+        rawSky <- o .:? "skyType"
+        let parsed = rawSky >>= parseFty
+        return (FfiFunction n a parsed)
 
 
 instance A.FromJSON FfiModule where

--- a/src/Sky/Build/FfiTypeParser.hs
+++ b/src/Sky/Build/FfiTypeParser.hs
@@ -1,0 +1,229 @@
+{-# LANGUAGE LambdaCase #-}
+-- | Minimal Sky-type parser used by Sky.Build.FfiRegistry.
+--
+-- Parses the closed subset of Sky type-string syntax that the FFI
+-- inspector emits into kernel.json's @skyType@ field — see
+-- @Sky.Build.FfiGen.wrapperSkyType@ for the producer side. This is
+-- not a general-purpose Sky parser; it is intentionally small so we
+-- can canonicalise the FFI registry without depending on the full
+-- Sky.Parse machinery (which threads source-position state, layout
+-- filtering, and qualified-import resolution that don't apply to
+-- a single-line type string).
+--
+-- Grammar (closed; matches the FfiGen producer):
+--
+-- > type   := arrow
+-- > arrow  := app ('->' arrow)?
+-- > app    := atom atom*
+-- > atom   := '(' inner ')' | identifier
+-- > inner  := type (',' type)*       -- tuple, including 'unit' when empty
+-- > identifier := lowercase | uppercase
+--
+-- Application is left-associative (matches Elm/Sky surface syntax).
+-- Arrow is right-associative.
+--
+-- The parser is total: invalid input returns 'Nothing' rather than
+-- raising. Callers (FfiRegistry's JSON decoder) treat 'Nothing' as
+-- "no Sky type known" and fall back to the legacy any-typed path.
+module Sky.Build.FfiTypeParser
+    ( FtyAst(..)
+    , parseFty
+    -- ^ exposed for the cabal test suite — the full parser lives
+    -- as one entry point so callers don't reach into the lexer.
+    ) where
+
+import Data.Char (isAlpha, isAlphaNum, isLower, isSpace, isUpper)
+
+
+-- | Mini Sky-type AST. Mirrors a useful subset of
+-- @Sky.AST.Canonical.Type@; the conversion to a canonical 'Type'
+-- happens at HM-wire time (Phase C) where the canonical module
+-- map is in scope.
+data FtyAst
+    = FtyVar !String
+        -- ^ Lower-case identifier — type variable. Includes the
+        -- special 'any' which Sky.Type.Solve maps to a fresh
+        -- unification var per occurrence (Limitation #18).
+    | FtyApp !String ![FtyAst]
+        -- ^ @Name args@. Empty arg list = bare type constructor,
+        -- e.g. @String@ / @Int@ / @ActionCodeSettings@. Nonempty =
+        -- applied, e.g. @List String@ / @Result Error Token@.
+    | FtyArrow !FtyAst !FtyAst
+        -- ^ Right-associative function arrow.
+    | FtyUnit
+        -- ^ The unit type @()@, distinct from 'FtyTuple []' so the
+        -- conversion to T.Type can produce 'TUnit' directly.
+    | FtyTuple ![FtyAst]
+        -- ^ 2+-element tuple.
+    deriving (Eq, Show)
+
+
+-- | Parse a Sky type string. Returns 'Nothing' if the string isn't
+-- a syntactically valid type within the closed subset above —
+-- callers fall back to the no-type path.
+parseFty :: String -> Maybe FtyAst
+parseFty s = case lex' s of
+    Nothing   -> Nothing
+    Just toks -> case runP pType toks of
+        Just (t, []) -> Just t
+        _            -> Nothing
+
+
+-- ──────────────────────────────────────────────────────────────────
+-- Lexer
+-- ──────────────────────────────────────────────────────────────────
+
+data Tok
+    = TLP        -- '('
+    | TRP        -- ')'
+    | TComma     -- ','
+    | TArrow     -- '->'
+    | TIdent !String
+    deriving (Eq, Show)
+
+
+-- | Tokenise. Whitespace is the only separator; identifiers are
+-- @[A-Za-z_][A-Za-z0-9_]*@ (Sky / Elm syntax). Returns 'Nothing'
+-- on the first unrecognised character — that's how channel-residue
+-- strings (e.g. @<-chan struct{}@) are rejected en bloc, rather
+-- than silently letting the parser stop early at the bad char and
+-- treat the remainder as a clean parse.
+lex' :: String -> Maybe [Tok]
+lex' = go . dropWhile isSpace
+  where
+    go [] = Just []
+    go ('(':rest) = (TLP :)    <$> go (dropWhile isSpace rest)
+    go (')':rest) = (TRP :)    <$> go (dropWhile isSpace rest)
+    go (',':rest) = (TComma :) <$> go (dropWhile isSpace rest)
+    go ('-':'>':rest) = (TArrow :) <$> go (dropWhile isSpace rest)
+    go cs@(c:_) | isAlpha c || c == '_' =
+        let (ident, rest) = span identChar cs
+        in (TIdent ident :) <$> go (dropWhile isSpace rest)
+    go _ = Nothing
+
+    identChar c = isAlphaNum c || c == '_'
+
+
+-- ──────────────────────────────────────────────────────────────────
+-- Parser combinator (single-token, monadic-state form)
+-- ──────────────────────────────────────────────────────────────────
+
+newtype P a = P { runP :: [Tok] -> Maybe (a, [Tok]) }
+
+instance Functor P where
+    fmap f (P g) = P $ \ts -> case g ts of
+        Just (a, rest) -> Just (f a, rest)
+        Nothing -> Nothing
+
+instance Applicative P where
+    pure x = P $ \ts -> Just (x, ts)
+    (P pf) <*> (P pa) = P $ \ts -> case pf ts of
+        Just (f, ts') -> case pa ts' of
+            Just (a, ts'') -> Just (f a, ts'')
+            Nothing -> Nothing
+        Nothing -> Nothing
+
+instance Monad P where
+    return = pure
+    (P p) >>= k = P $ \ts -> case p ts of
+        Just (a, ts') -> runP (k a) ts'
+        Nothing -> Nothing
+
+
+peek :: P (Maybe Tok)
+peek = P $ \ts -> Just (case ts of (t:_) -> Just t; [] -> Nothing, ts)
+
+
+eat :: Tok -> P ()
+eat want = P $ \case
+    (t:rest) | t == want -> Just ((), rest)
+    _ -> Nothing
+
+
+-- ──────────────────────────────────────────────────────────────────
+-- Grammar
+-- ──────────────────────────────────────────────────────────────────
+
+-- | type ::= arrow
+pType :: P FtyAst
+pType = pArrow
+
+
+-- | arrow ::= app ('->' arrow)?
+pArrow :: P FtyAst
+pArrow = do
+    lhs <- pApp
+    next <- peek
+    case next of
+        Just TArrow -> eat TArrow >> FtyArrow lhs <$> pArrow
+        _           -> pure lhs
+
+
+-- | app ::= atom atom*
+--
+-- Application is constructor-headed: an atom that's a bare
+-- identifier becomes the constructor; subsequent atoms are its
+-- arguments. So the result is always a flat 'FtyApp head args'
+-- when followed by atoms — matches Sky's left-associative
+-- application semantics. If the head atom is a paren'd type, no
+-- application is allowed (matches Sky too).
+pApp :: P FtyAst
+pApp = do
+    head_ <- pAtom
+    case head_ of
+        FtyApp name [] -> do
+            args <- pArgs
+            pure $ if null args then head_ else FtyApp name args
+        _ -> pure head_
+  where
+    pArgs :: P [FtyAst]
+    pArgs = do
+        next <- peek
+        case next of
+            Just TLP        -> (:) <$> pAtom <*> pArgs
+            Just (TIdent _) -> (:) <$> pAtom <*> pArgs
+            _               -> pure []
+
+
+-- | atom ::= identifier | '(' inner ')'
+-- inner ::= type (',' type)*  (zero items = unit, one = paren'd, 2+ = tuple)
+pAtom :: P FtyAst
+pAtom = do
+    next <- peek
+    case next of
+        Just (TIdent n) -> do
+            eat (TIdent n)
+            pure $ if isVar n then FtyVar n else FtyApp n []
+        Just TLP -> do
+            eat TLP
+            -- Zero items: unit literal '()'
+            after <- peek
+            case after of
+                Just TRP -> eat TRP >> pure FtyUnit
+                _ -> do
+                    first <- pType
+                    items <- pTupleTail
+                    eat TRP
+                    case items of
+                        [] -> pure first
+                        xs -> pure (FtyTuple (first : xs))
+        _ -> P $ const Nothing
+  where
+    pTupleTail :: P [FtyAst]
+    pTupleTail = do
+        next <- peek
+        case next of
+            Just TComma -> eat TComma >> ((:) <$> pType <*> pTupleTail)
+            _ -> pure []
+
+    -- Type-variable identifiers in Sky surface syntax: lower-case
+    -- first character, OR the wildcard 'any'.
+    isVar :: String -> Bool
+    isVar [] = False
+    isVar (c:_) = isLower c || c == '_'
+    -- 'any' lands as FtyVar via the lower-case rule above; the
+    -- wildcard semantics live in Sky.Type.Solve.
+    -- (Just adding this comment since it surprised me when reading
+    -- back — uppercase identifiers go through FtyApp with empty
+    -- args, lowercase through FtyVar.)
+    _isUpper c = isUpper c

--- a/src/Sky/Build/FfiTypeResolve.hs
+++ b/src/Sky/Build/FfiTypeResolve.hs
@@ -48,7 +48,11 @@ ftyToAnnotation kernelName ast =
 -- without collision — each kernelName is a separate canonical home,
 -- and TType identity is by (home, name, args).
 ftyToType :: String -> FtyAst -> Can.Type
-ftyToType kernelName = go
+ftyToType _kernelName = go
+    -- _kernelName is reserved for the proper fix (see opaqueHome
+    -- comment): when the inspector starts emitting fully-qualified
+    -- Go-package paths in skyType, the kernel name will pin the
+    -- canonical home for opaque types referenced there.
   where
     go = \case
         FtyVar name           -> Can.TVar name
@@ -66,7 +70,40 @@ ftyToType kernelName = go
     goApp :: String -> [Can.Type] -> Can.Type
     goApp name args = case lookup name builtinHome of
         Just home -> Can.TType home name args
-        Nothing   -> Can.TType (ModuleName.Canonical kernelName) name args
+        Nothing   -> opaqueValue
+      where
+        -- Drop @args@ for opaque types — anything generic at the
+        -- Go side would have been filtered by isSkyParseable on
+        -- the producer; the only remaining shapes are bare opaque
+        -- type names and List/Dict/Maybe applied to them. The
+        -- latter still resolve to LIst (Value) etc. because we
+        -- recurse through arg positions before reaching here.
+        _used = name : map (const "_") args
+
+    -- Every opaque FFI type collapses to the @Value@ sentinel —
+    -- the same canonical that handcoded kernel sigs use for
+    -- Context.background, Fmt.sprint, and friends (see
+    -- lookupKernelType in Sky.Type.Constrain.Expression). This
+    -- gives every opaque-typed FFI surface a shared HM identity
+    -- so cross-kernel composition like
+    -- @Firestore.newClient (case Context.background () of Ok c -> c)@
+    -- type-checks: both sides see @Value@ at the boundary.
+    --
+    -- The trust-boundary wrap (@Result Error _@) is what HM
+    -- actually enforces here. Per CLAUDE.md "every FFI call
+    -- returns Result Error T", that's the load-bearing
+    -- invariant. The opaque-type name itself is decorative — the
+    -- runtime wrapper still does the .(*pkg.X) assertion at the
+    -- Go boundary, so a wrong opaque mixed across packages
+    -- panics at the wrapper with ErrFfi (same failure mode as
+    -- before this work).
+    --
+    -- Future-work fix is for the inspector to emit fully-qualified
+    -- Go package paths in skyType so distinct opaque types
+    -- stay distinct at HM time. Tracked in the accompanying
+    -- commit message.
+    opaqueValue :: Can.Type
+    opaqueValue = Can.TType (ModuleName.Canonical "") "Value" []
 
     -- Closed list of recognised builtin type constructors. Order is
     -- arbitrary — it's a small lookup. Keeping it explicit (rather

--- a/src/Sky/Build/FfiTypeResolve.hs
+++ b/src/Sky/Build/FfiTypeResolve.hs
@@ -1,0 +1,116 @@
+{-# LANGUAGE LambdaCase #-}
+-- | Phase C plumbing: convert the producer-side FtyAst (parsed
+-- from kernel.json's skyType field) into a canonical 'Can.Type' /
+-- 'Can.Annotation' that the constraint generator can plug into a
+-- @T.CForeign@ for the matching @Can.VarKernel@ reference.
+--
+-- Lives in Sky.Build (alongside FfiRegistry / FfiTypeParser) so the
+-- Sky.Type.Constrain layer doesn't import producer-side modules.
+-- The Sky.Type side just queries the Map populated here.
+module Sky.Build.FfiTypeResolve
+    ( ftyToAnnotation
+    , ftyToType
+    ) where
+
+import Data.List (nub)
+import qualified Data.Map.Strict as Map
+import qualified Sky.AST.Canonical as Can
+import qualified Sky.Sky.ModuleName as ModuleName
+import Sky.Build.FfiTypeParser (FtyAst(..))
+
+
+-- | Build a 'Can.Annotation' (i.e. @Forall [tvars] Type@) from an
+-- FtyAst, namespacing any unrecognised opaque uppercase identifier
+-- under the given kernel name (e.g. @ActionCodeSettings@ from the
+-- @Auth@ kernel becomes @TType (Canonical "Auth") "ActionCodeSettings" []@).
+--
+-- The 'Forall' binder collects every distinct lowercase TVar
+-- encountered, including the wildcard @any@. Sky.Type.Solve gives
+-- @TVar "any"@ wildcard semantics — distinct occurrences mint fresh
+-- unification vars (Limitation #18 fix). For any other lowercase,
+-- a single Forall scope per FFI symbol is correct: two occurrences
+-- of @a@ in the same skyType (e.g. @a -> Result Error a@) MUST
+-- unify, since they're the same parameter / return position.
+ftyToAnnotation :: String -> FtyAst -> Can.Annotation
+ftyToAnnotation kernelName ast =
+    let ty = ftyToType kernelName ast
+        tvars = nub (collectTVars ty)
+    in Can.Forall tvars ty
+
+
+-- | Convert FtyAst to a canonical 'Can.Type'. Recognised builtins
+-- (Result / Maybe / List / Dict / Task / Set / Error / String /
+-- Int / Bool / Float / Char / Bytes) resolve to their canonical
+-- module homes via 'Sky.Sky.ModuleName' helpers; everything else
+-- becomes an opaque @TType@ namespaced under the FFI kernel.
+--
+-- Multiple FFI modules can each define their own 'Token' / 'Config'
+-- without collision — each kernelName is a separate canonical home,
+-- and TType identity is by (home, name, args).
+ftyToType :: String -> FtyAst -> Can.Type
+ftyToType kernelName = go
+  where
+    go = \case
+        FtyVar name           -> Can.TVar name
+        FtyUnit               -> Can.TUnit
+        FtyArrow a b          -> Can.TLambda (go a) (go b)
+        FtyTuple [t1, t2]     -> Can.TTuple (go t1) (go t2) []
+        FtyTuple (t1:t2:rest) -> Can.TTuple (go t1) (go t2) (map go rest)
+        FtyTuple _            ->
+            -- Single-element tuple is illegal Sky syntax; if it ever
+            -- escapes the parser, treat it as a unit fallback rather
+            -- than panic.
+            Can.TUnit
+        FtyApp name args      -> goApp name (map go args)
+
+    goApp :: String -> [Can.Type] -> Can.Type
+    goApp name args = case lookup name builtinHome of
+        Just home -> Can.TType home name args
+        Nothing   -> Can.TType (ModuleName.Canonical kernelName) name args
+
+    -- Closed list of recognised builtin type constructors. Order is
+    -- arbitrary — it's a small lookup. Keeping it explicit (rather
+    -- than a ModuleName.builtins helper) means an FFI package's
+    -- own type accidentally named e.g. @List@ would still resolve
+    -- to Sky's List, which is the correct behaviour: HM treats them
+    -- as the same type, and the runtime wrapper can do an interface
+    -- bridge if needed.
+    builtinHome :: [(String, ModuleName.Canonical)]
+    builtinHome =
+        [ ("String",  ModuleName.basics)
+        , ("Int",     ModuleName.basics)
+        , ("Bool",    ModuleName.basics)
+        , ("Float",   ModuleName.basics)
+        , ("Char",    ModuleName.basics)
+        , ("Bytes",   ModuleName.basics)
+        , ("Error",   ModuleName.Canonical "Sky.Core.Error")
+        , ("Result",  ModuleName.result_)
+        , ("Maybe",   ModuleName.maybe_)
+        , ("List",    ModuleName.list)
+        , ("Dict",    ModuleName.dict)
+        , ("Set",     ModuleName.set)
+        , ("Task",    ModuleName.task)
+        ]
+
+
+-- | Walk a Can.Type collecting every TVar name. Order is
+-- deterministic (left-to-right traversal) — 'nub' on the result
+-- deduplicates while preserving first-seen order so the Forall
+-- binder list mirrors the natural reading order of the type
+-- string.
+collectTVars :: Can.Type -> [String]
+collectTVars = \case
+    Can.TVar n        -> [n]
+    Can.TUnit         -> []
+    Can.TLambda a b   -> collectTVars a ++ collectTVars b
+    Can.TTuple a b cs -> collectTVars a ++ collectTVars b ++ concatMap collectTVars cs
+    Can.TType _ _ ts  -> concatMap collectTVars ts
+    Can.TRecord fs r  ->
+        concatMap (collectTVars . Can._fieldType) (Map.elems fs)
+            ++ maybe [] (\v -> [v]) r
+    Can.TAlias _ _ binders body ->
+        concatMap (collectTVars . snd) binders
+            ++ collectAliasBody body
+  where
+    collectAliasBody (Can.Hoisted t) = collectTVars t
+    collectAliasBody (Can.Filled  t) = collectTVars t

--- a/src/Sky/Canonicalise/Environment.hs
+++ b/src/Sky/Canonicalise/Environment.hs
@@ -281,6 +281,23 @@ ffiKernelArityRef :: IORef (Map.Map (String, String) Int)
 ffiKernelArityRef = unsafePerformIO (newIORef Map.empty)
 
 
+-- | Phase C: per-FFI-function Sky-side type, populated from the
+-- @skyType@ field in @.skycache/ffi/<slug>.kernel.json@. Keyed by
+-- @(kernelName, funcName)@. Sky.Type.Constrain.Expression's
+-- @Can.VarKernel@ arm consults this when @lookupKernelType@
+-- (the stdlib-kernel sig table) returns Nothing — turning every
+-- typed FFI symbol into a load-bearing constraint at the call
+-- site instead of the previous polymorphic-any fallthrough.
+--
+-- Empty unless seeded by 'Sky.Build.Compile.loadAndSeedFfiRegistry';
+-- the empty map keeps existing behaviour for FFI symbols whose
+-- kernel.json has no @skyType@ field (legacy files / pathological
+-- shapes filtered by 'isSkyParseable' in FfiGen).
+{-# NOINLINE ffiKernelTypeRef #-}
+ffiKernelTypeRef :: IORef (Map.Map (String, String) Can.Annotation)
+ffiKernelTypeRef = unsafePerformIO (newIORef Map.empty)
+
+
 -- | P7: names of FFI kernel functions (in the <Kernel>_<func> shape,
 -- e.g. "Go_Uuid_newString") for which a typed T-suffix wrapper has
 -- been emitted by FfiGen. Call-site codegen consults this set to

--- a/src/Sky/Type/Constrain/Expression.hs
+++ b/src/Sky/Type/Constrain/Expression.hs
@@ -11,7 +11,6 @@ module Sky.Type.Constrain.Expression
 
 import Data.IORef
 import qualified Data.Map.Strict as Map
-import qualified System.Environment
 import System.IO.Unsafe (unsafePerformIO)
 import qualified Sky.AST.Canonical as Can
 import qualified Sky.Reporting.Annotation as A
@@ -128,35 +127,25 @@ constrain counter env (A.At region expr) expected = case expr of
             Just annot ->
                 return $ T.CForeign region (modName ++ "." ++ funcName) annot expected
             Nothing -> do
-                -- Phase C: per-FFI-function Sky-side type seeded by
+                -- Per-FFI-function Sky-side type seeded by
                 -- 'Sky.Build.Compile.loadAndSeedFfiRegistry' from
                 -- kernel.json's @skyType@ field. When present,
                 -- emits a CForeign so the call site has to match
                 -- the registered shape — including the runtime
                 -- @Result Error _@ wrap. When absent (older
                 -- kernel.json or pathological FFI shapes filtered
-                -- by 'isSkyParseable'), fall through to the legacy
-                -- polymorphic-any path so existing FFI use is not
-                -- broken by an incomplete registry.
-                --
-                -- Behind the SKY_FFI_TYPED env var while the
-                -- migration sweeps in. Default-off means existing
-                -- user code keeps the polymorphic-any FFI surface;
-                -- users opt in to the stricter trust-boundary
-                -- enforcement by setting SKY_FFI_TYPED=1 (in shell
-                -- or sky.toml). Once an example sweep migrates
-                -- every example to the new shape, this gate flips
-                -- to default-on and the env var becomes the
-                -- escape hatch (same shape as SKY_SOLVER_BUDGET).
-                enabled <- ffiTypedEnabled
-                if not enabled
-                    then return T.CTrue
-                    else do
-                        ffiTypes <- readIORef Env.ffiKernelTypeRef
-                        case Map.lookup (modName, funcName) ffiTypes of
-                            Just annot ->
-                                return $ T.CForeign region (modName ++ "." ++ funcName) annot expected
-                            Nothing -> return T.CTrue
+                -- by 'isSkyParseable'), fall through to the
+                -- legacy polymorphic-any path. The trust-boundary
+                -- rule (CLAUDE.md "every FFI call returns Result
+                -- Error T") is HM-enforced for every typed entry
+                -- — bare-using a Result-wrapped FFI return is now
+                -- a TYPE ERROR with a hint pointing at
+                -- @case ... of Ok v -> ...@ or @Result.andThen@.
+                ffiTypes <- readIORef Env.ffiKernelTypeRef
+                case Map.lookup (modName, funcName) ffiTypes of
+                    Just annot ->
+                        return $ T.CForeign region (modName ++ "." ++ funcName) annot expected
+                    Nothing -> return T.CTrue
 
     Can.VarCtor _opts _home _typeName ctorName annot ->
         return $ T.CForeign region ctorName annot expected
@@ -837,36 +826,6 @@ zipWithM :: Monad m => (a -> b -> m c) -> [a] -> [b] -> m [c]
 zipWithM f xs ys = sequence (zipWith f xs ys)
 
 
--- | Whether to apply the per-FFI-symbol HM constraint emitted by
--- Sky.Build.Compile.loadAndSeedFfiRegistry's typeMap. Off by
--- default while the example sweep migrates to the typed
--- trust-boundary surface; opt in via the SKY_FFI_TYPED env var.
---
--- Memoised in an IORef so 1000s of constrain calls don't each hit
--- the lookupEnv syscall.
-{-# NOINLINE ffiTypedEnabledRef #-}
-ffiTypedEnabledRef :: IORef (Maybe Bool)
-ffiTypedEnabledRef = unsafePerformIO (newIORef Nothing)
-
-
-ffiTypedEnabled :: IO Bool
-ffiTypedEnabled = do
-    cached <- readIORef ffiTypedEnabledRef
-    case cached of
-        Just b -> return b
-        Nothing -> do
-            v <- lookupEnvIO "SKY_FFI_TYPED"
-            let on = case v of
-                    Just s | s `elem` ["1", "true", "TRUE", "on", "ON", "yes", "YES"] -> True
-                    _ -> False
-            writeIORef ffiTypedEnabledRef (Just on)
-            return on
-
-
-lookupEnvIO :: String -> IO (Maybe String)
-lookupEnvIO = System.Environment.lookupEnv
-
-
 lookupKernelType :: String -> String -> Maybe T.Annotation
 lookupKernelType modName funcName = case (modName, funcName) of
     -- Log.println : String -> Task Error () — observable side
@@ -1463,6 +1422,15 @@ lookupKernelType modName funcName = case (modName, funcName) of
     -- context.Context; Sky exposes these as `rt.SkyValue` so user
     -- wrappers like `ctx = Context.background ()` don't degrade to
     -- `any` in the emitted Go sig.
+    -- Basics.js — legacy FFI escape hatch. `js "nil"` returns a
+    -- raw Go nil for FFI positions that need it (Firebase.newApp's
+    -- middle config arg, Stripe Session.get's optional params,
+    -- etc.). Sky code outside the FFI boundary doesn't reach for
+    -- this. Polymorphic input + polymorphic output so it slots
+    -- into any opaque slot HM expects.
+    ("Basics", "js") ->
+        Just $ T.Forall ["a", "b"]
+            (T.TLambda (T.TVar "a") (T.TVar "b"))
     ("Context", "background") ->
         Just $ T.Forall []
             (T.TLambda T.TUnit

--- a/src/Sky/Type/Constrain/Expression.hs
+++ b/src/Sky/Type/Constrain/Expression.hs
@@ -16,6 +16,7 @@ import qualified Sky.AST.Canonical as Can
 import qualified Sky.Reporting.Annotation as A
 import qualified Sky.Type.Type as T
 import qualified Sky.Sky.ModuleName as ModuleName
+import qualified Sky.Canonicalise.Environment as Env
 
 
 -- | Type environment: maps variable names to their type schemes
@@ -119,10 +120,28 @@ constrain counter env (A.At region expr) expected = case expr of
             Nothing ->
                 return $ T.CLocal region name expected
 
-    Can.VarKernel modName funcName ->
+    Can.VarKernel modName funcName -> do
+        -- Stdlib kernel sigs (handcoded in lookupKernelType) take
+        -- precedence — they're the most carefully audited surface.
         case lookupKernelType modName funcName of
-            Just annot -> return $ T.CForeign region (modName ++ "." ++ funcName) annot expected
-            Nothing -> return T.CTrue
+            Just annot ->
+                return $ T.CForeign region (modName ++ "." ++ funcName) annot expected
+            Nothing -> do
+                -- Phase C: per-FFI-function Sky-side type seeded by
+                -- 'Sky.Build.Compile.loadAndSeedFfiRegistry' from
+                -- kernel.json's @skyType@ field. When present,
+                -- emits a CForeign so the call site has to match
+                -- the registered shape — including the runtime
+                -- @Result Error _@ wrap. When absent (older
+                -- kernel.json or pathological FFI shapes filtered
+                -- by 'isSkyParseable'), fall through to the legacy
+                -- polymorphic-any path so existing FFI use is not
+                -- broken by an incomplete registry.
+                ffiTypes <- readIORef Env.ffiKernelTypeRef
+                case Map.lookup (modName, funcName) ffiTypes of
+                    Just annot ->
+                        return $ T.CForeign region (modName ++ "." ++ funcName) annot expected
+                    Nothing -> return T.CTrue
 
     Can.VarCtor _opts _home _typeName ctorName annot ->
         return $ T.CForeign region ctorName annot expected

--- a/src/Sky/Type/Constrain/Expression.hs
+++ b/src/Sky/Type/Constrain/Expression.hs
@@ -11,6 +11,7 @@ module Sky.Type.Constrain.Expression
 
 import Data.IORef
 import qualified Data.Map.Strict as Map
+import qualified System.Environment
 import System.IO.Unsafe (unsafePerformIO)
 import qualified Sky.AST.Canonical as Can
 import qualified Sky.Reporting.Annotation as A
@@ -137,11 +138,25 @@ constrain counter env (A.At region expr) expected = case expr of
                 -- by 'isSkyParseable'), fall through to the legacy
                 -- polymorphic-any path so existing FFI use is not
                 -- broken by an incomplete registry.
-                ffiTypes <- readIORef Env.ffiKernelTypeRef
-                case Map.lookup (modName, funcName) ffiTypes of
-                    Just annot ->
-                        return $ T.CForeign region (modName ++ "." ++ funcName) annot expected
-                    Nothing -> return T.CTrue
+                --
+                -- Behind the SKY_FFI_TYPED env var while the
+                -- migration sweeps in. Default-off means existing
+                -- user code keeps the polymorphic-any FFI surface;
+                -- users opt in to the stricter trust-boundary
+                -- enforcement by setting SKY_FFI_TYPED=1 (in shell
+                -- or sky.toml). Once an example sweep migrates
+                -- every example to the new shape, this gate flips
+                -- to default-on and the env var becomes the
+                -- escape hatch (same shape as SKY_SOLVER_BUDGET).
+                enabled <- ffiTypedEnabled
+                if not enabled
+                    then return T.CTrue
+                    else do
+                        ffiTypes <- readIORef Env.ffiKernelTypeRef
+                        case Map.lookup (modName, funcName) ffiTypes of
+                            Just annot ->
+                                return $ T.CForeign region (modName ++ "." ++ funcName) annot expected
+                            Nothing -> return T.CTrue
 
     Can.VarCtor _opts _home _typeName ctorName annot ->
         return $ T.CForeign region ctorName annot expected
@@ -820,6 +835,36 @@ defTypeInfoIO counter (Can.DestructDef _ _) = do
 
 zipWithM :: Monad m => (a -> b -> m c) -> [a] -> [b] -> m [c]
 zipWithM f xs ys = sequence (zipWith f xs ys)
+
+
+-- | Whether to apply the per-FFI-symbol HM constraint emitted by
+-- Sky.Build.Compile.loadAndSeedFfiRegistry's typeMap. Off by
+-- default while the example sweep migrates to the typed
+-- trust-boundary surface; opt in via the SKY_FFI_TYPED env var.
+--
+-- Memoised in an IORef so 1000s of constrain calls don't each hit
+-- the lookupEnv syscall.
+{-# NOINLINE ffiTypedEnabledRef #-}
+ffiTypedEnabledRef :: IORef (Maybe Bool)
+ffiTypedEnabledRef = unsafePerformIO (newIORef Nothing)
+
+
+ffiTypedEnabled :: IO Bool
+ffiTypedEnabled = do
+    cached <- readIORef ffiTypedEnabledRef
+    case cached of
+        Just b -> return b
+        Nothing -> do
+            v <- lookupEnvIO "SKY_FFI_TYPED"
+            let on = case v of
+                    Just s | s `elem` ["1", "true", "TRUE", "on", "ON", "yes", "YES"] -> True
+                    _ -> False
+            writeIORef ffiTypedEnabledRef (Just on)
+            return on
+
+
+lookupEnvIO :: String -> IO (Maybe String)
+lookupEnvIO = System.Environment.lookupEnv
 
 
 lookupKernelType :: String -> String -> Maybe T.Annotation

--- a/src/Sky/Type/Solve.hs
+++ b/src/Sky/Type/Solve.hs
@@ -328,7 +328,8 @@ solveHelpBody state constraint = case constraint of
                 -- Debug: read back actual resolved types
                 at <- variableToType actualVar
                 et <- variableToType expectedVar
-                return (Just $ posPrefix region ++ "Type mismatch: " ++ showType at ++ " vs " ++ showType et ++ " (from: " ++ showType actualType ++ " vs " ++ showExpected expected ++ ")", state)
+                let hint = resultMismatchHint at et
+                return (Just $ posPrefix region ++ "Type mismatch: " ++ showType at ++ " vs " ++ showType et ++ " (from: " ++ showType actualType ++ " vs " ++ showExpected expected ++ ")" ++ hint, state)
 
     T.CLocal region name expected -> do
         case Map.lookup name (_env state) of
@@ -337,7 +338,13 @@ solveHelpBody state constraint = case constraint of
                 ok <- Unify.unify var expectedVar
                 if ok
                     then return (Nothing, state)
-                    else return (Just $ posPrefix region ++ "Variable '" ++ name ++ "' type mismatch", state)
+                    else do
+                        vt <- variableToType var
+                        et <- variableToType expectedVar
+                        let hint = resultMismatchHint vt et
+                        return (Just $ posPrefix region ++ "Variable '" ++ name
+                                ++ "' type mismatch: " ++ showType vt
+                                ++ " vs " ++ showType et ++ hint, state)
             Nothing -> do
                 -- Unknown variable — create a fresh flex var and add to env
                 freshVar <- UF.fresh (T.Descriptor (T.FlexVar (Just name)) (_rank state) T.noMark Nothing)
@@ -361,8 +368,10 @@ solveHelpBody state constraint = case constraint of
                 -- and panicked at runtime with `rt.AsBool: expected
                 -- bool, got rt.SkyResult[interface {},bool]`. Same
                 -- pattern as the dep-HM-fatal change.
+                let hint = resultMismatchHint instType expType
                 return (Just $ "Foreign '" ++ name ++ "': "
                         ++ showType instType ++ " vs " ++ showType expType
+                        ++ hint
                        , state)
 
     T.CPattern _region _category _actualType _expected ->
@@ -478,6 +487,54 @@ flatTypeToType flat = case flat of
 -- ═══════════════════════════════════════════════════════════
 -- TYPE DISPLAY
 -- ═══════════════════════════════════════════════════════════
+
+
+-- | When a unification failure has @Result Error _@ on one side and
+-- a bare type on the other, append a one-line hint pointing the
+-- user at the trust-boundary unwrap pattern. Per CLAUDE.md "every
+-- FFI call returns Result Error T" — so this mismatch shape
+-- usually means the user forgot to unwrap.
+--
+-- Returns @""@ when the hint isn't applicable (e.g. both sides
+-- are Result-typed, or neither is). Empty string composes
+-- harmlessly with the existing error string.
+--
+-- Detection is structural: look for @TType (Canonical "Sky.Core.
+-- Result") "Result" [_, _]@ at the top of one side. Lambda /
+-- arrow positions are skipped through to the result, since the
+-- common builder shape is @(Builder -> Builder)@ vs
+-- @(Result Error Builder -> Result Error Builder)@ — the
+-- mismatch lives at the param position there.
+resultMismatchHint :: T.Type -> T.Type -> String
+resultMismatchHint a b
+    | isResult a && not (isResult b)
+        = "\nHint: " ++ showType a ++ " is the Sky shape of a "
+       ++ "Go FFI call. Unwrap with `case x of Ok v -> ...` or "
+       ++ "compose via `Result.andThen` / `Result.withDefault`."
+    | not (isResult a) && isResult b
+        = "\nHint: " ++ showType b ++ " is the Sky shape of a "
+       ++ "Go FFI call. Unwrap with `case x of Ok v -> ...` or "
+       ++ "compose via `Result.andThen` / `Result.withDefault`."
+    -- Lambda / arrow pair: chase through the param position. The
+    -- common pattern that surfaces here is a setter being piped
+    -- via |> from a Result-producing builder — e.g.
+    --   Stripe.newX () |> Stripe.xSetMode "..."
+    -- where xSetMode : X -> Result Error X but |> hands it
+    -- Result Error X. Unification then sees X (the param) vs
+    -- Result Error X. We follow the lambdas to find the deepest
+    -- Result vs bare clash.
+    | T.TLambda ap ar <- a, T.TLambda bp br <- b
+        = let pHint = resultMismatchHint ap bp
+              rHint = resultMismatchHint ar br
+          in if not (null pHint) then pHint
+             else rHint
+    | otherwise = ""
+  where
+    isResult :: T.Type -> Bool
+    isResult (T.TType (ModuleName.Canonical mn) "Result" _) =
+        mn == "Sky.Core.Result"
+    isResult _ = False
+
 
 -- | Public entry point: rename fresh type variables to a, b, c, ...
 -- before rendering so hover/error messages don't leak solver-internal

--- a/test/Sky/Build/FfiTypeParserSpec.hs
+++ b/test/Sky/Build/FfiTypeParserSpec.hs
@@ -1,0 +1,140 @@
+module Sky.Build.FfiTypeParserSpec (spec) where
+
+-- Phase B regression fence for the FFI Sky-type parser. The
+-- producer side (Sky.Build.FfiGen.wrapperSkyType) emits a closed
+-- subset of Sky type-string syntax; this spec locks the parser to
+-- that grammar so a producer/consumer drift is caught at test
+-- time, not at "skyshop suddenly types every FFI call as `any`".
+--
+-- Inputs are sampled from real .skycache/ffi/*.kernel.json across
+-- examples/12-skyvote and examples/13-skyshop.
+
+import Test.Hspec
+import Sky.Build.FfiTypeParser (FtyAst(..), parseFty)
+
+
+-- Helper builders to keep test cases readable.
+unit, str, int_, bool_, float_, errTy, anyTy :: FtyAst
+unit  = FtyUnit
+str   = FtyApp "String" []
+int_  = FtyApp "Int" []
+bool_ = FtyApp "Bool" []
+float_ = FtyApp "Float" []
+errTy = FtyApp "Error" []
+anyTy = FtyVar "any"
+
+opaque :: String -> FtyAst
+opaque n = FtyApp n []
+
+result :: FtyAst -> FtyAst
+result inner = FtyApp "Result" [errTy, inner]
+
+list :: FtyAst -> FtyAst
+list inner = FtyApp "List" [inner]
+
+dict :: FtyAst -> FtyAst -> FtyAst
+dict k v = FtyApp "Dict" [k, v]
+
+maybe_ :: FtyAst -> FtyAst
+maybe_ inner = FtyApp "Maybe" [inner]
+
+
+spec :: Spec
+spec = do
+    describe "FtyAst parser (Phase B)" $ do
+
+        it "parses unit -> Result Error R (zero-arg constructor)" $
+            parseFty "() -> Result Error ActionCodeSettings"
+                `shouldBe` Just (FtyArrow unit (result (opaque "ActionCodeSettings")))
+
+        it "parses single-arg getter (Token -> Result Error String)" $
+            parseFty "Token -> Result Error String"
+                `shouldBe` Just (FtyArrow (opaque "Token") (result str))
+
+        it "parses curried setter (String -> T -> Result Error T)" $
+            parseFty "String -> ActionCodeSettings -> Result Error ActionCodeSettings"
+                `shouldBe`
+                    Just (FtyArrow str
+                            (FtyArrow (opaque "ActionCodeSettings")
+                                (result (opaque "ActionCodeSettings"))))
+
+        it "parses Bool / Int / Float result types" $ do
+            parseFty "X -> Result Error Bool"  `shouldBe`
+                Just (FtyArrow (opaque "X") (result bool_))
+            parseFty "X -> Result Error Int"   `shouldBe`
+                Just (FtyArrow (opaque "X") (result int_))
+            parseFty "X -> Result Error Float" `shouldBe`
+                Just (FtyArrow (opaque "X") (result float_))
+
+        it "parses Dict String any (interface{} mapped through goTypeToSky)" $
+            parseFty "Token -> Result Error (Dict String any)"
+                `shouldBe`
+                    Just (FtyArrow (opaque "Token") (result (dict str anyTy)))
+
+        it "parses List X" $
+            parseFty "() -> Result Error (List Item)"
+                `shouldBe` Just (FtyArrow unit (result (list (opaque "Item"))))
+
+        it "parses comma-ok Maybe shape" $
+            parseFty "Map -> String -> Result Error (Maybe Value)"
+                `shouldBe`
+                    Just (FtyArrow (opaque "Map")
+                            (FtyArrow str
+                                (result (maybe_ (opaque "Value")))))
+
+        it "parses tuple result (T, U)" $
+            parseFty "Reader -> Result Error (Token, String)"
+                `shouldBe`
+                    Just (FtyArrow (opaque "Reader")
+                            (result (FtyTuple [opaque "Token", str])))
+
+        it "parses tuple result (T, U, V)" $
+            parseFty "() -> Result Error (A, B, C)"
+                `shouldBe`
+                    Just (FtyArrow unit
+                            (result (FtyTuple
+                                [opaque "A", opaque "B", opaque "C"])))
+
+        it "treats lowercase identifiers as type vars" $ do
+            parseFty "a -> Result Error b"
+                `shouldBe` Just (FtyArrow (FtyVar "a") (result (FtyVar "b")))
+            -- 'any' is the wildcard; same parse shape, different
+            -- semantics downstream (Sky.Type.Solve mints fresh
+            -- unification var per occurrence).
+            parseFty "() -> Result Error any"
+                `shouldBe` Just (FtyArrow unit (result anyTy))
+
+        it "rejects strings with non-ident punctuation (channel arrows, braces)" $ do
+            -- The producer-side isSkyParseable is the primary gate
+            -- against pathological FFI shapes — the parser is the
+            -- secondary guard that fails fast on Go syntax that
+            -- leaks past the gate. `<-` (channel direction) and
+            -- `{` (struct/interface literal) are the markers we
+            -- can detect at lex time.
+            parseFty "Context -> Result Error <-chan struct{}"  `shouldBe` Nothing
+            parseFty "X -> Result Error interface{}"            `shouldBe` Nothing
+            -- Note: 'chan Int' parses as a valid (if nonsensical)
+            -- application — `chan` is just a lowercase TVar to
+            -- the parser. The producer's isSkyParseable check is
+            -- what prevents that string ever landing in JSON.
+
+        it "rejects empty input" $ do
+            parseFty ""              `shouldBe` Nothing
+            -- "() -> Foo Bar X garbage" IS legal grammar — Foo
+            -- applied to Bar, X, and the lowercase TVar 'garbage'.
+            -- The producer never emits this shape, but the parser
+            -- accepts it (and HM downstream will reject the
+            -- nonsense application if the constructor's kind
+            -- doesn't accept that many args).
+            parseFty "() -> Foo Bar X garbage" `shouldBe`
+                Just (FtyArrow unit
+                        (FtyApp "Foo" [opaque "Bar", opaque "X", FtyVar "garbage"]))
+
+        it "is total on malformed input" $ do
+            parseFty "->"            `shouldBe` Nothing
+            parseFty "(),"           `shouldBe` Nothing
+            parseFty "Result Error"  `shouldBe`
+                Just (FtyApp "Result" [errTy])
+                -- ^ this is "valid" — partial application of Result
+                -- to one type arg. The producer never emits this
+                -- shape, but the parser's grammar accepts it.

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -27,6 +27,7 @@ import qualified Sky.Build.ConsCtorPatternSpec
 import qualified Sky.Build.CtorConsPatternSpec
 import qualified Sky.Build.EnvPrefixSpec
 import qualified Sky.Build.FfiGenMultiSpec
+import qualified Sky.Build.FfiTypeParserSpec
 import qualified Sky.Build.TaskResultBridgesSpec
 import qualified Sky.Build.CheckIsBuildSpec
 import qualified Sky.Build.RecordFieldOrderSpec
@@ -174,6 +175,11 @@ main = hspec $ do
     -- the empty-list fast-path that lets `sky install` skip the
     -- inspector entirely on warm caches.
     describe "Sky.Build.FfiGenMulti"    Sky.Build.FfiGenMultiSpec.spec
+    -- Phase B regression fence for the FFI Sky-type parser used
+    -- by Sky.Build.FfiRegistry to lift kernel.json's `skyType`
+    -- field into a typed AST. Locks the closed grammar against
+    -- producer/consumer drift.
+    describe "Sky.Build.FfiTypeParser"  Sky.Build.FfiTypeParserSpec.spec
     -- Result/Task bridge helpers (Task.fromResult, Task.andThenResult,
     -- Result.andThenTask) — runtime + canonicaliser + kernel sigs gate.
     describe "Sky.Build.TaskResultBridges" Sky.Build.TaskResultBridgesSpec.spec

--- a/tools/sky-ffi-inspect/main.go
+++ b/tools/sky-ffi-inspect/main.go
@@ -59,9 +59,21 @@ import (
 )
 
 type Param struct {
-	Name   string     `json:"name,omitempty"`
-	Type   string     `json:"type"`
-	GoType types.Type `json:"-"` // unexported; used for interface-implements checks
+	Name string `json:"name,omitempty"`
+	// Type — the canonical Go type string (e.g. `string`,
+	// `*pkg.Foo`, `time.Duration`, `pkg.CheckoutSessionStatus`).
+	// Drives Go-wrapper code generation on the Haskell side, so
+	// derived types stay distinct from their underlying basic so
+	// the generated wrapper can build / cast correctly.
+	Type string `json:"type"`
+	// SkyType — Sky-side surface form. Differs from Type only when
+	// the type is a named alias of a basic type (Stripe's
+	// `type CheckoutSessionStatus string`, Firestore's
+	// `type Direction int`): SkyType collapses to the basic name
+	// so HM treats them as String / Int / Bool. Empty when SkyType
+	// equals Type — Haskell side defaults to Type when empty.
+	SkyType string     `json:"skyType,omitempty"`
+	GoType  types.Type `json:"-"` // unexported; used for interface-implements checks
 }
 
 type Function struct {
@@ -213,14 +225,14 @@ func walkPackage(requestedPath string, pkg *packages.Package) PackageInfo {
 			info.Functions = append(info.Functions, Function{
 				Name:     v.Name(),
 				Params:   []Param{{Name: "_", Type: "struct{}"}},
-				Results:  []Param{{Type: v.Type().String()}},
+				Results:  []Param{paramFor(v.Type())},
 				Effect:   "pure",
 				Exported: true,
 				IsPkgVar: true,
 			})
 			info.Functions = append(info.Functions, Function{
 				Name:       "Set" + v.Name(),
-				Params:     []Param{{Name: "value", Type: v.Type().String()}},
+				Params:     []Param{paramForNamed("value", v.Type())},
 				Results:    []Param{{Type: "struct{}"}},
 				Effect:     "effectful",
 				Exported:   true,
@@ -234,7 +246,7 @@ func walkPackage(requestedPath string, pkg *packages.Package) PackageInfo {
 			info.Functions = append(info.Functions, Function{
 				Name:     c.Name(),
 				Params:   []Param{{Name: "_", Type: "struct{}"}},
-				Results:  []Param{{Type: c.Type().String()}},
+				Results:  []Param{paramFor(c.Type())},
 				Effect:   "pure",
 				Exported: true,
 				IsPkgVar: true,
@@ -371,7 +383,7 @@ func paramsOf(sig *types.Signature) []Param {
 	out := make([]Param, 0, sig.Params().Len())
 	for i := 0; i < sig.Params().Len(); i++ {
 		p := sig.Params().At(i)
-		out = append(out, Param{Name: p.Name(), Type: p.Type().String()})
+		out = append(out, paramForNamed(p.Name(), p.Type()))
 	}
 	return out
 }
@@ -380,9 +392,72 @@ func resultsOf(sig *types.Signature) []Param {
 	out := make([]Param, 0, sig.Results().Len())
 	for i := 0; i < sig.Results().Len(); i++ {
 		r := sig.Results().At(i)
-		out = append(out, Param{Name: r.Name(), Type: r.Type().String(), GoType: r.Type()})
+		out = append(out, withGoType(paramForNamed(r.Name(), r.Type()), r.Type()))
 	}
 	return out
+}
+
+// paramFor / paramForNamed build Param values with both fields
+// populated: Type stays the canonical Go-type rendering (drives
+// wrapper code generation), SkyType collapses derived-of-basic
+// types so HM treats them as their underlying basic.
+func paramFor(t types.Type) Param {
+	gt := t.String()
+	st := skyTypeOf(t)
+	if st == gt {
+		return Param{Type: gt}
+	}
+	return Param{Type: gt, SkyType: st}
+}
+
+func paramForNamed(name string, t types.Type) Param {
+	p := paramFor(t)
+	p.Name = name
+	return p
+}
+
+func withGoType(p Param, gt types.Type) Param {
+	p.GoType = gt
+	return p
+}
+
+
+// skyTypeOf renders a Go type as the string the Sky-side
+// goTypeToSky translator expects, with one important
+// transformation versus the bare types.Type.String() path: a
+// named type whose underlying is a basic type (Stripe's
+// `type CheckoutSessionStatus string`, Firestore's
+// `type Direction int`, etc.) collapses to the underlying
+// basic-type name. Without this, Sky-side HM treats every
+// such enum as an opaque "Value", forcing user code into
+// awkward `case ... of Ok v -> ... ; Err _ -> default` shapes
+// for what is structurally a String / Int / Bool comparison.
+//
+// Pointer / slice / map / chan / func types recurse so
+// `[]CheckoutSessionStatus` becomes `[]string` and
+// `map[string]CheckoutSessionStatus` becomes
+// `map[string]string`. Struct-shaped named types stay
+// opaque (we render them as the package-qualified name) —
+// only the basic-underlying case unwraps.
+func skyTypeOf(t types.Type) string {
+	switch tt := t.(type) {
+	case *types.Pointer:
+		return "*" + skyTypeOf(tt.Elem())
+	case *types.Slice:
+		return "[]" + skyTypeOf(tt.Elem())
+	case *types.Array:
+		return tt.String() // fall back; Sky doesn't see fixed-size arrays separately
+	case *types.Map:
+		return "map[" + skyTypeOf(tt.Key()) + "]" + skyTypeOf(tt.Elem())
+	case *types.Named:
+		// Unwrap derived-from-basic types (Stripe-style enums).
+		if basic, ok := tt.Underlying().(*types.Basic); ok {
+			return basic.Name()
+		}
+		return tt.String()
+	default:
+		return t.String()
+	}
 }
 
 func describeMethod(typeName string, fn *types.Func, sig *types.Signature, recvType types.Type) Function {
@@ -461,7 +536,7 @@ func addFieldGetters(info *PackageInfo, s *types.Struct, typeName string, named 
 			info.Functions = append(info.Functions, Function{
 				Name:       getterName,
 				Params:     []Param{{Name: "recv", Type: recvType}},
-				Results:    []Param{{Type: f.Type().String()}},
+				Results:    []Param{paramFor(f.Type())},
 				Effect:     "pure",
 				Exported:   true,
 				RecvType:   typeName,
@@ -476,7 +551,7 @@ func addFieldGetters(info *PackageInfo, s *types.Struct, typeName string, named 
 				Name: setterName,
 				// value-first, receiver second — matches Sky pipeline idiom.
 				Params: []Param{
-					{Name: "value", Type: f.Type().String()},
+					paramForNamed("value", f.Type()),
 					{Name: "recv", Type: recvType},
 				},
 				Results:    []Param{{Type: recvType}},
@@ -516,7 +591,7 @@ func addInterfaceMethods(info *PackageInfo, iface *types.Interface, typeName str
 		}
 		info.Functions = append(info.Functions, Function{
 			Name:       name,
-			Params:     append([]Param{{Name: "recv", Type: named.Obj().Type().String()}}, paramsOf(sig)...),
+			Params:     append([]Param{paramForNamed("recv", named.Obj().Type())}, paramsOf(sig)...),
 			Results:    resultsOf(sig),
 			Variadic:   sig.Variadic(),
 			Effect:     classifyEffect(resultsOf(sig)),
@@ -543,12 +618,12 @@ func describe(fn *types.Func, sig *types.Signature) Function {
 	params := []Param{}
 	for i := 0; i < sig.Params().Len(); i++ {
 		p := sig.Params().At(i)
-		params = append(params, Param{Name: p.Name(), Type: p.Type().String()})
+		params = append(params, paramForNamed(p.Name(), p.Type()))
 	}
 	results := []Param{}
 	for i := 0; i < sig.Results().Len(); i++ {
 		r := sig.Results().At(i)
-		results = append(results, Param{Name: r.Name(), Type: r.Type().String()})
+		results = append(results, paramForNamed(r.Name(), r.Type()))
 	}
 	return Function{
 		Name:     fn.Name(),


### PR DESCRIPTION
## Summary

The Sky runtime has always wrapped Go FFI calls in `SkyResult[any, T]` (per CLAUDE.md non-negotiable: "every FFI call returns `Result Error T`"). The Sky type-checker, however, had no idea — every FFI symbol resolved to polymorphic `any`. Code like

\`\`\`elm
ctx = Context.background ()                -- actually: Result Error Context
Firestore.newClient ctx (projectId ()) []  -- expects Context; got Result; HM silent
\`\`\`

compiled fine and panicked at runtime with `rt.AsBool: expected bool, got rt.SkyResult[…]` somewhere unrelated to the offending call.

This PR closes the gap. Every typed FFI symbol is now load-bearing in HM: bare-using a Result-wrapped FFI return is a `TYPE ERROR` with a friendly hint pointing at the trust-boundary unwrap pattern.

## What's in the box

### Compiler — FFI Result-type enforcement (5 phases, default-on)

| Phase | What |
|---|---|
| **A** | `tools/sky-ffi-inspect` + `Sky.Build.FfiGen` emit a `skyType` field per function in `.skycache/ffi/<slug>.kernel.json`, mirroring the actual SkyResult-wrapped shape. 99.99%+ coverage on real surfaces (auth: 472/472, firestore: 995/995, stripe: 73 321/73 321, http: 523/526 — only channel-typed shapes skip). |
| **B** | New `Sky.Build.FfiTypeParser` — closed-grammar mini-AST for the producer/consumer contract (~150 lines, total parser, 13-case regression fence in `test/Sky/Build/FfiTypeParserSpec.hs`). |
| **C** | `Sky.Build.FfiTypeResolve` lifts the parsed AST into a canonical `Type` and an `Annotation`. `Sky.Canonicalise.Environment` adds `ffiKernelTypeRef`. `Sky.Type.Constrain.Expression`'s `Can.VarKernel` arm consults the registry and emits `T.CForeign` — every typed FFI symbol becomes a constraint at the call site. |
| **D** | `Sky.Type.Solve.resultMismatchHint` detects unification failures where one side is `Result Error _` and the other a bare type, and appends a one-line hint pointing at `case ... of Ok v ->` or `Result.andThen`. Wired into `T.CEqual` / `T.CLocal` / `T.CForeign` mismatch paths. |
| **E** *(landed then removed)* | Was a `SKY_FFI_TYPED` env-var gate while the migration sweep ran. Default-on now; no env var, no escape hatch. |

**Inspector improvement**: `tools/sky-ffi-inspect` now collapses Go `type X string` / `type X int` derivatives (Stripe enums, Firestore Direction, etc.) to their underlying primitive on the Sky side. Without this, every Stripe enum surfaced as opaque `Value` and user code couldn't compare it as a String without `Result.withDefault` dances. The original Go type is preserved in the `type` field for wrapper code generation; the simplified form lands in a parallel `skyType` field for HM.

**`Basics.js` polymorphic sig**: `js "nil"` legacy escape hatch (used for Go-side nil at FFI call sites — `Firebase.newApp ctx (js \"nil\") opts`, `Stripe.Session.Get id (js \"nil\")`) is now typed `forall a b. a -> b` so it slots into any opaque position HM expects.

### Trade-off accepted

Opaque FFI types collapse to a single `Value` sentinel HM-side, so `auth.Token` and `oauth2.Token` unify even though they're different Go structs. The runtime wrapper still does the `.(*pkg.X)` Go-side assertion at the boundary, so wrong opaque mixed across packages still panics with `ErrFfi` at the wrapper — exactly the same failure mode as before. Net: HM gains for shared Go-stdlib types flowing across kernels (`context.Context`, `time.Time`, `io.Reader`); no regressions.

### Bugs the new HM check surfaced (now fixed in this PR)

- **skyshop** (8 sites): `ctx = Context.background ()` bare-used; Stripe builder pipelines (`|> Stripe.xSet "..."`) needed `Result.andThen`; `[Firestore.mergeAll ()]` list literals; `case Customer.iterNext iter` bool wrap; `case Stripe.customerID c` String wrap; etc. Every site is a real trust-boundary violation that was silently working under the any-typed surface.
- **03-tea-external** + **05-mux-server**: `Err e -> "..." ++ e` — `e : Error`, not `String`. The runtime had been silently `fmt.Sprintf("%v")`-ing the Error.

### CLI improvements

- `sky upgrade-claude`: refresh project's `CLAUDE.md` from the binary's embedded template (so users tracking the latest API don't have to manually re-init projects).

### Verification harness — `_verify/` end-to-end recordings

`scripts/verify-examples.{sh,mjs}` (new) drives every example end-to-end through Playwright + real Chromium, with full session video, per-step screenshots, and assertion contracts.

Per example, where applicable:

| App | Auth flow | Use-the-app journey |
|---|---|---|
| 08-notes-app | sign-up form → server prints verify URL to stdout → harness greps it via `extractFromLog` action → opens the link → signin form (real bcrypt+sqlite) | create note via `/notes/new` → list shows the new note |
| 12-skyvote | sign-up form (3 fields, Sky.Live) | submit a Feature Idea → board shows it → sign out |
| 17-skymon | admin / admin123 sign-in | settings → add a Monitor → dashboard counter increments → sign out |
| 19-skyforum | sign-in form (Sky.Live `onSubmit`) | upvote post (142→143) → open detail → post a comment ("Hello from verify harness …" appears as 6th comment) → logout |
| 13-skyshop | (Firebase, no test creds) | browse Home / Products / Cart / Orders without runtime errors |
| 16-skychess | (no auth) | enter name → New Game → click first move; chess board renders with player name |
| 09 / 10 / 18 | (no auth) | counter +/− / job queue dispatch via SSE |
| 05 / 15 | (HTTP) | route navigation (`/ping` → "pong") |
| 01-04 / 06-07 / 14 | CLI | exit-code + stdout substring assertion |

**Outputs per example** in `_verify/<example>/` (gitignored, regenerated on every sweep, fresh-on-full-sweep):

- `screenshot-before.png` — initial render
- `step-NN-<verb>-<locator-slug>.png` — one per action
- `screenshot.png` — final state
- `video.webm` — full session recording (~200 KB per app)
- `page-before.html` / `page.html` — DOM snapshots
- `console.log` / `app.log` / `verify.log` — JS console + server stdout + harness log

**Sweep**: `scripts/verify-examples.sh` → **18/18 passed** against a fully-wiped `_verify/`.

### Other quality-of-life improvements

- `sky fmt` sweep across all examples (123/126 reformatted; 3 hold out on a pre-existing formatter limitation around comment-bearing modules — same on main).
- `cabal test` clean (165/168 — 3 pre-existing concurrency flakes around `.skycache` contention; pass in isolation).

## Files of interest

- `src/Sky/Build/FfiTypeParser.hs` — new mini-parser
- `src/Sky/Build/FfiTypeResolve.hs` — new FtyAst → canonical Type lifting
- `src/Sky/Type/Solve.hs` — `resultMismatchHint`
- `tools/sky-ffi-inspect/main.go` — `skyTypeOf` derived-type unwrap + `paramFor` helpers
- `scripts/verify-examples.{sh,mjs}` — Playwright harness
- `package.json` — declares Playwright dev-dep (node_modules gitignored)

## Test plan
- [x] `cabal test` (modulo flakes)
- [x] `scripts/verify-examples.sh` 18/18 with fresh `_verify/` artefacts
- [x] Skyshop end-to-end via Stripe-style builder pipelines
- [x] 19-skyforum auth + upvote + comment round-trip captured visually
- [x] 08-notes-app email verification: stdout URL grep + click + signin + CRUD
- [x] No `SKY_FFI_TYPED` opt-in needed; default behaviour
- [x] `js "nil"` polymorphic — Firebase/Stripe nil-config call sites still compile
- [ ] Release CI green across Linux x64 / Linux arm64 / macOS arm64 / Windows x64