### PR TITLE
docs: SKY_ADMIN_TOKEN is canonical (SKY_METRICS_TOKEN is legacy alias)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Notable user-visible changes. Keep this file additive — never rewrite history.
 
+## v0.15.1 — Docs: `SKY_ADMIN_TOKEN` canonical (2026-05-24)
+
+- **Docs: `SKY_ADMIN_TOKEN` is the canonical env var** for gating
+  `/_sky/metrics` and `/_sky/console` in production. The v0.15.0 doc
+  refresh accidentally kept `SKY_METRICS_TOKEN` (a v0.14.21 legacy
+  alias) as the recommended name in `README.md` + `CLAUDE.md` +
+  `templates/CLAUDE.md`. Runtime behaviour unchanged — both
+  `SKY_METRICS_TOKEN` (v0.14.21) and `SKY_CONSOLE_TOKEN_SECRET`
+  (v0.14.20) are still honoured by `adminTokenSecret()` in
+  `runtime-go/rt/subapp.go`.
+
 ## v0.15.0 — Type-directed lowering (2026-05-24)
 
 ### Type system

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -435,7 +435,8 @@ SKY_DEV_BANNER=on           # off suppresses the floating link (keeps mount)
 SKY_CONSOLE_URL=/_sky/console
 SKY_SUBAPP_VERBOSE=0        # 1 forwards spawned-child stdout/stderr to parent terminal
 SKY_BIN=…                   # override `sky` binary path for SpawnSkyConsole
-SKY_METRICS_TOKEN=…         # /_sky/metrics requires Bearer in production
+SKY_ADMIN_TOKEN=…           # /_sky/metrics + /_sky/console require Bearer in production
+                            # (legacy: SKY_METRICS_TOKEN / SKY_CONSOLE_TOKEN_SECRET still honoured)
 ```
 
 The production gate is `ENV` then `SKY_ENV` fallback. Unset OR

--- a/README.md
+++ b/README.md
@@ -325,7 +325,8 @@ DATABASE_URL=postgres://…   # fallback when SKY_LIVE_STORE_PATH unset
 SKY_AUTH_TOKEN_SECRET=…     # ≥32 bytes; Sky errors at startup if shorter
 SKY_LOG_FORMAT=json
 SKY_LOG_LEVEL=info
-SKY_METRICS_TOKEN=…         # /_sky/metrics requires Bearer in prod
+SKY_ADMIN_TOKEN=…           # /_sky/metrics + /_sky/console require Bearer in prod
+                            # (legacy: SKY_METRICS_TOKEN / SKY_CONSOLE_TOKEN_SECRET still honoured)
 # OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
 ```
 

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -3581,7 +3581,8 @@ DATABASE_URL=postgres://user:pass@host/db  # fallback if SKY_LIVE_STORE_PATH uns
 # ─── observability ─────────────────────────────────────────────────
 SKY_LOG_FORMAT=json
 SKY_LOG_LEVEL=info
-SKY_METRICS_TOKEN=…             # /_sky/metrics requires `Authorization: Bearer <this>`
+SKY_ADMIN_TOKEN=…               # gates /_sky/metrics + /_sky/console in production
+                                # legacy aliases: SKY_METRICS_TOKEN (v0.14.21), SKY_CONSOLE_TOKEN_SECRET (v0.14.20)
 # OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318  # optional OTel export
 
 # ─── secrets ───────────────────────────────────────────────────────
@@ -3595,7 +3596,7 @@ SKY_AUTH_TOKEN_SECRET=…         # ≥32 bytes; Sky errors at startup if shorte
 | `ENV` value | Mode | Console mount | `🔍 Console` banner | `/_sky/metrics` auth |
 |---|---|---|---|---|
 | unset / `dev` / `development` / `local` | dev | ✓ at `/_sky/console` | ✓ floating link | open (any read) |
-| `production` / `prod` / `staging` / `qa` / `preview` / anything else | prod | hidden | hidden | `Authorization: Bearer $SKY_METRICS_TOKEN` |
+| `production` / `prod` / `staging` / `qa` / `preview` / anything else | prod | hidden | hidden | `Authorization: Bearer $SKY_ADMIN_TOKEN` |
 
 Bias-to-gate: if you bother to set `ENV` at all, you mean it's not dev.
 
@@ -3617,7 +3618,7 @@ A Sky-side ergonomic API (`Live.app { subApps = [...] }`) is on the v0.14 list; 
 
 | Platform | What it gives you | What you set |
 |---|---|---|
-| Fly.io / Render / Railway | `PORT`, `DATABASE_URL`, secret manager | `ENV=production`, `SKY_AUTH_TOKEN_SECRET`, `SKY_METRICS_TOKEN` |
+| Fly.io / Render / Railway | `PORT`, `DATABASE_URL`, secret manager | `ENV=production`, `SKY_AUTH_TOKEN_SECRET`, `SKY_ADMIN_TOKEN` |
 | Cloud Run | `PORT`, secret manager | same + map `PORT` → `SKY_LIVE_PORT` if your code reads SKY_LIVE_PORT explicitly |
 | Kubernetes | ConfigMap + Secret + Service | mount `/_sky/healthz` as liveness probe, `/_sky/readyz` as readiness probe |
 | Docker compose | env_file: `.env.production` | same |


### PR DESCRIPTION
Fix drift introduced by the v0.15 doc refresh.

Per `runtime-go/rt/subapp.go` (`adminTokenSecret` at line 500-524):

> The canonical env var is `SKY_ADMIN_TOKEN`. Two legacy aliases
> are honoured for tenants seeded on earlier Sky versions:
>
> - `SKY_METRICS_TOKEN` — v0.14.21's first-pass unification name
>   (kept "metrics" in the name; promoted to admin-wide).
> - `SKY_CONSOLE_TOKEN_SECRET` — v0.14.20's console-specific
>   secret before any unification.

The README + CLAUDE.md + templates/CLAUDE.md were still showing `SKY_METRICS_TOKEN` as the primary env var; this PR flips them to `SKY_ADMIN_TOKEN` and notes the legacy aliases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)