### PR TITLE
v0.15.2 — codegen panic fix + sky build injects compiler version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Notable user-visible changes. Keep this file additive — never rewrite history.
 
+## v0.15.2 — `sky build` propagates compiler version to apps (2026-05-24)
+
+- **`sky build` now injects `-ldflags "-X sky-app/rt.skyVersion=<compiler version>"`** into the underlying `go build`. Every Sky-built app's `/_sky/buildinfo` now reports the actual Sky version that built it instead of the default `"dev"`. No deploy-script ceremony — a tagged Sky binary built with `cabal install -ldflags="-X main.skyBuildVersion=0.15.2"` propagates that string to every app it compiles.
+  - **Why:** pre-v0.15.2, the `rt.skyVersion` package-level var defaulted to `"dev"` and was only populated by the Sky compiler's own release CI (`-X main.skyBuildVersion=...`). The compiler's own version never reached the apps it built — every deployed Sky app reported `"skyVersion":"dev"` regardless of which tagged compiler had built it.
+  - **Migration:** none. Existing apps rebuild → buildinfo flips from `"dev"` to the real version on next `sky build`. Deploy scripts that previously injected the ldflag manually (none in the public examples) can remove that step.
+
 ## v0.15.1 — Docs: `SKY_ADMIN_TOKEN` canonical (2026-05-24)
 
 - **Docs: `SKY_ADMIN_TOKEN` is the canonical env var** for gating

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,42 @@
 
 Notable user-visible changes. Keep this file additive — never rewrite history.
 
-## v0.15.2 — `sky build` propagates compiler version to apps (2026-05-24)
+## v0.15.2 — Cfg_R[any] panic fix + version propagation (2026-05-24)
+
+### Codegen
+
+- **Closed `interface conversion: Cfg_R[any] vs Cfg_R[Msg]` runtime
+  panic** at every place a `Can.Record` literal sits in a typed
+  call-arg slot whose Go target is a parametric record alias
+  instantiation. Surfaced by skydeploy's Editor (`Editor.view
+  editorCfg` at AppDetail.sky:Source tab) on every mount — Go
+  generic types are nominal, so `any(Cfg_R[any]{...}).(Cfg_R[Msg])`
+  fails at runtime even though Go's type checker accepts it.
+  - **Fix:** call-arg lowering at every site (`zipWithDefault
+    coerceArg exprToGo`, `coerceCallArgsAt`'s `coerceOne`,
+    `kernelCoerceArg`, bare ctor-call zip) now routes
+    `Can.Record` literals targeting parametric record slots
+    through `exprToGoExpectGo` → `lowerRecordLiteralTo`, which
+    emits the literal with the target's concrete type args
+    directly (no nominal-type-assert wrapper).
+  - **Symmetry:** the same pipeline also routes `Can.Lambda` at
+    typed `func(...) ...` slots through `lowerTypedLambda` (was
+    already happening at some call sites; now uniform across all
+    five).
+  - **Edge cases handled:** the new arms are uniformly gated on
+    `not (containsGenericTypeParam ty)` so call sites where σ
+    hasn't pinned the callee's TVar (`Cfg_R[T1]`) fall back to
+    the legacy `coerceArg` path — emitting `Cfg_R[T1]{...}` at
+    the caller would trigger `undefined: T1` since T1 names the
+    callee's type variable, not in scope here. The existing
+    `exprToGoExpectGo` arms (record-field-init, list-elem) are
+    unchanged because they're only reached from contexts where σ
+    is already concrete.
+  - Stage E shipped the parametric record alias struct generation
+    + Stage E.2 routed the record-field-init context; v0.15.2 closes
+    the call-arg context that Stage E missed.
+
+### `sky build`
 
 - **`sky build` now injects `-ldflags "-X sky-app/rt.skyVersion=<compiler version>"`** into the underlying `go build`. Every Sky-built app's `/_sky/buildinfo` now reports the actual Sky version that built it instead of the default `"dev"`. No deploy-script ceremony — a tagged Sky binary built with `cabal install -ldflags="-X main.skyBuildVersion=0.15.2"` propagates that string to every app it compiles.
   - **Why:** pre-v0.15.2, the `rt.skyVersion` package-level var defaulted to `"dev"` and was only populated by the Sky compiler's own release CI (`-X main.skyBuildVersion=...`). The compiler's own version never reached the apps it built — every deployed Sky app reported `"skyVersion":"dev"` regardless of which tagged compiler had built it.

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -2463,9 +2463,25 @@ runGoBuildWithDiagnostics outDir binName _goPath = do
     -- bindings). If the static build fails, transparently retry
     -- with cgo enabled and note it; the resulting binary then
     -- needs a glibc base.
-    let buildCmd cgo =
+    -- v0.15.2: inject the Sky compiler version into the emitted binary's
+    -- rt.skyVersion via -ldflags. Pre-v0.15.2 every sky-built app's
+    -- `/_sky/buildinfo` reported `skyVersion: "dev"` regardless of which
+    -- Sky compiler had built it — the variable defaults to "dev" and was
+    -- only populated by the release CI's `cabal install -ldflags="-X
+    -- sky-app/rt.skyVersion=..."` (which only the Sky compiler binary
+    -- itself got, not the apps it builds). Propagating the compiler's
+    -- own version through `go build` makes any sky-built app report the
+    -- truth without per-project deploy-script ceremony.
+    --
+    -- Quoting: skyBuildVersion is a tag name like `0.15.2` (alphanumerics
+    -- + dot only — no shell metacharacters), so single-quoting is enough
+    -- to defend against an accidental space without breaking under sh -c.
+    let versionLdflag =
+            "-ldflags '-X sky-app/rt.skyVersion=" ++ skyBuildVersion ++ "'"
+        buildCmd cgo =
             "cd " ++ outDir ++ " && CGO_ENABLED=" ++ (if cgo then "1" else "0")
-            ++ " go build -o " ++ binName ++ " ."
+            ++ " go build " ++ versionLdflag
+            ++ " -o " ++ binName ++ " ."
     (ec0, _o0, e0) <- System.Process.readCreateProcessWithExitCode
         (System.Process.shell (buildCmd False)) ""
     (ec, berr) <- case ec0 of

--- a/src/Sky/Build/Compile.hs
+++ b/src/Sky/Build/Compile.hs
@@ -6705,8 +6705,13 @@ exprToGo (A.At _ expr) = case expr of
                 in if got < declared
                     then emitPartialCtor func args (declared - got)
                     -- T1: coerce each arg to the ctor's declared param type.
+                    -- v0.15.2: route through `zipWithDefaultExpect` so a
+                    -- Can.Record literal passed to a parametric record
+                    -- ctor slot lowers with the slot's type args, not the
+                    -- generic Cfg_R[any] + Coerce wrap that panics on
+                    -- Go's nominal generic types.
                     else GoIr.GoCall (exprToGo func)
-                          (zipWithDefault coerceArg exprToGo paramTys args)
+                          (zipWithDefaultExpect paramTys args)
             Can.VarTopLevel home name ->
                 -- Partial application of a top-level function:
                 -- `canViewMonitor session` where canViewMonitor : Session -> Monitor -> Bool
@@ -6803,7 +6808,14 @@ exprToGo (A.At _ expr) = case expr of
                         _ -> []
                     goArgs
                         | not (null ctorParamTypes) =
-                            zipWith (\e ty -> coerceArg e ty) (map exprToGo args) (ctorParamTypes ++ repeat "any")
+                            -- v0.15.2: ctor call args go through
+                            -- `zipWithDefaultExpect` to surface Can.Record /
+                            -- Can.Lambda at parametric-record / typed-func
+                            -- slots directly (no `Cfg_R[any] + Coerce`
+                            -- wrap that panics under Go's nominal generic
+                            -- type assertions).  Behaviour identical for
+                            -- non-special args (falls through to coerceArg).
+                            zipWithDefaultExpect (ctorParamTypes ++ repeat "any") args
                         | not (null localQual) =
                             coerceCallArgs localQual args
                         | otherwise = map exprToGo args
@@ -7572,7 +7584,11 @@ emitPartialCtor func suppliedArgs missing =
                                         then "any" else t) extraTys
         sanitisedRet = if containsGenericTypeParam ctorRetTy
                           then "any" else ctorRetTy
-        suppliedGo  = zipWithDefault coerceArg exprToGo suppliedTys suppliedArgs
+        -- v0.15.2: typed-target call args via `zipWithDefaultExpect`
+        -- (see note at the helper definition near the bottom of this
+        -- file).  Required for `Editor.view editorCfg` and similar
+        -- parametric-record passing on partial-applied ctors.
+        suppliedGo  = zipWithDefaultExpect suppliedTys suppliedArgs
         extraNames  = [ "__p" ++ show i | i <- [0 .. missing - 1] ]
         extraIdents = zipWith (\n ty -> coerceArg (GoIr.GoIdent n) ty)
                               extraNames sanitisedExtras
@@ -7651,7 +7667,8 @@ coerceCallArgs qualName args =
                                  then eraseTypeParams subbed
                                  else subbed
                  substituted = map substituteOnly paramTypes
-             in zipWithDefault coerceArg exprToGo substituted args
+             -- v0.15.2: typed-target call args via `zipWithDefaultExpect`.
+             in zipWithDefaultExpect substituted args
 
 
 -- | v0.13 Phase A5 — call-site-aware variant of `coerceCallArgs`.
@@ -7864,6 +7881,30 @@ coerceCallArgsAt region qualName args =
                             Can.Let{}
                                 | isEmittableGoType subbed
                                 , not (isGenericTypeParam subbed) ->
+                                    exprToGoExpectGo subbed e
+                            -- v0.15.2: Can.Record at a parametric-alias
+                            -- monomorphisation slot (`Cfg_R[Msg]`).  Route
+                            -- to `exprToGoExpectGo` so the literal emits
+                            -- with the target's type args directly,
+                            -- avoiding the `Cfg_R[any]{...}.(Cfg_R[Msg])`
+                            -- nominal-type-assert panic that surfaced as
+                            -- "interface conversion: Cfg_R[interface {}]
+                            -- vs Cfg_R[State_Msg]" on every editor mount
+                            -- in skydeploy.  Stage E handled this for
+                            -- record-field-init contexts but missed the
+                            -- monomorphisation call-arg path.
+                            --
+                            -- Gated on `not containsGenericTypeParam`:
+                            -- when the target's type args are still bare
+                            -- type params (`Cfg_R[T1]` for a Sky-side
+                            -- polymorphic call where σ didn't pin the
+                            -- TVar), emitting `Cfg_R[T1]{...}` at the
+                            -- caller's site triggers `undefined: T1` in
+                            -- `go build` — T1 names the CALLEE's type
+                            -- variable, not in scope at the call site.
+                            Can.Record{}
+                                | isParametricAliasInstantiation subbed
+                                , not (containsGenericTypeParam subbed) ->
                                     exprToGoExpectGo subbed e
                             _ ->
                                 if subbed == "any" && containsTypeParam orig
@@ -8455,6 +8496,22 @@ kernelCoerceArg _allSubbed _idx subbed e@(A.At _ inner) =
                 in if bodyPreTyped
                     then curryLambdaPatTypedPre inputTypes finalRet pats body'
                     else curryLambdaPatTyped inputTypes finalRet pats body'
+        -- v0.15.2: Can.Record at a parametric-alias kernel slot —
+        -- same insight as `coerceCallArgsAt`'s Record arm and
+        -- `lowerArgExpect`.  Without this, a `Maybe.withDefault
+        -- defaultCfg (Just newCfg)` where Cfg is a parametric alias
+        -- with σ={a → State.Msg} substituted the slot to `Cfg_R[State_Msg]`
+        -- would emit `any(Cfg_R[any]{...}).(Cfg_R[State_Msg])` and
+        -- panic on Go's nominal generic-type assertion.
+        --
+        -- Gated on `not containsGenericTypeParam subbed` for the same
+        -- reason the other arms are: the kernel's σ may still have
+        -- TVars at the call site (only the callee body has them in
+        -- scope as Go generic params).
+        Can.Record _
+            | isParametricAliasInstantiation subbed
+            , not (containsGenericTypeParam subbed) ->
+                exprToGoExpectGo subbed e
         _ -> coerceArg (exprToGo e) subbed
 
 
@@ -8635,6 +8692,63 @@ zipWithDefault _ _  _ [] = []
 zipWithDefault f fb (a:as) (c:cs) = f (fb c) a : zipWithDefault f fb as cs
 
 
+-- | v0.15.2 — Can.Expr-aware variant of `zipWithDefault coerceArg
+-- exprToGo`.  At call-arg sites where the target Go type is a
+-- parametric record alias instantiation (`Cfg_R[Msg]`) and the
+-- source is a `Can.Record` literal, route through
+-- `exprToGoExpectGo` so the literal emits with the target's type
+-- args directly (`Cfg_R[Msg]{ OnSubmit: func(...) Msg {...} }`).
+--
+-- Pre-fix the lowerer first emitted the literal generically as
+-- `Cfg_R[any]{...}` (no target context) then wrapped it with
+-- `any(...).(Cfg_R[Msg])` via `coerceArg`.  Go generic types are
+-- nominal, so the runtime type assertion panicked with
+-- `interface conversion: Cfg_R[interface {}] vs Cfg_R[Msg]`.
+-- Surfaced by skydeploy's Editor (`Editor.view editorCfg` at
+-- AppDetail.sky) on every Source-tab mount — pre-Stage-E this
+-- worked because Cfg_R was an unparameterised struct.
+--
+-- Same insight applies to `Can.Lambda` at a typed `func(...) ...`
+-- slot — route to `lowerTypedLambda` via `exprToGoExpectGo` so
+-- the inner func emits with the slot's typed params and return.
+-- The pre-existing `coerceArg` would have wrapped a generic
+-- `func(any) any` body with `rt.Coerce[func(X) Y]`, working but
+-- reflecting through MakeFunc on every call.
+zipWithDefaultExpect :: [String] -> [Can.Expr] -> [GoIr.GoExpr]
+zipWithDefaultExpect [] cs = map exprToGo cs
+zipWithDefaultExpect _ [] = []
+zipWithDefaultExpect (ty:tys) (e:es) =
+    lowerArgExpect ty e : zipWithDefaultExpect tys es
+
+
+-- | v0.15.2 — single arg lowering with target type awareness.
+-- Falls through to the historic `coerceArg . exprToGo` pipeline
+-- for every shape EXCEPT the two type-directed ones above.
+--
+-- Parametric-alias arm gated on `not containsGenericTypeParam`:
+-- a target like `Cfg_R[T1]` (Sky-side polymorphic, σ didn't pin
+-- the TVar at this site) would emit `Cfg_R[T1]{...}` at the
+-- caller, triggering `undefined: T1` in `go build` because T1
+-- names the callee's type variable, not in scope at the caller.
+-- Typed-lambda arm already excludes generic param targets via
+-- `all (/= "any") paramTys` (a func type containing a TVar would
+-- have at least one "any" position).
+lowerArgExpect :: String -> Can.Expr -> GoIr.GoExpr
+lowerArgExpect ty e@(A.At _ expr)
+    | isParametricAliasInstantiation ty
+    , not (containsGenericTypeParam ty)
+    , Can.Record _ <- expr
+    = exprToGoExpectGo ty e
+    | Just (paramTys, _retTy) <- parseFuncType ty
+    , Can.Lambda pats _ <- expr
+    , length pats == length paramTys
+    , all (/= "any") paramTys
+    , not (containsGenericTypeParam ty)
+    = exprToGoExpectGo ty e
+    | otherwise
+    = coerceArg (exprToGo e) ty
+
+
 -- | Over-application: the call supplied MORE args than the callee's
 -- declared arity. Means the callee returns a function value which we
 -- continue to apply.
@@ -8718,7 +8832,8 @@ emitPartialUserCall func suppliedArgs missing =
         ultRetType = eraseTypeParams
                         (Map.findWithDefault "any" qualName
                            (Rec._cg_funcUltimateRetType env))
-        suppliedGo = zipWithDefault coerceArg exprToGo suppliedTypes suppliedArgs
+        -- v0.15.2: typed-target call args via `zipWithDefaultExpect`.
+        suppliedGo = zipWithDefaultExpect suppliedTypes suppliedArgs
         extraNames = [ "__pp" ++ show i | i <- [0 .. missing - 1] ]
         extraIdents = zipWith (\n ty -> coerceArg (GoIr.GoIdent n) ty)
                               extraNames extraTypes


### PR DESCRIPTION
Two fixes bundled for v0.15.2.

## 1. fix(codegen): \`Cfg_R[any] vs Cfg_R[Msg]\` runtime panic

Stage E shipped Go generics on parametric record aliases + Stage E.2 routed record-field-init contexts through \`lowerRecordLiteralTo\`. **Call-arg contexts were missed.** A \`Can.Record\` literal passed to a function expecting \`Cfg_R[Msg]\` lowered generically as \`Cfg_R[any]{...}\` via \`exprToGo\`, then \`coerceArg\` wrapped with \`any(...).(Cfg_R[Msg])\`. Go generic types are nominal, so the runtime assertion panicked:

\`\`\`
interface conversion:
  interface {} is main.Editor_Cfg_R[interface {}],
  not main.Editor_Cfg_R[sky-app/rt.SkyADT]
\`\`\`

Surfaced by skydeploy's Editor (\`Editor.view editorCfg\` at AppDetail.sky) on every Source-tab mount in production.

### Fix surface — every place a Sky-source expression gets paired with a concrete Go target type

| Path | Pre-v0.15.2 | v0.15.2 |
|---|---|---|
| Non-mono Sky function call args | \`zipWithDefault coerceArg exprToGo\` (4 sites) | \`zipWithDefaultExpect\` → typed Record/Lambda via \`exprToGoExpectGo\` |
| Mono-instance call args (\`coerceCallArgsAt\`) | per-arg \`coerceArg (exprToGo e)\` fallthrough | added \`Can.Record\` arm (matches existing \`Can.Lambda\`/\`Case\`/\`If\`/\`Let\` arms) |
| Kernel call args (\`kernelCoerceArg\`) | per-arg \`coerceArg (exprToGo e)\` fallthrough | added \`Can.Record\` arm (matches existing \`Can.Lambda\` arm) |
| Bare ADT-ctor call args | \`zipWith coerceArg (map exprToGo args) (...)\` | \`zipWithDefaultExpect\` (suffix \"any\" args fall through unchanged) |

### Edge cases handled

- Every new arm is uniformly gated on \`not (containsGenericTypeParam ty)\` — call sites where σ hasn't pinned the callee's TVar (\`Cfg_R[T1]\`) fall back to the legacy \`coerceArg\` path. Emitting \`Cfg_R[T1]{...}\` at the caller would trigger \`undefined: T1\` in \`go build\`.
- Existing \`exprToGoExpectGo\` arms (record-field-init, list-elem) stay unchanged — they're only reached from contexts where σ is already concrete (already-typed parent record/list/function body, where TVars ARE in scope as Go generic params). Narrowing the fix to call-arg sites avoids regressing in-body codegen.

## 2. feat(build): \`sky build\` injects compiler version into app binary

Every Sky-built app's \`/_sky/buildinfo\` previously reported \`skyVersion: \"dev\"\` regardless of which tagged Sky compiler built it. \`sky build\` now passes \`-ldflags '-X sky-app/rt.skyVersion=<skyBuildVersion>'\` to the underlying \`go build\`. A tagged Sky binary propagates its own version into every app it compiles.

Surfaced when redeploying skydeploy with the v0.15.1 tagged binary — \`/_sky/buildinfo\` still showed \"dev\".

## Verification

- 27/27 example clean-build sweep
- 120/120 stdlib Sky.Test assertions (\`examples/00-standard-libs\`)
- 21/21 v0.15 parametric-record-alias stress test sections
- skydeploy/control-plane: editor pane now emits \`Editor_Cfg_R[State_Msg]{...}\` directly (no Coerce wrapper) — verified by inspecting generated Go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)