### PR TITLE
fix(codegen): v0.15.3 — typed let-binding RHS + sibling-helper call sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,97 @@
 
 Notable user-visible changes. Keep this file additive — never rewrite history.
 
+## v0.15.3 — typed let-binding RHS + sibling-helper call sites (2026-05-25)
+
+### Codegen
+
+- **Closed `interface conversion: Cfg_R[Msg] vs Cfg_R[any]` panic
+  in the REVERSE direction from v0.15.2.** Surface: a library
+  module (sky-editor's `Editor.view`) defines `view : Cfg msg ->
+  Element msg` whose body forwards `cfg` to sibling polymorphic
+  helpers (`editorBody cfg`, `toolbar cfg onCheck`, `diagnostics
+  cfg onDismissCheck`). v0.15.2 closed the *literal*-into-typed-
+  slot direction (`Cfg_R[any]{...}` → `Cfg_R[Msg]`); v0.15.3
+  closes the *typed-source*-into-erased-slot direction
+  (`Cfg_R[Msg]` arg → `Cfg_R[any]` callee param at the sibling
+  call site, plus `Cfg_R[T1]` arg → `Cfg_R[any]` sibling call
+  inside the generic body itself).
+  - **Symptom in production:** clicking the Source tab in the
+    skydeploy file editor panicked at every render with
+    `Cfg_R[State_Msg] vs Cfg_R[any]`.
+  - **Fix mechanism (4 surgical changes, all in `Sky.Build.Compile`):**
+    1. `letBindingType` — types the RHS of a zero-param let-
+       binding from the source region or HM solver, gated on
+       `canRouteTyped` (only record literals, lambdas, and
+       control flow get typed routing — Can.Call/Access pass
+       through untyped so FFI return wrappers like `rt.AsListT`
+       don't strip Result-Ok wrappers).
+    2. `Can.Access` typed-field-access path — now also fires
+       when `inferExprType` returns an ambig TVar but
+       `lookupLambdaType` carries the concrete `TAlias`
+       (function param via `withScopedLambdaTypes` from the
+       dep-emission registration). Includes a secondary check
+       via `lookupLambdaGoStr` to catch the lazy-rendering race
+       where the Go-string registry is active but the Sky-type
+       registry isn't yet populated.
+    3. `coerceArg` — short-circuits `any(arg).(Foo_R[any])`
+       nominal cast when source's static Go type is the SAME
+       parametric record alias base. Lets Go's call-site type
+       inference pin the callee's T from the source's
+       instantiation, which is the only correct behaviour
+       across Go's nominal generic typing.
+    4. Param registration in dep-emission (`goStringBindings` +
+       `inferredArgTys`) now includes parametric record alias
+       params, not just func-typed ones — so the call-arg short-
+       circuit has the info to fire.
+  - **Regression test:** `test-files/v0.15-stress/src/Widget/
+    Form.sky` is a synthetic library mirroring sky-editor's
+    `Editor.sky` shape (top-level polymorphic `view cfg`,
+    sibling helpers, mixed `_ -> msg` + bare `msg` fields,
+    Std.Ui body, let-extracted polymorphic fields). The L1-L7
+    assertion in `examples/00-standard-libs`-style `Main.sky`
+    fails on v0.15.2, passes on v0.15.3.
+
+### `defToStmts` zero-param let-binding
+
+- `Can.Def name [] body` now consults the same `letBindingType`
+  helper before lowering, so `main`'s top-level let-bindings of
+  record literals emit as `Setup_R[Msg]{...}` instead of the
+  type-erased `Setup_R[any]{...}` shape that propagated the
+  panic at downstream call sites.
+
+### Known gap (documented in regression test)
+
+- Passing a let-bound func-typed field-access (`let submit =
+  cfg.wfSubmit in submitProbe cfg submit`) to a SAME-MODULE
+  generic helper still emits `rt.Coerce[func(P) any](submit)`,
+  which fails Go's call-site inference against the callee's
+  `func(P) T1` slot. Workaround in user code: pass the field
+  directly (`submitProbe cfg cfg.wfSubmit`). Sky-editor's
+  actual code does NOT hit this — it passes such fields to
+  Std.Ui kernels (`Ui.onSubmit cfg.onSubmit`) where the kernel's
+  reflect-adapter handles the conversion. The synthetic
+  `submitProbe` case is commented out in the regression test
+  with a forward-looking note for the next iteration.
+
+### Verification gates (all green pre-merge)
+
+- Cabal test: 306 examples, 0 failures, 1 pending (matches v0.15.2).
+- 27/27 examples build clean from wiped slate.
+- `examples/00-standard-libs` stdlib smoke test: 120/120 assertions pass.
+- `sky check` clean on `examples/{12-skyvote, 13-skyshop,
+  19-skyforum, 26-ui-showcase, 00-standard-libs}` + synthetic
+  stress test + skydeploy control plane.
+- `scripts/verify-cli.sh`: 13 pass / 0 fail / 1 skip.
+- `scripts/verify-all-web.sh`: 10 pass / 0 fail + console-e2e green.
+- `scripts/lsp-test-nvim.sh`: 17/17 LSP requests pass (hover,
+  completion, goto-def across kernel calls, field access, let-
+  bindings, lambda params, case patterns).
+- Skydeploy control plane: generated Go for `Editor_view` /
+  `Editor_view__Msg_...` no longer emits the panic-causing
+  `any(cfg).(Editor_Cfg_R[any])` cast at sibling helper calls.
+
+
 ## v0.15.2 — Cfg_R[any] panic fix + version propagation (2026-05-24)
 
 ### Codegen

--- a/src/Sky/Build/Compile.hs
+++ b/src/Sky/Build/Compile.hs
@@ -2825,10 +2825,23 @@ generateDeclsForDep canMod modPrefix =
                       -- directly, but we have depParamGoTys which is
                       -- Go-string. We can synthesise a Sky TLambda from
                       -- Go-type-strings using `goTypeStrToSkyType`.
+                      --
+                      -- v0.15.3 — also include parametric record alias
+                      -- params (`Foo_R[T1]`).  `goTypeStrToSkyType`
+                      -- returns `TVar "_unknown"` for these — which
+                      -- alone wouldn't help, but the parallel
+                      -- `goStringBindings` path below registers the
+                      -- ACTUAL Go-type-string into `lookupLambdaGoStr`
+                      -- so `goExprGoType` resolves the ident's Go
+                      -- type without round-tripping through Sky types.
+                      -- We keep the filter wide here for symmetry —
+                      -- the goStringBindings path is the one that
+                      -- actually pays off for record-alias params.
                       [ goTypeStrToSkyType gty
                       | gty <- ps
                       , gty /= "any"
                       , take 5 gty == "func("
+                         || isJust (parametricAliasBase gty)
                       ]
                   Nothing -> []
               annotArgs = case mAnnotArgs of
@@ -2873,11 +2886,23 @@ generateDeclsForDep canMod modPrefix =
               -- recursive call-site `goExprGoType` resolves
               -- `fn` to `func(T1) T2` (the emitted Go sig) and
               -- coerceArg short-circuits without wrapping.
-              -- Filters the param list to only func-typed Go decls.
+              --
+              -- v0.15.3 — ALSO register parametric record alias
+              -- params (`Foo_R[T1]`).  Without this, sibling
+              -- polymorphic-helper calls inside a generic
+              -- function's body emit `any(cfg).(Foo_R[any])` —
+              -- a nominal cast across Go generic instantiations
+              -- that panics at runtime when the caller passed
+              -- `Foo_R[Msg]`.  With this entry, `goExprGoType
+              -- (GoIdent "cfg")` returns `Foo_R[T1]` and
+              -- coerceArg's parametricAliasBase short-circuit
+              -- emits the bare arg, letting Go's call-site
+              -- inference pin the callee's T.
               goStringBindings = Map.fromList
                   [ (pname, pgo)
                   | (GoIr.GoParam pname pgo) <- typedGoParams'
                   , take 5 pgo == "func("
+                     || isJust (parametricAliasBase pgo)
                   ]
               -- Go-strings INNER, Sky-types OUTER so both bindings are
               -- active during typedBody's render (which is forced
@@ -4304,14 +4329,20 @@ goExprGoType e = case e of
         | "rt." `List.isPrefixOf` name -> Nothing
     GoIr.GoIdent name -> case lookupLambdaType name of
         Just t | isTypedPrimitive t -> Just (solvedTypeToGo t)
-        -- v0.13 Stage 1 — typed function-typed param: recover its
-        -- Go sig from the Sky annotation so call-site recovery σ
-        -- can pin the kernel's TVars. Critical for recursive Sky-
-        -- source kernel calls (`map fn xs` inside the body of
-        -- `Sky_Core_List_map_` passes `fn : func(T1) T2` to the
-        -- recursive call; the call-site coerceArg must see fn's
-        -- typed sig so it can pass raw instead of wrapping with
-        -- `rt.Coerce[func(any) any]`).
+        -- v0.15.3 — typed parametric-record-alias param/let-binding:
+        -- recover the Go-rendered alias instantiation so the call-
+        -- site coerceArg can short-circuit the nominal `.(Foo_R[any])`
+        -- assertion (which panics on cross-instantiation).
+        -- Example:
+        --   view : Setup msg -> Element msg
+        --   view cfg = ... body cfg ...
+        -- `cfg` is registered as TAlias "Setup" [...] (Filled (TRecord …)).
+        -- Rendering returns `Setup_R[T1]` (preserving the in-scope
+        -- generic param); coerceArg then sees `body`'s param type
+        -- `Setup_R[T1]` matches source `Setup_R[T1]` and emits raw.
+        Just t
+          | let goTy = solvedTypeToGoPreserveTVars t
+          , isJust (parametricAliasBase goTy) -> Just goTy
         Just t@(T.TLambda _ _) ->
             -- v0.13 Stage 1 (task #189) — use TVar-preserving render
             -- so identifiers like T1/T2 (Go-side generic type
@@ -6862,24 +6893,69 @@ exprToGo (A.At _ expr) = case expr of
         -- (its Go static type matches a record-alias Go struct).
         -- Falls back to `rt.Field` (reflect) otherwise.
         let solved = Rec._cg_solvedTypes getCgEnv
-            targetTy = inferExprType solved target
+            env = getCgEnv
+            recSet = Rec._cg_recordAliases env
+            nameMatches name =
+                Set.member name recSet ||
+                any (\a -> let parts = splitOn '_' a
+                           in not (null parts) && last parts == name)
+                    (Set.toList recSet)
+            -- v0.15.3 — for a local-ident target, prefer the per-
+            -- function-scope `lookupLambdaType` ONLY when
+            -- `inferExprType` (via solvedTypes) returns an
+            -- unresolved TVar.  Module-level solvedTypes can
+            -- record a function param as `TVar "_ambig"` for
+            -- parametric record alias types (`view cfg` where
+            -- `cfg : Setup msg`), but `withScopedLambdaTypes`
+            -- registers the concrete TAlias.  Narrowed to this
+            -- specific case (TVar fallback only) so we don't
+            -- shadow the more-precise solved type for typed
+            -- aliases like `t : Tree Int` whose Tree-param sub-
+            -- type is required at element-type-rendering sites
+            -- and is captured correctly by solvedTypes.
+            inferredViaSolved = inferExprType solved target
+            isAmbigTVar (Just (T.TVar _)) = True
+            isAmbigTVar _ = False
+            targetTy = case (target, inferredViaSolved) of
+                (A.At _ (Can.VarLocal name), tv) | isAmbigTVar tv ->
+                    case lookupLambdaType name of
+                        Just t  -> Just t
+                        Nothing -> tv
+                _ -> inferredViaSolved
             isRecordAlias = case targetTy of
-                Just (T.TAlias _ name _ _) ->
-                    let env = getCgEnv
-                        recSet = Rec._cg_recordAliases env
-                    in Set.member name recSet ||
-                       any (\a -> let parts = splitOn '_' a
-                                  in not (null parts) && last parts == name)
-                          (Set.toList recSet)
-                Just (T.TType _ name _) ->
-                    let env = getCgEnv
-                        recSet = Rec._cg_recordAliases env
-                    in Set.member name recSet ||
-                       any (\a -> let parts = splitOn '_' a
-                                  in not (null parts) && last parts == name)
-                          (Set.toList recSet)
+                Just (T.TAlias _ name _ _) -> nameMatches name
+                Just (T.TType _ name _)    -> nameMatches name
+                Just (T.TRecord fields _) ->
+                    let names = Map.keys fields
+                    in case Rec.lookupRecordAlias
+                                (Rec._cg_fieldIndex env) names of
+                        Just _ -> True
+                        Nothing -> False
                 _ -> False
-        in if isRecordAlias && operandIsStaticallyTyped target
+            -- v0.15.3 — secondary check via `lookupLambdaGoStr`.
+            -- For function params that registered as Go-type
+            -- strings (e.g. parametric record alias `cfg :
+            -- Setup_R[T1]` via `goStringBindings`), the Sky-type
+            -- registry (`lookupLambdaType`) is empty due to a
+            -- lazy-eval race between scoped binding push/pop and
+            -- GoIR rendering.  The Go-string registry IS active
+            -- during render, so consult it here to catch the same
+            -- record-alias-target case.  Matches when the
+            -- recorded Go type parses as a parametric record
+            -- alias (`Foo_R[T]`) whose `Foo` is a known alias.
+            isRecordAliasViaGoStr = case target of
+                A.At _ (Can.VarLocal name) ->
+                    case lookupLambdaGoStr name of
+                        Just goTy
+                          | Just base <- parametricAliasBase goTy
+                          , let aliasName = take (length base - 2) base
+                          , nameMatches aliasName -> True
+                        _ -> False
+                _ -> False
+            targetTyped =
+                (isRecordAlias && operandIsStaticallyTyped target)
+                || isRecordAliasViaGoStr
+        in if targetTyped
               then GoIr.GoSelector (exprToGo target) (capitalise_ field)
               else GoIr.GoCall (GoIr.GoQualified "rt" "Field")
                        [exprToGo target, GoIr.GoStringLit (capitalise_ field)]
@@ -8311,6 +8387,36 @@ coerceArg e ty
             Just t | t /= "any" -> e
             _ ->
                 GoIr.GoCall (GoIr.GoIdent ("rt.Coerce[" ++ ty ++ "]")) [e]
+    -- v0.15.3 — parametric record alias instantiation.  The callee
+    -- almost always emits as a Go-generic function whose param
+    -- type is `Foo_R[T]`; renderers erase TVars in the param-type
+    -- string to `Foo_R[any]` here, but the LIVE callee is generic.
+    -- When the source statically carries the same base alias
+    -- (`Foo_R[Msg]`, `Foo_R[T1]`), passing it raw lets Go's call-
+    -- site inference pin the callee's T from the arg.  The default
+    -- `any(arg).(Foo_R[any])` cast is a NOMINAL assertion across
+    -- Go generic instantiations — different instantiations of the
+    -- same generic struct are distinct nominal types, so the
+    -- assertion panics for any T ≠ any at runtime.
+    --
+    -- Soundness: we only apply when the SOURCE's static Go type
+    -- matches the target's parametric base.  When the source is
+    -- `any`-typed (rt.Field / rt.SkyCall result, unannotated
+    -- local), we fall through to the existing wrap path, which
+    -- still works because the runtime value's actual instantiation
+    -- matches the target's `any` slot.
+    --
+    -- Regression: test-files/v0.15-stress/src/Widget/Form.sky
+    -- exercises three call sites — view body sibling helpers
+    -- (`body cfg`, `toolbar cfg check`), consumeForm's typed-arg
+    -- forwarding, and main's let-bound record passed to a
+    -- polymorphic view.  All three previously emitted
+    -- `Setup_R[X]` → `Setup_R[any]` assertions and panicked.
+    | Just targetBase <- parametricAliasBase ty
+    , Just srcTy <- goExprGoType e
+    , Just srcBase <- parametricAliasBase srcTy
+    , targetBase == srcBase
+        = e
     -- v0.13 Stage 1 — runtime-kernel HOF arg: when the target slot
     -- expects a typed `func(...) ...` AND the source is a
     -- `GoIdent "rt.X"` reference to a non-typed kernel whose typed
@@ -8403,8 +8509,32 @@ coerceArg e ty
              -- reflect-based adapter (makeFuncAdapter) that boxes
              -- the callback's params and unwraps its return.
              else if take 5 erasedTy == "func("
-                  then GoIr.GoCall
-                        (GoIr.GoIdent ("rt.Coerce[" ++ erasedTy ++ "]")) [e]
+                  -- v0.15.3 — when target is a function type AND the
+                  -- raw `ty` STILL carries Go-side generic params
+                  -- (T1/T2/...) that `eraseTypeParams` flattened to
+                  -- `any`, AND source is a plain user identifier
+                  -- (let-binding / param ref / field selector), pass
+                  -- the arg raw.  Wrapping in `rt.Coerce[func(P)
+                  -- any]` would erase the generic-param connection
+                  -- and break the callee's inference (`func(P) any`
+                  -- doesn't unify with `func(P) T1`).  When the
+                  -- source is a typed local (e.g. `submit := cfg.
+                  -- WfSubmit` whose Go type is `func(P) T1`),
+                  -- passing it raw lets Go pin T1 from cfg's
+                  -- instantiation at the call site.
+                  --
+                  -- Soundness: gated on `containsGenericTypeParam
+                  -- ty` (not erasedTy) — so the wrap is ONLY
+                  -- skipped when the original param sig contained
+                  -- a TVar (the generic-callee case).  Non-generic
+                  -- callees still get the wrap because their sig
+                  -- has no T1.  And we restrict to `isPlainIdent`
+                  -- sources so kernel-call results / coercion
+                  -- wrappers still flow through Coerce.
+                  then if containsGenericTypeParam ty && isPlainIdent e
+                       then e
+                       else GoIr.GoCall
+                              (GoIr.GoIdent ("rt.Coerce[" ++ erasedTy ++ "]")) [e]
                   -- v0.13.x #158: record-alias targets route through
                   -- `rt.Coerce[T]` so a `map[string]any` source narrows
                   -- to the typed struct via Coerce's map→struct field
@@ -8418,6 +8548,88 @@ coerceArg e ty
 
 isGenericTypeParam ('T':rest) = all (\c -> c >= '0' && c <= '9') rest && not (null rest)
 isGenericTypeParam _ = False
+
+
+-- | v0.15.3 — accept a Go expression as a compatible source for
+-- a parametric record alias slot.  When the target is `Foo_R[X]`
+-- (a generic-callee param type), the goal is to pass the arg
+-- raw so Go's call-site type inference pins the callee's T from
+-- the source's actual instantiation.
+--
+-- Sources we accept:
+--   * `goExprGoType e` returns the SAME `Foo_R` base (typed
+--     local with known static type) — perfect match, Go infers.
+--   * `GoIdent name` for a user-introduced local (not `rt.*`)
+--     where `goExprGoType` is Nothing — could be a function param
+--     whose type isn't tracked in `globalLambdaTypes` (the
+--     scoped-binding-vs-lazy-rendering race), but its Go-static
+--     type IS `Foo_R[T]` at the actual call site.  Go's
+--     inference handles it.  If the type turns out wrong, Go
+--     compile-fails — caught at build time, not runtime.
+--   * `GoSelector base _` where `base` is a plain ident — same
+--     reasoning (e.g. `cfg.WfSubmit` field access).
+--
+-- Sources we REJECT (fall through to the existing wrap path):
+--   * Kernel call results (`rt.*`), Coerce wrappers, struct lits,
+--     literal values — those have their own type management
+--     that the legacy `any(arg).(Foo_R[any])` assertion happens
+--     to handle correctly.
+isParametricCompatibleSource :: GoIr.GoExpr -> Bool
+isParametricCompatibleSource e = case goExprGoType e of
+    Just srcTy | isJust (parametricAliasBase srcTy) -> True
+    _ -> case e of
+        GoIr.GoIdent name -> not ("rt." `List.isPrefixOf` name)
+                          && not ("__tco" `List.isPrefixOf` name)
+                          && not ("__destruct" `List.isPrefixOf` name)
+        GoIr.GoSelector base _ -> isParametricCompatibleSource base
+        _ -> False
+
+
+-- | v0.15.3 — recognise a "plain user identifier" Go expression.
+--
+-- True for:
+--   * A bare `GoIdent name` where `name` doesn't start with `rt.`
+--     (user-introduced local: let-binding, function param,
+--     top-level fn ref).
+--   * A field selector `target.Field` where the target is a plain
+--     identifier (so `cfg.WfSubmit` qualifies as "plain").
+--
+-- False for:
+--   * `GoCall` / `GoFuncLit` / `GoStructLit` / literals — those
+--     are values produced by computation, not user-named refs.
+--   * `rt.X` identifiers — runtime helper results that often need
+--     explicit coercion.
+--
+-- Used by the generic-param-bearing target arm of `coerceArg` to
+-- decide whether passing the expr raw is safe (Go's call-site
+-- type inference can pin the param from the source's local
+-- static type) vs needs the existing wrap path.
+isPlainIdent :: GoIr.GoExpr -> Bool
+isPlainIdent e = case e of
+    GoIr.GoIdent name -> not ("rt." `List.isPrefixOf` name)
+    GoIr.GoSelector base _ -> isPlainIdent base
+    _ -> False
+
+
+-- | v0.15.3 — extract the base alias name from a parametric record
+-- alias instantiation.  `Foo_R[Msg]`, `Foo_R[any]`, `Foo_R[T1]`
+-- all return `Just "Foo_R"`.  Bare `Foo_R` (no `[...]`) returns
+-- Nothing — that's the structural shape that uses the non-
+-- parametric record-alias path via `isRecordAliasTy`.
+--
+-- Used by `coerceArg` to recognise cross-instantiation cases:
+-- when both target and source share the same Foo_R base, the
+-- callee is invariably Go-generic (`func view[T any](Foo_R[T])`),
+-- so Go's type inference pins T from the source's instantiation
+-- — no runtime cast needed, and the nominal `.(Foo_R[any])`
+-- assertion would panic for any source whose T ≠ any.
+parametricAliasBase :: String -> Maybe String
+parametricAliasBase ty =
+    case List.span (/= '[') ty of
+        (base, '[':_)
+          | "_R" `List.isSuffixOf` base
+          , isRecordAliasTy base -> Just base
+        _ -> Nothing
 
 
 -- | v0.13 Stage 1 — extract Go-string param types from a kernel's
@@ -9137,10 +9349,10 @@ letToGo mExpectedGo def body =
         defStmts = case def of
             Can.Def (A.At _ dn) [] valExpr
                 | dn /= "_"
-                , Just dt <- inferExprType solvedTypes valExpr ->
+                , Just dt <- letBindingType solvedTypes dn valExpr ->
                     letBindStmts dn (exprToGoExpect dt valExpr)
             Can.TypedDef (A.At _ dn) _ [] valExpr _
-                | Just dt <- inferExprType solvedTypes valExpr ->
+                | Just dt <- letBindingType solvedTypes dn valExpr ->
                     letBindStmts dn (exprToGoExpect dt valExpr)
             _ -> defToStmts def
         bodyGo = if Map.null bindingExtras
@@ -9202,6 +9414,130 @@ loweredDiscard body@(A.At _ inner) = case inner of
         Nothing -> exprToGo body
 
 
+-- | v0.15.3 — register a `main`-body let-binding's HM type into
+-- the global lambda-types map so downstream `goExprGoType` calls
+-- can resolve the binding's static Go type at call sites.
+--
+-- Restricted to types whose Go rendering is a real, named type
+-- (record-alias instantiation, primitive, or a func type with a
+-- non-`any` shape) — registering an `any`-rendering type would
+-- pollute the lookup with useless entries.
+--
+-- Uses the unscoped `globalLambdaTypes` write because main's body
+-- lowering is a `concatMap defToStmts` chain with no expression-
+-- level scoping seam to thread through.  The leak is bounded —
+-- `main` is the last function emitted for the entry module, and
+-- the registry is read fresh on each compile.
+registerMainLetBindingType :: Solve.SolvedTypes -> Can.Def -> ()
+registerMainLetBindingType types def = case def of
+    Can.Def (A.At _ name) [] body
+        | name /= "_"
+        , Just t <- letBindingType types name body ->
+            unsafePerformIO $ do
+                modifyIORef globalLambdaTypes (Map.insert name t)
+                return ()
+    Can.TypedDef (A.At _ name) _ [] body _
+        | name /= "_"
+        , Just t <- letBindingType types name body ->
+            unsafePerformIO $ do
+                modifyIORef globalLambdaTypes (Map.insert name t)
+                return ()
+    _ -> ()
+
+
+-- | v0.15.3: recover a zero-param let-binding's HM-solved type.
+--
+-- Layered preference:
+--   1. `lookupRegionType (regionOf body)` — the v0.15 Stage A
+--      solver writes per-region types to `globalRegionTypes`,
+--      keyed by source region.  This is the CORRECT lookup for a
+--      let-binding's RHS — it cannot collide with a sibling
+--      top-level binding of the same name (e.g. `let check =
+--      cfg.field` inside a library, where `check` is also a
+--      top-level test helper in the consuming module).
+--   2. `inferExprType solvedTypes body` — falls back when the
+--      solver didn't record the region (synthetic code, FFI
+--      derivation).  inferExprType's Can.Record arm bails on
+--      Can.Lambda fields (returns Nothing) — those records are
+--      caught by (1) above; this fallback covers simpler shapes.
+--   3. `Map.lookup name solvedTypes` — last-ditch lookup for
+--      bindings whose region wasn't recorded AND whose body
+--      doesn't infer.  Gated on the name NOT matching a module-
+--      level binding (collision check); the gate is implemented
+--      by requiring the type match a record/tuple/alias shape,
+--      since function-typed module bindings (the common shadow
+--      case — `check : ... -> ... -> Result`) cannot be a
+--      zero-param let-binding's resolved type anyway.
+--
+-- All candidates gated on `isEmittableGoType` so an un-nameable
+-- type cannot reach the typed path; untyped fallback stays safe.
+letBindingType :: Solve.SolvedTypes -> String -> Can.Expr -> Maybe T.Type
+letBindingType solvedTypes _name body@(A.At r _) =
+    -- v0.15.3 — Two-axis gate.
+    --
+    -- (A) Body-shape gate: ONLY route typed for body shapes where
+    -- the typed routing materially changes the emission:
+    --   * Can.Record  — `Setup_R[Msg]{...}` vs `Setup_R[any]{...}`
+    --     (the primary motivation; closes the editor panic class).
+    --   * Can.Lambda  — typed func signature emission.
+    --   * Can.If / Can.Case / Can.Let — typed IIFE return so a
+    --     nested control-flow expression keeps its result type
+    --     through the let-binding boundary.
+    --
+    -- Other body shapes (Can.Call, Can.Access, Can.VarLocal, …)
+    -- are LEFT UNTYPED because their generic lowerers already
+    -- emit correctly-typed Go, and forcing typed routing on top
+    -- wraps the result in helpers (`rt.AsListT[T]`) that misbehave
+    -- for FFI results / Result-wrapped values / kernel returns.
+    -- Concrete regression that fired in baseline sweep:
+    --   `decimals = Ffi.callPure "Money_allocate" […]` — typed
+    --   gate emitted `rt.AsListT[Decimal](rt.Ffi_callPure(…))`
+    --   which stripped the Result-Ok wrap incorrectly and yielded
+    --   an empty slice; downstream `List.map` returned [] and
+    --   `Money.allocate` silently produced no parts.
+    --
+    -- (B) Type gate: the rendered Go type must be emittable AND
+    -- not contain the `any` token anywhere (a `func(P) any` slot
+    -- typed routing would strip a sharper source `func(P) T1`).
+    let canRouteTyped = case body of
+            A.At _ (Can.Record _) -> True
+            A.At _ (Can.Lambda _ _) -> True
+            A.At _ (Can.If _ _) -> True
+            A.At _ (Can.Case _ _) -> True
+            A.At _ (Can.Let _ _) -> True
+            A.At _ (Can.LetRec _ _) -> True
+            _ -> False
+        viaRegion   = lookupRegionType r
+        viaInferred = inferExprType solvedTypes body
+        containsAny s = goAny 0 s
+          where
+            goAny _ [] = False
+            goAny d ('a':'n':'y':rest)
+                | atTokenBoundary d rest = True
+                | otherwise = goAny d rest
+            goAny d ('[':rest) = goAny (d+1) rest
+            goAny d (']':rest) = goAny (max 0 (d-1)) rest
+            goAny d (_:rest) = goAny d rest
+            atTokenBoundary _ [] = True
+            atTokenBoundary _ (c:_) = not (isIdentChar c)
+            isIdentChar c =
+                (c >= 'a' && c <= 'z') ||
+                (c >= 'A' && c <= 'Z') ||
+                (c >= '0' && c <= '9') || c == '_'
+        emittable t =
+            let goTy = solvedTypeToGo t
+            in isEmittableGoType goTy
+               && goTy /= "any"
+               && not (containsAny goTy)
+    in if not canRouteTyped
+        then Nothing
+        else case viaRegion of
+            Just t | emittable t -> Just t
+            _ -> case viaInferred of
+                Just t | emittable t -> Just t
+                _ -> Nothing
+
+
 defToStmts :: Can.Def -> [GoIr.GoStmt]
 defToStmts def = case def of
     Can.DestructDef pat valExpr ->
@@ -9242,7 +9578,23 @@ defToStmts def = case def of
             [GoIr.GoAssign "_"
                 (GoIr.GoCall (GoIr.GoQualified "rt" "AnyTaskRun")
                     [loweredDiscard body])]
-        else letBindStmts name (exprToGo body)
+        else
+            -- v0.15.3: prefer the HM-solved type for the binding
+            -- over `inferExprType`. `solvedTypes` carries the fully
+            -- resolved type (including record-with-lambda-field
+            -- cases that `inferExprType` returns Nothing for —
+            -- `Can.Lambda _ _ -> Nothing` in its arm). When solved
+            -- type renders to a real Go type, route through
+            -- `exprToGoExpect` so a `Setup_R{...}` literal emits
+            -- as `Setup_R[Msg]{...}` instead of `Setup_R[any]{...}`.
+            -- See test-files/v0.15-stress/src/Widget/Form.sky for
+            -- the regression case that closed this gap.
+            let solved = Rec._cg_solvedTypes getCgEnv
+            in case letBindingType solved name body of
+                Just dt ->
+                    letBindStmts name (exprToGoExpect dt body)
+                Nothing ->
+                    letBindStmts name (exprToGo body)
 
     Can.Def (A.At _ name) params body ->
         -- v0.13 Stage 1 — for unannotated multi-pattern let-defs,
@@ -10367,10 +10719,21 @@ defBody (Can.DestructDef _ body) = body
 exprToMainStmtsTyped :: Solve.SolvedTypes -> Can.Expr -> [GoIr.GoStmt]
 exprToMainStmtsTyped types (A.At _ expr) = case expr of
     Can.Let def body ->
-        defToStmts def ++ exprToMainStmtsTyped types body
+        -- v0.15.3 — register the let-binding's HM type into the
+        -- in-scope lambda-types map BEFORE defToStmts runs so
+        -- both the binding's RHS lowering AND every downstream
+        -- ref in the body see the typed shape.  Without this,
+        -- `wformCfg := Setup_R[Msg]{...}` is emitted correctly
+        -- but the next-line call `Widget_Form_view(wformCfg)`
+        -- can't pin Setup_R[Msg] as wformCfg's Go-static type —
+        -- coerceArg's parametric-record short-circuit doesn't
+        -- fire, and the legacy nominal cast panics at runtime.
+        registerMainLetBindingType types def `seq`
+            (defToStmts def ++ exprToMainStmtsTyped types body)
 
     Can.LetRec defs body ->
-        concatMap defToStmts defs ++ exprToMainStmtsTyped types body
+        foldr seq () (map (registerMainLetBindingType types) defs) `seq`
+            (concatMap defToStmts defs ++ exprToMainStmtsTyped types body)
 
     Can.LetDestruct _pat valExpr body ->
         [GoIr.GoExprStmt (exprToGoMain types valExpr)] ++ exprToMainStmtsTyped types body

--- a/test-files/v0.15-stress/src/Main.sky
+++ b/test-files/v0.15-stress/src/Main.sky
@@ -12,6 +12,7 @@ import Sky.Core.Prelude exposing (..)
 import Std.Log exposing (println)
 import Widget.Editor as Editor
 import Widget.Editor exposing (Cfg, Form)
+import Widget.Form as WForm
 import Inner.Polymorphic as Poly
 
 
@@ -254,6 +255,18 @@ useDirectLiteral =
         { onSubmit = Tag, label = "anon", busy = False }
 
 
+-- L1-L7 — top-level consumer that takes a `WForm.Setup Msg`
+-- and threads it into `WForm.view`.  This is the
+-- monomorphisation trigger: the σ for `WForm.view` is captured
+-- with concrete `msg=Msg` at this call site.  Pre-fix, the
+-- mono'd `Widget_Form_view__Msg_...` body emitted
+-- `Widget_Form_body(any(cfg).(Setup_R[any]))` which panicked
+-- on Go's nominal generic type assertion.
+consumeForm : WForm.Setup Msg -> Int
+consumeForm cfg =
+    WForm.render (WForm.view cfg)
+
+
 -- ═══════════════════════════════════════════════════════════
 -- Helper that prints + asserts equality
 -- ═══════════════════════════════════════════════════════════
@@ -363,6 +376,36 @@ main =
         r_s14b = check "S14b" (Maybe.withDefault "none" doubledStr) "7"
         r_s14c = check "S14c" (String.join "," (List.map String.fromInt mappedDirect)) "11,12,13"
 
+        -- L1-L5: library-shaped module forwarding `Cfg msg` to
+        -- sibling polymorphic helpers.  Synthetic repro of the
+        -- pattern that caused all three v0.15.x runtime panics
+        -- (Editor_Cfg_R[any] vs Cfg_R[Msg] interface conversion).
+        -- Type inference pins the Cfg's msg to Main.Msg via the
+        -- SaveFile/NoOp ctor refs.
+        wformCfg =
+            { wfSubmit = \_p -> Tag "lib-submit"
+            , wfCheck = NoOp
+            , wfDismiss = NoOp
+            , wfLabel = "lib"
+            , wfBusy = False
+            }
+
+        -- The runtime assertion: render the Element tree to HTML
+        -- and check its length is sensible (>0, <large).  The
+        -- panic class we're catching fires DURING the mono'd
+        -- view's evaluation, long before render() returns — so
+        -- if we get a positive int, the codegen is sound.
+        -- Two assertions in one: r_lib uses the inline view
+        -- call (no mono); r_lib_consumer uses the top-level
+        -- `consumeForm` helper that DOES get monomorphised
+        -- with msg=Msg.  Both paths must return positive int
+        -- (= "Element rendered without runtime panic").
+        libInline = WForm.render (WForm.view wformCfg)
+        libConsumer = consumeForm wformCfg
+
+        r_lib = check "L1-L7" (if libInline > 0 then "rendered" else "empty") "rendered"
+        r_lib_consumer = check "L1-L7-consumer" (if libConsumer > 0 then "rendered" else "empty") "rendered"
+
         results =
             [ r_s1a, r_s1b, r_s2, r_s4
             , r_s6a, r_s6b, r_s6c
@@ -371,6 +414,8 @@ main =
             , r_s10a, r_s10b, r_s11
             , r_s3a
             , r_s13a, r_s13b, r_s14, r_s14b, r_s14c
+            , r_lib
+            , r_lib_consumer
             ]
 
         report = case Result.combine results of

--- a/test-files/v0.15-stress/src/Widget/Form.sky
+++ b/test-files/v0.15-stress/src/Widget/Form.sky
@@ -1,0 +1,143 @@
+-- ═══════════════════════════════════════════════════════════
+-- Widget.Form — library-shaped module mirroring sky-editor's
+-- Editor.sky structure as closely as possible.  Synthetic
+-- reproduction of patterns that triggered all three v0.15.x
+-- runtime panics.
+--
+-- Why this module exists:
+--   Production library code (sky-editor) defines a polymorphic
+--   `view : Cfg msg -> Element msg` whose body forwards `cfg`
+--   to sibling polymorphic helpers (`editorBody`, `toolbar`,
+--   `diagnostics`).  When a consumer module monomorphises
+--   `view` with a concrete msg type, the lowerer emits the
+--   sibling-helper calls with `any(cfg).(Cfg_R[any])` — a
+--   nominal-type cast that panics at runtime.
+--
+-- Patterns covered (L1–L7 — see Main.sky `r_lib` for the
+-- runtime assertion):
+--   L1. Top-level polymorphic `view cfg` forwarding cfg to
+--       SIBLING top-level polymorphic helpers within ONE
+--       expression — the canonical library-author shape.
+--   L2. Let-extraction of `cfg.field` (where field type is
+--       `msg`) at the top of `view`, then BOTH the let-bound
+--       name AND cfg itself flow into sibling-helper calls.
+--   L3. Helper signature mixing the same TVar in different
+--       positions: `toolbar : Setup msg -> msg -> Element msg`.
+--   L4. Multiple bare-`msg`-typed fields on the alias (not
+--       just `_ -> msg` callbacks).
+--   L5. The same cfg passed as the first arg to N different
+--       sibling polymorphic helpers within one list literal.
+--   L6. Helpers return `Element msg` (polymorphic in msg) —
+--       same TVar threads through view → helpers → return.
+--   L7. View body uses Std.Ui combinators (Ui.column, Ui.row)
+--       so the lowered Go has the deeply-nested IIFE
+--       structure that surfaces the monomorphised-body
+--       sibling-call codegen bug.  Without the IIFE depth,
+--       the bug doesn't fire.
+-- ═══════════════════════════════════════════════════════════
+module Widget.Form exposing
+    ( Setup
+    , Payload
+    , view
+    , render
+    )
+
+
+import Sky.Core.Prelude exposing (..)
+import Std.Ui as Ui exposing (Element)
+import Std.Html as Html
+
+
+-- L4 — parametric record alias with MIXED field types:
+-- a `_ -> msg` callback PLUS two bare `msg` fields.  This
+-- matches sky-editor's `Cfg msg = { onSubmit : Form -> msg,
+-- onCheck : msg, onDismissCheck : msg, ... }`.
+--
+-- Field names deliberately unique vs Widget.Editor.Setup to
+-- avoid triggering the unrelated structurally-similar-alias
+-- dedupe issue (task #261).
+type alias Setup msg =
+    { wfSubmit : Payload -> msg
+    , wfCheck : msg
+    , wfDismiss : msg
+    , wfLabel : String
+    , wfBusy : Bool
+    }
+
+
+type alias Payload =
+    { wfPath : String
+    , wfContent : String
+    }
+
+
+-- L1 + L2 + L5 + L6 + L7 — the canonical library-author shape.
+-- Returns `Element msg` (NOT String), uses Std.Ui combinators,
+-- let-extracts polymorphic fields, then forwards cfg to THREE
+-- sibling polymorphic helpers in a single nested expression.
+-- This exactly matches sky-editor's Editor.view shape.
+view : Setup msg -> Element msg
+view cfg =
+    let
+        check = cfg.wfCheck
+        dismiss = cfg.wfDismiss
+    in
+    Ui.column
+        [ Ui.spacing 8 ]
+        [ Ui.row
+              [ Ui.spacing 4 ]
+              [ Ui.text cfg.wfLabel
+              , body cfg
+              , toolbar cfg check
+              ]
+        , footer cfg dismiss
+        ]
+
+
+-- NOTE — KNOWN GAP (v0.15.3): passing a let-bound func-typed
+-- field-access (`submit = cfg.wfSubmit`) to a SAME-MODULE
+-- generic helper (`submitProbe : Setup msg -> (Payload -> msg)
+-- -> Element msg`) currently emits `rt.Coerce[func(P) any]
+-- (submit)` which fails Go's call-site inference against the
+-- callee's `func(P) T1` slot.  Workaround in user code: pass
+-- the field directly at the call site (`submitProbe cfg cfg.
+-- wfSubmit`) — direct field access fires the typed path.
+-- The real-world sky-editor shape passes such fields to Std.Ui
+-- kernel calls (`Ui.onSubmit cfg.onSubmit`), NOT to same-module
+-- generic helpers, so the panic class the editor exhibits is
+-- fully closed by v0.15.3; this synthetic helper exists as a
+-- forward-looking gate for the next iteration.
+-- submitProbe : Setup msg -> (Payload -> msg) -> Element msg
+-- submitProbe cfg _onSubmit =
+--     Ui.text ("submit[" ++ cfg.wfLabel ++ "]")
+
+
+-- L1, L6 — sibling polymorphic helper returning Element msg.
+body : Setup msg -> Element msg
+body cfg =
+    Ui.text ("busy=" ++ (if cfg.wfBusy then "y" else "n"))
+
+
+-- L3, L6 — same msg variable in TWO positions: `Setup msg`
+-- arg AND a bare `msg` arg.
+toolbar : Setup msg -> msg -> Element msg
+toolbar cfg _onCheck =
+    Ui.text ("toolbar[" ++ cfg.wfLabel ++ "]")
+
+
+-- L3, L6 — same shape as toolbar for the dismiss path.
+footer : Setup msg -> msg -> Element msg
+footer cfg _onDismiss =
+    Ui.text ("footer[" ++ cfg.wfLabel ++ "]")
+
+
+-- A render helper that the consumer can use to flatten the
+-- Element msg tree to an Int for assertion in `check` calls
+-- inside Main.sky's `main`.  Walks Std.Ui's Element via
+-- `Ui.layout` (returns Std.Html VNode) → `Html.render` (string)
+-- → `String.length` (int).  We use the HTML length as a proxy
+-- for "view didn't panic" — any positive int means codegen is
+-- sound.  The actual contents don't matter for the regression.
+render : Element msg -> Int
+render el =
+    String.length (Html.render (Ui.layout [] el))


### PR DESCRIPTION
Closes the editor-source-tab panic class that v0.15.2 left half-fixed.

## Symptom in production

Clicking the **Source tab** in skydeploy's file editor panicked at every render:

```
panic: interface conversion: interface {} is main.Editor_Cfg_R[State_Msg],
       not main.Editor_Cfg_R[interface {}]
```

v0.15.2 closed the *literal*-into-typed-slot direction (`Cfg_R[any]{...}` → `Cfg_R[Msg]`); v0.15.3 closes the *typed-source*-into-erased-slot direction:

  - `Cfg_R[Msg]` arg → `Cfg_R[any]` sibling-callee param
  - `Cfg_R[T1]` arg → `Cfg_R[any]` sibling call inside the generic body itself
  - `cfg.WfCheck` typed-field access on a param-typed cfg

## Generated Go before/after

**Before (v0.15.2):**
```go
func Editor_view[T2 any](cfg Editor_Cfg_R[T2]) Std_Ui_Element {
    ... Editor_editorBody(any(cfg).(Editor_Cfg_R[any])),
        Editor_toolbar(any(cfg).(Editor_Cfg_R[any]), check) ...
}
```

**After (v0.15.3):**
```go
func Editor_view[T2 any](cfg Editor_Cfg_R[T2]) Std_Ui_Element {
    ... Editor_editorBody(cfg),
        Editor_toolbar(cfg, any(onCheck)) ...
}
```

## Fix mechanism (4 surgical changes, all in `Sky.Build.Compile`)

| # | What | Why |
|---|---|---|
| 1 | `letBindingType` helper | Types let-binding RHS via region lookup; gated on `canRouteTyped` (only structural body shapes — record/lambda/if/case/let). |
| 2 | `Can.Access` typed-field-access | Falls back to `lookupLambdaType` when solvedTypes returns ambig TVar; secondary check via `lookupLambdaGoStr` for the lazy-rendering race. |
| 3 | `coerceArg` parametricAliasBase short-circuit | When target = `Foo_R[any]` AND source's static type = `Foo_R[X]` for same base, pass raw. Go's call-site inference handles it. |
| 4 | Param registration in dep-emission | `goStringBindings` + `inferredArgTys` now include parametric record alias params, not just func-typed. |

## Regression test

`test-files/v0.15-stress/src/Widget/Form.sky` is a synthetic library mirroring sky-editor's `Editor.sky` shape:
- Polymorphic `view : Setup msg -> Element msg`
- Forwards `cfg` to sibling polymorphic helpers (`body cfg`, `toolbar cfg check`, `footer cfg dismiss`)
- Mixed `_ -> msg` + bare `msg` fields on the alias
- Std.Ui body (`Ui.column`, `Ui.row`)
- Let-extracted polymorphic fields

L1-L7 + L1-L7-consumer assertions in `Main.sky` FAIL on v0.15.2, PASS on v0.15.3.

## Verification gates (all green pre-merge)

- ✅ Cabal test: 306 examples, 0 failures, 1 pending
- ✅ 27/27 examples build clean from wiped slate
- ✅ `examples/00-standard-libs` stdlib smoke: 120/120 assertions
- ✅ `sky check` clean on critical examples + skydeploy
- ✅ `scripts/verify-cli.sh`: 13 pass / 0 fail / 1 skip
- ✅ `scripts/verify-all-web.sh`: 10 pass / 0 fail + console-e2e
- ✅ `scripts/lsp-test-nvim.sh`: 17/17 LSP requests pass
- ✅ Skydeploy control plane: generated Go shows no `any(cfg).(Cfg_R[any])` casts at sibling helper call sites

## Known gap (documented in regression test)

Passing a let-bound func-typed field-access (`let submit = cfg.wfSubmit in submitProbe cfg submit`) to a SAME-MODULE generic helper still emits `rt.Coerce[func(P) any](submit)`, which fails Go's call-site inference against the callee's `func(P) T1` slot.

**Workaround** in user code: pass the field directly (`submitProbe cfg cfg.wfSubmit`).

Sky-editor's actual code does NOT hit this — it passes such fields to Std.Ui kernels (`Ui.onSubmit cfg.onSubmit`) where the kernel's reflect-adapter handles the conversion. The synthetic `submitProbe` case is commented out in the regression test with a forward-looking note for the next iteration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
