### PR TITLE
refactor(compiler): introduce LowerCtx module + threading scaffolding (v0.15.4 step 1/6)

### DIFF
--- a/docs/fragility-audit-v0.15.3.md
+++ b/docs/fragility-audit-v0.15.3.md
@@ -1,0 +1,248 @@
+# Fragility Audit — Sky Compiler v0.15.3
+
+> Source: autonomous audit by Agent A (Explore) on branch
+> `refactor/compiler-fragility-audit`, 2026-05-25.
+
+## Executive Summary
+
+Sky's v0.15.x release ships **type-directed lowering** to address parametric record alias soundness bugs, but the implementation **accumulates ad-hoc recovery points** rather than replacing the type-blind lowering architecture. The compiler now has **18 NOINLINE global IORefs** managing implicit state, **97+ call sites emitting runtime coercions**, and **multiple "lazy-evaluation race" mitigations** that create new fragility vectors. The recent v0.15.2-v0.15.3 panic fixes closed **specific surface instances** but left the **underlying divergence between HM types and emitted Go IR** unaddressed.
+
+---
+
+## Critical (Panic-Class Risk, Not Yet Exercised)
+
+### 1. Race Between Lambda-Types IORef Push/Pop and GoIR Lazy Rendering
+
+**File:** `src/Sky/Build/Compile.hs:322-334, 368-374`
+
+**Functions:** `withScopedLambdaTypes`, `withScopedLambdaGoStrings`
+
+**Issue:**
+The `withScopedLambdaTypes` mechanism uses `unsafePerformIO` + manual IORef state management to register parameter types in scope. The lambda-body expression is emitted as a `GoIr.GoExpr` (a lazy data structure), but the IORef is **popped immediately after rendering to string**. If a sibling expression in the same statement-sequence references a lambda param but the expression evaluation defers its type lookup until AFTER the pop, the lookup returns `Nothing`.
+
+**Concrete scenario that would trigger it:**
+```haskell
+-- Pseudo-code
+let f = \x -> someFunc x        -- x registered in globalLambdaTypes
+    g = h (f)                    -- if g's codegen is lazy-deferred,
+                                 -- by the time it runs exprToGo on (f),
+                                 -- x is no longer in the IORef
+```
+
+**Why it's not caught today:**
+- Most lambda uses occur in inline positions where forcing is immediate.
+- Sibling-reference cases (like the recent v0.15.3 editor panic) happen at field-access sites where `lookupLambdaGoStr` provides a fallback via a second IORef (`globalLambdaGoStrings`).
+- No systematic lazy-deferral testing across the entire lowering pipeline.
+
+**Soundness impact:** Runtime panic with `interface conversion: <actual> vs <expected>` when the deferred codegen uses `any` instead of the cached type.
+
+---
+
+### 2. `inferExprType` Returns `Nothing` for Unhandled Expression Forms
+
+**File:** `src/Sky/Build/Compile.hs:11028-11177`
+
+**Functions:** `inferExprType`
+
+**Issue:**
+The `inferExprType` helper reconstructs HM type info at codegen time by walking `Can.Expr`. It handles literals, variable lookups, function calls (with special cases for polymorphic list operations), records, tuples, if/case, and field access. **It does NOT handle:**
+
+- `Can.Lambda` → returns `Nothing` (no way to reconstruct the lambda's signature from the body alone)
+- `Can.Update` → returns `Nothing` (would need to walk the original record type + unify with field changes)
+- `Can.BinOp`, `Can.Negate` → returns `Nothing` (would need operator-level type rules)
+- `Can.Let`, `Can.LetRec` (partially — case arms are handled, but let-bound names inside a call's arg are not)
+- `Can.Accessor` (standalone field-access function) → returns `Nothing`
+
+**Soundness impact:** Silent loss of type precision; downstream panics if the actual runtime value's type diverges from the nominal `any` assumption.
+
+---
+
+### 3. `containsGenericTypeParam` Gate Applied Backward
+
+**File:** `src/Sky/Build/Compile.hs:8734-8750, 8390-8410`
+
+**Issue:**
+The `coerceArg` short-circuit fires ONLY when **both source and target are parametric aliases with the SAME base name**. But what if:
+- Target is `Cfg_R[T1]` (generic context)
+- Source is `Cfg_R[Msg]` (concrete context)
+- They have the same base `Cfg_R`
+
+The short-circuit will NOT fire because `containsGenericTypeParam "Cfg_R[T1]"` is true, so we skip the entire parametric-alias arm and fall through to the `any(arg).(Cfg_R[any])` assertion, which **panics at runtime** when the actual value is `Cfg_R[Msg]`.
+
+**Soundness impact:** Go nominal-type assertion panic: `interface conversion: Cfg_R[Msg] vs Cfg_R[any]`.
+
+---
+
+### 4. `eraseTypeParams` Loses Information At Container Boundaries
+
+**File:** `src/Sky/Build/Compile.hs:8878-8891`
+
+**Issue:**
+`eraseTypeParams` walks a Go-type string and replaces all `T\d+` with `any`. When the string contains **nested parametric types** that should preserve their structure:
+
+```go
+rt.Coerce[[]rt.SkyResult[T1, String]](x)  // should stay as-is for type-pinning
+// but eraseTypeParams produces:
+rt.Coerce[[]rt.SkyResult[any, String]](x) // T1 erased → loses type info
+```
+
+**Soundness impact:** Go build error (`undefined: T1`) or runtime panic from type mismatch.
+
+---
+
+### 5. Wildcard-`any` Soundness Gate Can Be Mis-gated
+
+**File:** `Sky.Canonicalise.Type.freeTypeVars` + `Instantiate.fromAnnotation`
+
+**Issue:**
+If new code is added that checks `not (null (freeTypeVars sig))` instead of `not (null (filter (/= "any") (freeTypeVars sig)))`, it will treat `view : Model -> any` as polymorphic and route it through fresh-per-call CForeign instantiation. This diverges body ↔ caller UF vars and silently accepts type mismatches.
+
+**Soundness impact:** Silent type-mismatch acceptance; the solver unifies the body and caller with DIFFERENT UF-var chains.
+
+---
+
+### 6. `lookupLambdaGoStr` Can Serve Stale Entries Across Module Boundaries
+
+**File:** `src/Sky/Build/Compile.hs:362-390, 6935-6957`
+
+**Issue:**
+`globalLambdaGoStrings` is a **module-global IORef** that accumulates Go-type-string registrations. Unlike `globalLambdaTypes` which uses scoped push/pop, the Go-strings registry has **weaker isolation**. If the lowerer later re-enters (e.g., during DCE-pass codegen or re-lowering), old registrations are still in the map.
+
+**Soundness impact:** Type mismatches when stale type-strings from one function instantiation are used in another function's codegen.
+
+---
+
+## High (Incorrect-Codegen-With-Workaround)
+
+### 7. `coerceArg` Has 10+ Special-Case Branches
+
+**File:** `src/Sky/Build/Compile.hs:8371-8510`
+
+10 distinct branches, each handling a different panic scenario:
+1. `ty == "any"` → skip
+2. Generic type param + `any`-typed arg → `rt.Coerce[T]`
+3. Parametric record alias with matching base → pass raw
+4. `rt.SkyResult` → `rt.ResultCoerce`
+5. `rt.SkyMaybe` → `rt.MaybeCoerce`
+6. Sky-uncurried constructor at curried HOF slot → curry adapter
+7. Already-correct type → skip
+8. Parametric `rt.SkyTask` → `rt.TaskCoerceT`
+9. (Disabled) HOF-kernel-variant routing
+10. Plus more in downstream path
+
+**Each branch is a special case bolted on for a specific panic class.** No evidence that they are complete — they cover OBSERVED panic instances but not all possible shapes.
+
+**What's missing:**
+- Nested parametric types: `[]rt.SkyResult[T1, T2]`?
+- Partial application of generic constructors stored in records?
+- Closure-captured polymorphic function refs?
+- Cross-module polymorphic-call re-instantiation in non-sibling contexts?
+
+---
+
+### 8. `inferExprType` Cache Inconsistency With Solver's `solvedTypes`
+
+**File:** `src/Sky/Build/Compile.hs:9510-9538, 11028-11177`
+
+**Issue:**
+`letBindingType` tries to infer a let-binding's type using two sources (region lookup vs `inferExprType`). These can diverge when:
+- The solver produced a region type (in `globalRegionTypes`)
+- But `inferExprType`'s reconstruction is different (incomplete or wrong)
+- The code picks one source over the other and they disagree
+
+**Soundness impact:** Silent type-mismatch acceptance.
+
+---
+
+### 9. `lookupLambdaType` Can Return Wrong Type After Sibling-Scope Bindings Register
+
+**File:** `src/Sky/Build/Compile.hs:349-352, 304-312`
+
+**Issue:**
+`withLambdaTypes` permanently mutates `globalLambdaTypes` without scoping. If function A registers `x : T1`, then function B has a parameter named `x`, the inner `x` will find A's `T1` in the global map — classic variable-capture bug at the global level.
+
+---
+
+### 10. `splitCurriedFuncStr` Can Mis-parse Nested Generics
+
+**File:** `src/Sky/Build/Compile.hs:8800-8814`
+
+**Issue:**
+`splitToplevelCommas` doesn't track BRACKET depth (only paren depth). A HOF parameter whose arg type is a generic container `func([]rt.SkyResult[T1, T2]) func(T1) any` causes the `int, string` comma (inside `SkyResult[...]`) to be treated as a top-level separator.
+
+**Soundness impact:** Malformed parameter-type list → curry adapter generated with wrong arity → runtime panic.
+
+---
+
+## Medium (Architectural-Debt-With-Tests-Pinning-Current-Behavior)
+
+### 11. `globalRegionTypes` Not Populated for All Expression Regions
+
+Sub-expressions inside let-bindings, case arms, and deeply-nested calls often have regions NOT in `globalRegionTypes`. Type-directed lowering doesn't activate for them.
+
+### 12. Monomorphisation Doesn't Account For Type-Alias Equivalence
+
+`mangleType` mangles type aliases by **name only**. Two aliases that point to the same underlying type but have different names mangle to two separate Go types.
+
+### 13. `rt.Coerce` Reflect Fallback Can Silently Succeed With Wrong Values
+
+The reflect fallback uses **type.Kind() matching** rather than **exact structural equality**. `map[string]int` vs `map[string]interface{}` are kind-compatible but semantically different.
+
+### 14. `defToStmts` Zero-Param Let-Binding Routing Assumes `canRouteTyped` Completeness
+
+If a zero-param let-binding's body is an unhandled shape (e.g., `Can.Call` or `Can.Access`), `letBindingType` returns `Nothing` and the binding emits as untyped.
+
+---
+
+## Low (Cosmetic/Clarity)
+
+### 15. `globalLambdaGoStrings` Never Cleaned Up Between Compilation Phases
+### 16. `eraseTypeParams` Removes Useful Information Even When It Shouldn't
+### 17. `parametricAliasBase` Uses String Heuristics Instead of Structural Analysis
+
+---
+
+## Hot Spots
+
+1. **`src/Sky/Build/Compile.hs:8371-8510`** — `coerceArg` (10+ special-case branches)
+2. **`src/Sky/Build/Compile.hs:9474-9538`** — `letBindingType` (two-axis gate, discovered empirically)
+3. **`src/Sky/Build/Compile.hs:6900-6960`** — `Can.Access` field-access with dual-IORef fallback
+4. **`src/Sky/Build/Compile.hs:322-390`** — Lambda-type registration + dual-IORef management
+5. **`src/Sky/Build/Monomorphise.hs:280-520`** — Per-call-site type instantiation
+
+---
+
+## Patterns That Signal Fragility
+
+**A. "Special Case Added on $DATE for $PANIC"** — Each panic was closed by adding a NEW code path, not by fixing the underlying divergence. The architecture still has type-blind lowering; we're just recovering type info at more call sites.
+
+**B. "Regression Test Shows Issue, But Root Cause Remains"** — v0.15.3's regression test (`test-files/v0.15-stress/src/Widget/Form.sky`) exists because the real code panicked. Fixing the test didn't fix the root cause.
+
+**C. "Soundness Fix Widens Recovery Surface But Leaves Underlying Gap Untouched"** — explicitly documented as a design problem in `docs/v1-rfc/type-soundness-deep-analysis.md`.
+
+**D. "Global IORef State With Manual Push/Pop Instead of Monadic Threading"** — 18 global IORefs in Compile.hs alone. `unsafePerformIO` with global state is inherently fragile.
+
+---
+
+## Likelihood of Undiscovered Panics
+
+### High-Risk Shapes (Not Systematically Tested)
+
+- Polymorphic functions returning polymorphic-return-type-var values in lists
+- Generic containers storing typed-record-alias instances
+- Wildcard-only signatures (e.g., `view : Model -> any`) re-instantiated per call with different concrete returns
+- Func-typed fields in parametric records passed across module boundaries
+- Same-callee polymorphic calls where type args share unification variables
+
+---
+
+## Conclusion
+
+Sky v0.15.3 is **sound for the tested subset**. But the architecture — mixing type-blind lowering with ad-hoc type recovery — **creates new fragility vectors with each fix**.
+
+1. **No off-ramp:** Each panic is closed by adding a special case to `coerceArg` or `letBindingType`.
+2. **Implicit state races:** IORef-based lambda-type registration has lazy-evaluation races worked around (dual-IORef fallback) rather than fixed.
+3. **Incomplete gates:** Both `letBindingType` (body shapes) and `containsGenericTypeParam` (TVar detection) have documented gaps.
+4. **Test-pinning:** The regression test suite is good, but it only pins the bugs we've hit.
+
+The principled solution documented in the RFC is **full type-directed lowering** (replace 124 `exprToGo` (blind) callsites with `lower :: LowerCtx -> ExpectedType -> Can.Expr -> GoExpr`). Until that's done, **fragility will accumulate** with each new feature.

--- a/docs/improvement-plan-v0.16.md
+++ b/docs/improvement-plan-v0.16.md
@@ -1,0 +1,280 @@
+# Improvement plan — Sky compiler v0.16+
+
+> Status: planning artefact for branch `refactor/compiler-fragility-audit`. Author: Agent B (compiler expert review of Agent A's audit at `docs/fragility-audit-v0.15.3.md`). Date: 2026-05-25.
+
+> The audit identifies 17 fragility items; the RFC at `docs/v1-rfc/type-soundness-deep-analysis.md` already names the principled solution (full type-directed lowering via `LowerCtx`). Stages A–E shipped in v0.15.0/.1, closing the worst Surface-1/2/3 bugs. What remains is the **fragility tail**: 18 NOINLINE IORefs (`Compile.hs:67-295`), 48 `unsafePerformIO` uses, 10+ branches in `coerceArg` (`Compile.hs:8371-8547`), and an `inferExprType` that returns `Nothing` for `Can.Lambda`/`Can.Update`/`Can.Accessor`/`Can.LetRec` (`Compile.hs:11178-11232`). This plan turns those into discrete, sequenced, low-risk PRs.
+
+> Scope contract: no language-surface breaking changes; all 306 cabal tests + 27 examples + 120 stdlib assertions must remain green at every PR boundary; `examples/13-skyshop` build time and binary size must not regress > 3 %.
+
+---
+
+## 1. Triage of audit findings
+
+Decisions: **fix** (root-cause work this cycle), **defer** (track but don't block v0.16), **accept** (documented invariant, not a bug).
+
+| # | Audit item | Severity | Decision | Rationale |
+|---|---|---|---|---|
+| 1 | Lambda-types IORef push/pop race vs lazy GoIR rendering | Critical | **fix** | Root cause of every "lazy-deferral" panic class. §2. |
+| 2 | `inferExprType` returns `Nothing` for Lambda/Update/Accessor/BinOp/LetRec | Critical | **fix** | Each `Nothing` collapses to `"any"` → downstream uses `any(...)` → runtime panic. §4. |
+| 3 | `containsGenericTypeParam` gate applied backward at `coerceArg` | Critical | **fix** | Symptom-fix inside §3. |
+| 4 | `eraseTypeParams` loses info at container boundaries | Critical | **fix** | Replace with structural walk over `GoType` ADT. §3. |
+| 5 | Wildcard-`any` gate easy to mis-edit | Critical | **accept + lock** | Add explicit test (Invariant I6). |
+| 6 | `lookupLambdaGoStr` stale entries | Critical | **fix** | Subsumed by §2 (LowerCtx is scoped per-module). |
+| 7 | `coerceArg` 10+ branches | High | **fix** | Collapse to ≤4 cases. §3. |
+| 8 | `inferExprType` ↔ `globalRegionTypes` divergence | High | **fix** | Subsumed by §4. |
+| 9 | `withLambdaTypes` permanent global mutation | High | **fix** | Goes away with LowerCtx. |
+| 10 | `splitCurriedFuncStr` bracket-depth bug | High | **fix** | One-line fix inside §3. |
+| 11 | `globalRegionTypes` not populated for all regions | Medium | **fix-with-§2** | Snapshot at lowering entry. |
+| 12 | Monomorphisation type-alias equivalence | Medium | **defer** | Track in v0.17. |
+| 13 | `rt.Coerce` Kind-based reflect fallback | Medium | **defer** | Already documented safety net. |
+| 14 | `defToStmts` zero-param routing on `canRouteTyped` | Medium | **fix** | Subsumed by §4. |
+| 15 | `globalLambdaGoStrings` not cleaned between phases | Low | **fix-incidentally** | Goes away with §2. |
+| 16 | `eraseTypeParams` over-zealous | Low | **fix-with-§3** | Same fix as #4. |
+| 17 | `parametricAliasBase` string heuristics | Low | **fix-with-§3** | Replaced by structural classifier. |
+
+**Headline**: 11 fixes, 3 defers, 2 accept/lock.
+
+---
+
+## 2. Priority 1 — Race-free type-context threading (`LowerCtx`)
+
+### Problem (audit #1, #6, #9, #15)
+
+`withScopedLambdaTypes` / `withScopedLambdaGoStrings` force the GoExpr to a string inside the IORef bracket so the pop happens after the read. This works ONLY when there is no laziness escape. The v0.15.3 editor panic was exactly such an escape. The fix added a second IORef (`globalLambdaGoStrings`) as a fallback — band-aiding the race rather than fixing it.
+
+### Fix — introduce explicit `LowerCtx` reader monad
+
+Replace the two `globalLambda*` IORefs with a `LowerCtx` record threaded as an explicit parameter through every `exprToGo` / `exprToGoExpectGo` / `coerceArg` / `kernelCoerceArg` / `letBindingType` etc.
+
+**New module** `src/Sky/Build/LowerCtx.hs` (~150 LOC):
+
+```haskell
+data LowerCtx = LowerCtx
+    { _lc_module       :: !ModuleName.Canonical
+    , _lc_solved       :: !Solve.SolvedTypes
+    , _lc_regionTypes  :: !Solve.RegionTypes
+    , _lc_lambdaTypes  :: !(Map.Map String T.Type)
+    , _lc_lambdaGoStr  :: !(Map.Map String String)
+    , _lc_aliases      :: !(Map.Map String Can.Alias)
+    , _lc_fieldIdx     :: !Rec.RecordRegistry
+    , _lc_unionNames   :: !(Set.Set String)
+    , _lc_aliasMap     :: !(Map.Map String String)
+    , _lc_annotMap     :: !(Map.Map String T.Annotation)
+    }
+```
+
+### Implementation steps
+
+1. Add the module (no callers yet) — 1h.
+2. Build `LowerCtx` at entry to `generateGoMulti` (`Compile.hs:3069`). Pass to wrapper functions. — 3h.
+3. Migrate ~90 call sites bottom-up — 8-10h, mechanical.
+4. Replace `withScopedLambdaTypes` calls with `(withLambdaTypes m ctx)` passed to recursive call — 2-3h.
+5. Delete `globalLambdaTypes`, `globalLambdaGoStrings`, `globalRegionTypes` IORefs — 30min.
+6. Keep `globalCgEnv`, `globalReachableSet`, `globalReachableProgram`, `globalDceDisabled`, `globalEntryPath`, `globalSourceFile` as legitimately program-global.
+
+### Files affected
+
+- **New**: `src/Sky/Build/LowerCtx.hs` (~150 LOC).
+- **Edited**: `src/Sky/Build/Compile.hs` (~600 LOC of signature changes; no logic change).
+- **Untouched**: `Solve.hs`, `Monomorphise.hs`, `runtime-go/rt/*.go`.
+
+### Risk
+
+Low — sequence-equivalent. Every IORef read becomes a `Map.lookup` of the same key against the same data.
+
+### Estimate
+
+**14-16 hours**, splittable into 4 hour-sized commits.
+
+---
+
+## 3. Priority 2 — `coerceArg` simplification
+
+### Problem (audit #3, #4, #7, #10, #16, #17)
+
+`coerceArg` operates on string-encoded Go types. Every classifier is a hand-rolled string parser. Audit #4 and #10 are direct consequences: any non-trivial nested generic gets mis-parsed.
+
+### Fix — small structural `GoType` ADT
+
+**New module** `src/Sky/Build/GoType.hs` (~120 LOC):
+
+```haskell
+data GoType
+    = GoAny
+    | GoPrim PrimTy
+    | GoTVar Int
+    | GoNamed String [GoType]
+    | GoSlice GoType
+    | GoMap GoType GoType
+    | GoFunc [GoType] GoType
+    | GoTuple Int
+
+parseGoType :: String -> GoType
+emitGoType :: GoType -> String
+eraseTVars :: GoType -> GoType
+classifyAlias :: LowerCtx -> GoType -> AliasKind
+```
+
+### `coerceArg` reduced to 4 cases
+
+```haskell
+coerceArg :: LowerCtx -> GoIr.GoExpr -> GoType -> GoIr.GoExpr
+coerceArg ctx e target = case (target, classifyAlias ctx target, exprStaticType e) of
+    (GoAny, _, _)                                      -> e
+    (_, _, Just src) | src == target                   -> e
+    (_, ParametricAlias base _, Just src)
+        | ParametricAlias srcBase _ <- classifyAlias ctx src, base == srcBase -> e
+    (_, _, _) | Just call <- runtimeContainerCoerce target e -> call
+    _                                                  -> goCoerceCall target e
+```
+
+### Files affected
+
+- **New**: `src/Sky/Build/GoType.hs` (~120 LOC).
+- **Edited**: `src/Sky/Build/Compile.hs` — `coerceArg` reduced from ~177 LOC to ~50 LOC. ~15 helpers deleted. Net -350 LOC.
+
+### Estimate
+
+**18-22 hours**.
+
+### Risk
+
+Medium. Stage as 2 PRs: 3a (behaviour-preserving) + 3b (structural eraser, may flip call sites).
+
+---
+
+## 4. Priority 3 — Complete `inferExprType` arms
+
+### Problem (audit #2, #8, #14)
+
+`inferExprType` returns `Nothing` for `Can.Lambda`, `Can.Update`, `Can.Accessor`, `Can.LetRec`, and `Can.Binop` (`|>`, `<|`, `>>`, `<<`). Each `Nothing` collapses to `"any"` downstream.
+
+### Fix — implement the missing arms
+
+See full plan body — Lambda walks params + body; Update inherits from origExpr; Accessor returns placeholder; LetRec fixpoint; pipe/composition handle binop arity.
+
+### Consequence
+
+Audit #8 (`letBindingType` two-axis gate) and #14 (`canRouteTyped` completeness) drop to medium-priority cosmetic. The body-shape gate is removed entirely.
+
+### Files affected
+
+- **Edited**: `src/Sky/Build/Compile.hs` — `inferExprType` grows by ~70 LOC; `letBindingType` shrinks by ~30 LOC.
+
+### Estimate
+
+**8-10 hours**.
+
+### Risk
+
+Low-to-medium. Each arm is additive.
+
+---
+
+## 5. Priority 4 — Systematic regression test suite
+
+### Layer A — combinatorial shape matrix (`test-files/v0.16-shapes/`)
+
+Auto-generated by `tools/sky-shape-gen/Main.hs`. 10 Containers × 5 ParameterKinds × 4 CallShapes = **200 sections**, ~3000 LOC of Sky.
+
+### Layer B — generated-Go grep gates (`test/Sky/Build/GeneratedGoSpec.hs`)
+
+Forbidden patterns: `any(<typed-var>).(Foo_R[T])`, `rt.Coerce[T_R[X]](T_R{...})`, `func(any) any` inside `*_R{}`, etc.
+
+### Layer C — property-based codegen invariants (`test/Sky/Build/CodegenInvariantSpec.hs`)
+
+QuickCheck properties over random Sky programs.
+
+### Layer D — LSP / sky check parity (`test/Sky/Lsp/CheckBuildParitySpec.hs`)
+
+`sky check ≡ sky build` for every Layer A shape.
+
+### Estimate
+
+**24-30 hours**.
+
+---
+
+## 6. Priority 5 — Optional larger rewrite (full type-directed lowering)
+
+RFC §5.1's `lower :: LowerCtx → ExpectedType → Can.Expr → TypedGoExpr`. Replaces ~169 callsites of `exprToGo`/`exprToGoExpectGo`.
+
+**Recommendation**: DEFER to v0.17. Priorities 1-4 deliver ~70% of the benefit at ~30% of the risk.
+
+### Estimate
+
+**45-55 hours**.
+
+---
+
+## 7. Invariant gates (mechanical)
+
+| # | Invariant |
+|---|---|
+| I1 | No raw `any(x).(T)` assertion where `x` is statically typed AND `T` is a parametric alias instantiation. |
+| I2 | Every `rt.Coerce[T]` call site is either no-op OR crosses a documented dynamic boundary. |
+| I3 | `inferExprType ctx e == Nothing` ⇒ `e`'s position NOT type-routed downstream. |
+| I4 | `_lc_lambdaTypes` and `_lc_lambdaGoStr` agree under `solvedTypeToGo`. |
+| I5 | `sky check ≡ sky build` for every v0.16-shapes section. |
+| I6 | `freeTypeVars sig` non-`"any"` count drives polymorphism detection. |
+| I7 | Parametric record struct literals always include explicit type args. |
+| I8 | `Compile.hs` NOINLINE global IORefs ≤ 5. |
+| I9 | `Compile.hs` `unsafePerformIO` uses ≤ 10. |
+| I10 | `examples/13-skyshop` build time within ±3% of v0.15.3 baseline. |
+
+---
+
+## 8. Merge order
+
+**6 atomic PRs**, sequenced, each independently green. NO big-bang.
+
+| Order | PR | Branch | Estimate |
+|---|---|---|---|
+| 1 | `refactor: introduce LowerCtx module and plumbing` | `refactor/lower-ctx-intro` | 8h |
+| 2 | `refactor: migrate lookups from IORef to LowerCtx` | `refactor/lower-ctx-migrate-lookups` | 8h |
+| 3 | `refactor: complete inferExprType arms` | `refactor/infer-expr-completeness` | 10h |
+| 4 | `refactor: replace string Go-type with GoType ADT in coerceArg` | `refactor/gotype-adt` | 12h |
+| 5 | `fix: structural eraseTVars + parametricAliasBase` | `refactor/gotype-structural-eraser` | 8h |
+| 6 | `test: combinatorial shape matrix + invariant gates` | `test/v0.16-shape-matrix` | 28h |
+
+**v0.16 release** = PRs 1-6 merged. **v0.17** = optional Priority 5.
+
+---
+
+## 9. Acceptance criteria for v0.16
+
+### Compiler internals
+
+- [ ] `Compile.hs` has ≤ 5 NOINLINE global IORefs (down from 18)
+- [ ] `Compile.hs` has ≤ 10 `unsafePerformIO` uses (down from 48)
+- [ ] `coerceArg` has ≤ 4 branches
+- [ ] `inferExprType` returns `Just t` for every `Can.Expr` constructor
+- [ ] No string-level Go-type parser in `Compile.hs`
+- [ ] `letBindingType` has no `canRouteTyped` body-shape gate
+
+### Test suite
+
+- [ ] `test-files/v0.16-shapes/` ≥ 200 sections
+- [ ] `GeneratedGoSpec.hs` ≥ 6 forbidden patterns
+- [ ] `CodegenInvariantSpec.hs` ≥ 5 QuickCheck properties
+- [ ] `CheckBuildParitySpec.hs` covers v0.16-shapes matrix
+- [ ] `AnyWildcardSpec.hs` extended with #5 gate-direction test
+
+### Non-regression (CLAUDE.md non-negotiables)
+
+- [ ] `cabal test` — 306+ specs all green
+- [ ] All 27 examples build clean from wiped slate
+- [ ] `examples/00-standard-libs` — 120 assertions still pass
+- [ ] `scripts/verify-all-web.sh` Playwright sweep green
+- [ ] `scripts/verify-cli.sh` green
+- [ ] `examples/13-skyshop` build time within ±3% of baseline
+- [ ] `examples/13-skyshop` emitted main.go size within ±3% of baseline
+- [ ] skydeploy clean build
+
+### Documentation
+
+- [ ] `CLAUDE.md` "Current state" updated
+- [ ] `docs/v1-rfc/type-soundness-deep-analysis.md` annotated with shipped sections
+- [ ] `docs/fragility-audit-v0.15.3.md` superseded by `docs/fragility-audit-v0.16.md`
+
+When this checklist is green, tag v0.16.0 and ship.

--- a/sky-compiler.cabal
+++ b/sky-compiler.cabal
@@ -160,6 +160,7 @@ executable sky
     -- Build system
     Sky.Build.ModuleGraph
     Sky.Build.Compile
+    Sky.Build.LowerCtx
     Sky.Build.Dce
     Sky.Build.EmbedDirTH
     Sky.Build.EmbeddedRuntime

--- a/src/Sky/Build/Compile.hs
+++ b/src/Sky/Build/Compile.hs
@@ -30,6 +30,7 @@ import System.FilePath (takeDirectory, takeExtension, (</>))
 import qualified Data.ByteString as BS
 import Sky.Build.EmbeddedRuntime (embeddedRuntime, embeddedSkyStdlib)
 import qualified Sky.Build.TailCallOpt as TCO
+import qualified Sky.Build.LowerCtx as LC
 
 import qualified Sky.AST.Source as Src
 import qualified Sky.AST.Canonical as Can
@@ -3220,6 +3221,37 @@ generateGoMulti canMod srcMod config solvedTypes depDecls depRecAliases depUnion
         -- Force `imports` before anything else so the env is set up
         -- before depDecls / decls are evaluated (they read getCgEnv).
         importsForced = imports `seq` imports
+        -- v0.16 PR 1 — snapshot the lowering-time IORef state into a
+        -- pure `LowerCtx` value.  `imports` has already populated
+        -- `globalCgEnv` + `globalUnionNames`; `globalRegionTypes`,
+        -- `globalAllAliases`, `globalAllFieldIdx`, `globalAnnotMap`,
+        -- `globalLambdaTypes`, `globalLambdaGoStrings` were written
+        -- by `continueCompile` earlier.  Sequence the snapshot AFTER
+        -- `importsForced` so all writes are visible.
+        --
+        -- The value is constructed but has NO CALLERS in this PR.
+        -- PRs 2-6 of the v0.16 sequence (see
+        -- docs/improvement-plan-v0.16.md §2) migrate `exprToGo` /
+        -- `exprToGoExpectGo` / `coerceArg` / `letBindingType` /
+        -- `inferExprType` to read from `lowerCtx` instead of the
+        -- IORefs, after which the IORefs are deleted.
+        lowerCtx = unsafePerformIO $ do
+            -- Sequence the snapshot AFTER `importsForced` so writes
+            -- to `globalCgEnv` + `globalUnionNames` are visible.
+            importsForced `seq` return ()
+            regions <- readIORef globalRegionTypes
+            aliases <- readIORef globalAllAliases
+            fieldIdx <- readIORef globalAllFieldIdx
+            unions <- readIORef globalUnionNames
+            annots <- readIORef globalAnnotMap
+            return $ LC.buildLowerCtx
+                (Can._name canMod)
+                solvedTypes
+                regions
+                aliases
+                fieldIdx
+                unions
+                annots
         unionDecls = generateUnionTypes canMod
         aliasDecls = generateAliasTypes canMod
         decls = generateDecls canMod solvedTypes
@@ -3383,7 +3415,11 @@ generateGoMulti canMod srcMod config solvedTypes depDecls depRecAliases depUnion
             , GoIr._pkg_imports = imports
             , GoIr._pkg_decls = rtPin ++ errorAliasStub ++ portDefault ++ depDecls ++ unionDecls ++ aliasDecls ++ decls ++ anonRecordDecls ++ specDecls ++ mainDecl
             }
-    in GoBuilder.renderPackage pkg
+    -- Force `lowerCtx` so the IORef snapshot actually runs (v0.16
+    -- PR 1).  The value has no callers in this PR — PRs 2-6 migrate
+    -- `exprToGo` etc. to consume it — but exercising the snapshot
+    -- here verifies the scaffolding works in every release build.
+    in lowerCtx `seq` GoBuilder.renderPackage pkg
 
 
 -- | Emit a Go if-not-already-set runtime default for a sky.toml-derived
@@ -6223,6 +6259,29 @@ splitFuncType _ ty = ([], ty)  -- not enough arrows, return as-is
 -- ═══════════════════════════════════════════════════════════
 -- EXPRESSION CODE GENERATION
 -- ═══════════════════════════════════════════════════════════
+
+
+-- | v0.16 PR 1 — explicit-context lowering wrapper.  Delegates to
+-- `exprToGo` today; PRs 2-6 of the v0.16 sequence migrate the
+-- function body to read from `ctx` instead of the NOINLINE IORefs.
+--
+-- The signature already accepts `LowerCtx` so call sites can be
+-- migrated bottom-up without further churn to type signatures.
+-- The `_ctx` underscore is deliberate: until PR 2 lands, the
+-- delegated `exprToGo` still reads the IORefs, and `ctx` is the
+-- snapshot the eventual migration will consult.  See
+-- `docs/improvement-plan-v0.16.md` Priority 1.
+lowerExpr :: LC.LowerCtx -> Can.Expr -> GoIr.GoExpr
+lowerExpr _ctx = exprToGo
+
+
+-- | v0.16 PR 1 — explicit-context typed-slot wrapper.  Mirror of
+-- `lowerExpr` for the `exprToGoExpectGo` entry point.  Delegates
+-- to the existing IORef-based implementation; PR 2+ migrates the
+-- body.
+lowerExprExpectGo :: LC.LowerCtx -> String -> Can.Expr -> GoIr.GoExpr
+lowerExprExpectGo _ctx = exprToGoExpectGo
+
 
 -- | v0.13 typed lowerer: convert a canonical expression to Go IR
 -- WITH a known expected type from the surrounding context.

--- a/src/Sky/Build/LowerCtx.hs
+++ b/src/Sky/Build/LowerCtx.hs
@@ -1,0 +1,204 @@
+-- | Sky.Build.LowerCtx — explicit, immutable lowering context.
+--
+-- Background. The codegen pipeline today reads ~7 NOINLINE IORefs
+-- (`globalLambdaTypes`, `globalLambdaGoStrings`, `globalRegionTypes`,
+-- `globalAllAliases`, `globalAllFieldIdx`, `globalUnionNames`,
+-- `globalAnnotMap`) during pure lowering.  That setup races with
+-- lazy GoIR evaluation (the v0.15.3 editor panic) and makes scoping
+-- accidental rather than structural.  The principled fix — named in
+-- `docs/v1-rfc/type-soundness-deep-analysis.md` §5.1 and tracked by
+-- `docs/improvement-plan-v0.16.md` Priority 1 — is to thread an
+-- explicit `LowerCtx` reader value through every `exprToGo` /
+-- `exprToGoExpectGo` / `coerceArg` / `letBindingType` call.
+--
+-- This module is the scaffolding step (PR 1 of 6).  It introduces:
+--
+--   * The `LowerCtx` record (10 fields, matching the plan).
+--   * A `buildLowerCtx` constructor that snapshots the IORef state
+--     once at codegen entry (`generateGoMulti`).
+--   * Pure lookup helpers (`lookupLambdaType`, `lookupLambdaGoStr`,
+--     `lookupRegionType`, …) that read from the snapshot.
+--   * `withLambdaTypes` / `withLambdaGoStrs` helpers for nested
+--     scopes — these return a NEW `LowerCtx` rather than mutating a
+--     global, which is the whole point.
+--
+-- This PR does NOT migrate any existing call sites.  The IORef-
+-- backed helpers in `Compile.hs` stay live; the new helpers
+-- delegate to the same `Map.lookup` over the snapshot.  PRs 2-6
+-- migrate the call sites one bottom-up batch at a time, until the
+-- IORefs can be deleted.
+--
+-- See `docs/improvement-plan-v0.16.md` §2 for the staging.
+module Sky.Build.LowerCtx
+    ( LowerCtx (..)
+    , emptyLowerCtx
+    , buildLowerCtx
+    , lookupLambdaType
+    , lookupLambdaGoStr
+    , memberLambdaType
+    , lookupRegionType
+    , lookupAlias
+    , lookupAnnotation
+    , withLambdaTypes
+    , withLambdaGoStrs
+    ) where
+
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+
+import qualified Sky.AST.Canonical as Can
+import qualified Sky.Generate.Go.Record as Rec
+import qualified Sky.Reporting.Annotation as A
+import qualified Sky.Sky.ModuleName as ModuleName
+import qualified Sky.Type.Solve as Solve
+import qualified Sky.Type.Type as T
+
+
+-- | Snapshot of every piece of state the lowerer needs.  Constructed
+-- once at codegen entry (`generateGoMulti`), passed by value down
+-- through the call tree.  Scope-nested updates (e.g. entering a
+-- typed-lambda body) return a NEW `LowerCtx` via `withLambdaTypes`
+-- — the parent ctx is unaffected, so the race-with-laziness class
+-- of bug that `withScopedLambdaTypes` band-aided in v0.15.3 is
+-- structurally impossible here.
+data LowerCtx = LowerCtx
+    { _lc_module      :: !ModuleName.Canonical
+        -- ^ The module currently being lowered.  Used for
+        -- module-prefix qualification of unqualified names.
+    , _lc_solved      :: !Solve.SolvedTypes
+        -- ^ HM-solved types for every top-level binding in the
+        -- current module.  Snapshotted from the entry-point.
+    , _lc_regionTypes :: !Solve.RegionTypes
+        -- ^ Per-source-region HM types (v0.15 Stage A).
+        -- Snapshotted from `globalRegionTypes`.
+    , _lc_lambdaTypes :: !(Map.Map String T.Type)
+        -- ^ Lambda-scope local-variable type bindings.  Replaces
+        -- `globalLambdaTypes`.  Nested scopes update this field
+        -- via `withLambdaTypes`.
+    , _lc_lambdaGoStr :: !(Map.Map String String)
+        -- ^ Lambda-scope Go-type strings for function-typed
+        -- parameters in scope.  Replaces `globalLambdaGoStrings`.
+        -- Updated via `withLambdaGoStrs`.
+    , _lc_aliases     :: !(Map.Map String Can.Alias)
+        -- ^ Entry + dep merged alias map.  Snapshotted from
+        -- `globalAllAliases`.  Read by parametric-alias generic-args
+        -- renderer (`aliasGenericArgs`).
+    , _lc_fieldIdx    :: !Rec.RecordRegistry
+        -- ^ Field-set → alias-name registry.  Snapshotted from
+        -- `globalAllFieldIdx`.  Read by `tvarsInEmitted` and
+        -- friends to resolve `TRecord` nodes to `_R` Go struct
+        -- names without forcing the env build.
+    , _lc_unionNames  :: !(Set.Set String)
+        -- ^ Union-name set.  Snapshotted from `globalUnionNames`.
+        -- Read by `typeStrWithAliasesReg` while emitting dep-function
+        -- sigs to discriminate union-typed args.
+    , _lc_aliasMap    :: !(Map.Map String String)
+        -- ^ Reserved for a future module-prefix → unprefixed alias
+        -- shortcut map.  Empty today; populated in PR 2 when the
+        -- alias-lookup migration lands.  Kept in the record so PRs
+        -- 2-6 don't need to grow the type again.
+    , _lc_annotMap    :: !(Map.Map String T.Annotation)
+        -- ^ Per-callee generalised annotation map.  Snapshotted
+        -- from `globalAnnotMap`.  Read by σ-derivation at every
+        -- reachable instance emission.
+    }
+
+
+-- | Empty `LowerCtx` for tests and bootstrap.  Real compilation
+-- always goes through `buildLowerCtx`.
+emptyLowerCtx :: ModuleName.Canonical -> LowerCtx
+emptyLowerCtx home = LowerCtx
+    { _lc_module      = home
+    , _lc_solved      = Map.empty
+    , _lc_regionTypes = Map.empty
+    , _lc_lambdaTypes = Map.empty
+    , _lc_lambdaGoStr = Map.empty
+    , _lc_aliases     = Map.empty
+    , _lc_fieldIdx    = Map.empty
+    , _lc_unionNames  = Set.empty
+    , _lc_aliasMap    = Map.empty
+    , _lc_annotMap    = Map.empty
+    }
+
+
+-- | Construct a `LowerCtx` from the values the IORefs hold at
+-- codegen entry.  Pure — callers (`generateGoMulti`) read the
+-- IORefs once in IO and pass the snapshots here.  Decoupling the
+-- snapshot from the read site means tests can build a `LowerCtx`
+-- directly without touching any global state.
+buildLowerCtx
+    :: ModuleName.Canonical
+    -> Solve.SolvedTypes
+    -> Solve.RegionTypes
+    -> Map.Map String Can.Alias
+    -> Rec.RecordRegistry
+    -> Set.Set String
+    -> Map.Map String T.Annotation
+    -> LowerCtx
+buildLowerCtx home solved regions aliases fieldIdx unions annots = LowerCtx
+    { _lc_module      = home
+    , _lc_solved      = solved
+    , _lc_regionTypes = regions
+    , _lc_lambdaTypes = Map.empty
+    , _lc_lambdaGoStr = Map.empty
+    , _lc_aliases     = aliases
+    , _lc_fieldIdx    = fieldIdx
+    , _lc_unionNames  = unions
+    , _lc_aliasMap    = Map.empty
+    , _lc_annotMap    = annots
+    }
+
+
+-- | Look up a variable in the current lambda-types scope.  Pure
+-- substitute for `Compile.lookupLambdaType` (which reads
+-- `globalLambdaTypes` via `unsafePerformIO`).
+lookupLambdaType :: LowerCtx -> String -> Maybe T.Type
+lookupLambdaType ctx k = Map.lookup k (_lc_lambdaTypes ctx)
+
+
+-- | Look up a Go-type string for a function-typed variable in
+-- the current scope.  Pure substitute for
+-- `Compile.lookupLambdaGoStr`.
+lookupLambdaGoStr :: LowerCtx -> String -> Maybe String
+lookupLambdaGoStr ctx k = Map.lookup k (_lc_lambdaGoStr ctx)
+
+
+-- | Membership-only sister of `lookupLambdaType`.  Pure substitute
+-- for `Compile.memberLambdaType`.
+memberLambdaType :: LowerCtx -> String -> Bool
+memberLambdaType ctx k = Map.member k (_lc_lambdaTypes ctx)
+
+
+-- | Look up the HM type at a given source region.  Pure
+-- substitute for `Compile.lookupRegionType`.
+lookupRegionType :: LowerCtx -> A.Region -> Maybe T.Type
+lookupRegionType ctx region = Map.lookup region (_lc_regionTypes ctx)
+
+
+-- | Look up an alias by name.  No module-prefix fallback yet — that
+-- ships with the PR 2 migration of `Compile.lookupAliasDecl`.
+lookupAlias :: LowerCtx -> String -> Maybe Can.Alias
+lookupAlias ctx aliasName = Map.lookup aliasName (_lc_aliases ctx)
+
+
+-- | Look up a callee's generalised annotation.  Pure substitute
+-- for reads of `globalAnnotMap`.
+lookupAnnotation :: LowerCtx -> String -> Maybe T.Annotation
+lookupAnnotation ctx name = Map.lookup name (_lc_annotMap ctx)
+
+
+-- | Extend the lambda-types scope.  Returns a NEW ctx — the parent
+-- ctx is unchanged, so nested scopes obey lexical structure
+-- automatically.  Replaces `withScopedLambdaTypes`'s push/pop +
+-- forced-rendering trick (the trick exists because the previous
+-- design had no scoping; this design has scoping for free).
+withLambdaTypes :: Map.Map String T.Type -> LowerCtx -> LowerCtx
+withLambdaTypes additions ctx =
+    ctx { _lc_lambdaTypes = Map.union additions (_lc_lambdaTypes ctx) }
+
+
+-- | Extend the lambda-Go-string scope.  Mirror of `withLambdaTypes`
+-- for the Go-type-string registry.
+withLambdaGoStrs :: Map.Map String String -> LowerCtx -> LowerCtx
+withLambdaGoStrs additions ctx =
+    ctx { _lc_lambdaGoStr = Map.union additions (_lc_lambdaGoStr ctx) }

--- a/test-files/v0.15-stress/src/Widget/Form.sky
+++ b/test-files/v0.15-stress/src/Widget/Form.sky
@@ -79,6 +79,7 @@ type alias Payload =
 view : Setup msg -> Element msg
 view cfg =
     let
+        submit = cfg.wfSubmit
         check = cfg.wfCheck
         dismiss = cfg.wfDismiss
     in
@@ -91,25 +92,34 @@ view cfg =
               , toolbar cfg check
               ]
         , footer cfg dismiss
+        , submitProbe cfg submit
         ]
 
 
--- NOTE — KNOWN GAP (v0.15.3): passing a let-bound func-typed
--- field-access (`submit = cfg.wfSubmit`) to a SAME-MODULE
--- generic helper (`submitProbe : Setup msg -> (Payload -> msg)
--- -> Element msg`) currently emits `rt.Coerce[func(P) any]
--- (submit)` which fails Go's call-site inference against the
--- callee's `func(P) T1` slot.  Workaround in user code: pass
--- the field directly at the call site (`submitProbe cfg cfg.
--- wfSubmit`) — direct field access fires the typed path.
--- The real-world sky-editor shape passes such fields to Std.Ui
--- kernel calls (`Ui.onSubmit cfg.onSubmit`), NOT to same-module
--- generic helpers, so the panic class the editor exhibits is
--- fully closed by v0.15.3; this synthetic helper exists as a
--- forward-looking gate for the next iteration.
--- submitProbe : Setup msg -> (Payload -> msg) -> Element msg
--- submitProbe cfg _onSubmit =
---     Ui.text ("submit[" ++ cfg.wfLabel ++ "]")
+-- L8 — passing a let-bound FUNC-typed field-access to a SAME-
+-- module generic helper.  The let-binding `submit = cfg.wfSubmit`
+-- emits as a typed selector (`submit := cfg.WfSubmit`), giving
+-- submit's Go-static type `func(Widget_Form_Payload_R) T1`.
+-- At the `submitProbe cfg submit` call site, Go's call-site
+-- type inference pins both the cfg arg (matching `Setup_R[T1]`)
+-- AND the submit arg (matching `func(P) T1`) — no nominal cast
+-- or reflect-adapter wrap required.
+--
+-- v0.15.3 closes this case via the combination of:
+--   * `parametricAliasBase` short-circuit in `coerceArg` (target
+--     base matches source base → emit raw),
+--   * `lookupLambdaGoStr` registration of typed func + record-
+--     alias params at dep-emission (so `goExprGoType` returns
+--     the typed signature for the call-site short-circuit gate).
+--
+-- Initial commit of this regression suite (v0.15.3 PR #70)
+-- omitted this case under the false belief it was a residual
+-- gap.  Subsequent verification showed it actually passes — this
+-- commit adds the case as a permanent regression gate so a
+-- future change can't silently regress it.
+submitProbe : Setup msg -> (Payload -> msg) -> Element msg
+submitProbe cfg _onSubmit =
+    Ui.text ("submit[" ++ cfg.wfLabel ++ "]")
 
 
 -- L1, L6 — sibling polymorphic helper returning Element msg.


### PR DESCRIPTION
## Summary

First step of the v0.15.x compiler-reliability work. Adds a new module `src/Sky/Build/LowerCtx.hs` (~204 LOC) and wires it into `generateGoMulti` as a snapshot of the current global IORef state. Future PRs migrate the actual lookups.

**Zero behaviour change.** All gates green:

| Gate | Result |
|---|---|
| `cabal test` | 306/0 + 1 pending |
| 27/27 examples build clean from wiped slate | ✅ |
| `examples/00-standard-libs` runtime | 120/120 assertions |
| `test-files/v0.15-stress` runtime | 23/23 ALL PASS |

## Why this is part of the v0.15.x patch series

The user-facing fix in v0.15.3 closed the editor-Source-tab panic by adding more recovery points (a second IORef, a structural-by-field-set check, a let-binding type-pinning gate). That worked, but the audit (`docs/fragility-audit-v0.15.3.md`) showed the underlying architecture — type-blind lowering with global IORef state — is still the root cause of every v0.15.x panic class.

This PR is the first step toward replacing the IORef-with-manual-pop pattern with an explicit `LowerCtx` reader-style threading. Each subsequent PR (v0.15.4 step 2/6 through 6/6) migrates one or two IORef readers at a time.

## Inputs (committed in this PR)

- `docs/fragility-audit-v0.15.3.md` — Agent A's audit (17 fragility items)
- `docs/improvement-plan-v0.16.md` — Agent B's plan (6-PR sequence). NOTE: plan was written assuming v0.16 release target but the actual delivery is via v0.15.x patches (one tag per PR). Plan content remains valid.

## What this PR does NOT do

- Does NOT migrate any `lookupLambdaType` / `lookupRegionType` / `lookupLambdaGoStr` / `withScopedLambdaTypes` call sites in `Compile.hs`. That's step 2/6.
- Does NOT remove any IORef.
- Does NOT touch `coerceArg`, `inferExprType`, `letBindingType`, or `lookupAliasDecl`.
- The `lowerExpr` / `lowerExprExpectGo` wrappers are placeholders with no callers yet.

## Files

- `src/Sky/Build/LowerCtx.hs` (new, +204)
- `src/Sky/Build/Compile.hs` (+60 / -1)
- `sky-compiler.cabal` (+1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)