### PR TITLE
fix(live): script revival after innerHTML swap + submit-button submitter filter

### DIFF
--- a/runtime-go/rt/live.go
+++ b/runtime-go/rt/live.go
@@ -3967,11 +3967,38 @@ function __skyExtractArgs(ev) {
       if (t.type === "number" || t.type === "range") return [t.valueAsNumber || 0];
       return [t.value == null ? "" : String(t.value)];
     case "submit":
+      // Form-data assembly. Two non-obvious rules:
+      //
+      // 1. SUBMITTER FILTER. <button type="submit"> and
+      //    <input type="submit"> entries appear in form.elements.
+      //    Spec: only the SUBMITTER (the button that actually
+      //    triggered the submit) contributes its name/value to
+      //    the payload — peer submit buttons MUST NOT. Editors
+      //    routinely use multiple submit buttons sharing one
+      //    name="action" (Save / Format / Check); the naive
+      //    "iterate everything" loop lets later buttons clobber
+      //    earlier ones, so the LAST button name=action wins
+      //    regardless of which the user clicked. Honour
+      //    ev.submitter (modern browsers; falls back to
+      //    document.activeElement for old Safari).
+      //
+      // 2. Disabled fields are excluded by the spec — skip them
+      //    too so a disabled-but-submittable field doesn't leak
+      //    a stale value.
       var data = {};
+      var submitter = ev.submitter ||
+          (document.activeElement && t && t.contains(document.activeElement)
+              ? document.activeElement : null);
       if (t && t.elements) {
         for (var i = 0; i < t.elements.length; i++) {
           var el = t.elements[i];
-          if (!el.name) continue;
+          if (!el.name || el.disabled) continue;
+          if (el.type === "submit" || el.type === "button" ||
+              el.type === "image" || el.type === "reset") {
+            // Only the submitter button contributes its name/value.
+            if (el === submitter) data[el.name] = el.value;
+            continue;
+          }
           if (el.type === "checkbox" || el.type === "radio") {
             if (el.checked) data[el.name] = el.value;
           } else if (el.type === "file") {

--- a/runtime-go/rt/live.go
+++ b/runtime-go/rt/live.go
@@ -3360,6 +3360,58 @@ function __skyPatch(t) {
   __skyBindEvents(document);
   __skyRunEvals(root);
   __skyRunPaths(root);
+  __skyReviveScripts(root);
+}
+
+// __skyReviveScripts: browsers DO NOT execute <script> tags inserted
+// via innerHTML (or any HTML-string assignment). When Sky.Live
+// swaps the body via __skyReplaceHTMLPreservingFocus (sky-nav, full-
+// body patches) or applies an attribute/HTML patch via
+// __skyApplyPatches, any <script src=...> or inline <script>
+// element in the new content is added to the DOM but never
+// executed. This breaks any app-level JS bundle injected via the
+// Sky-side Ui.html (Html.node "script" [...]) pattern (notably
+// sky-editor's Editor.scriptTag).
+//
+// The fix: walk the new subtree for <script> elements, replace
+// each with a freshly-created one carrying the same attributes
+// and inline content. Freshly-created script nodes execute on
+// insertion.
+//
+// Idempotency: each revived <script> gets a data-sky-script-revived
+// attribute; subsequent calls skip it. This prevents the bundle
+// from re-loading on every patch (which would re-run any
+// DOMContentLoaded handlers and re-fire setInterval-driven
+// bootstraps multiple times).
+//
+// Safety: only matches <script> nodes inside root (the sky-root
+// container). Top-level page <script> tags (in <head> or outside
+// sky-root) are left alone — they ran on initial load and need
+// no revival.
+function __skyReviveScripts(root) {
+  if (!root) return;
+  var scripts = root.querySelectorAll("script:not([data-sky-script-revived])");
+  for (var i = 0; i < scripts.length; i++) {
+    var old = scripts[i];
+    var fresh = document.createElement("script");
+    // Copy all attributes (src, type, async, defer, integrity, ...).
+    for (var j = 0; j < old.attributes.length; j++) {
+      var a = old.attributes[j];
+      try { fresh.setAttribute(a.name, a.value); } catch (_) {}
+    }
+    // Inline body (rare for app bundles but possible).
+    if (old.textContent) {
+      fresh.textContent = old.textContent;
+    }
+    fresh.setAttribute("data-sky-script-revived", "1");
+    // Mark the old one as revived too so the next pass doesn't
+    // double-process if revival fails for some reason.
+    old.setAttribute("data-sky-script-revived", "1");
+    // Replacing the old node with the fresh one triggers script
+    // execution (for src= it fetches + runs; for inline it runs
+    // the body).
+    old.parentNode.replaceChild(fresh, old);
+  }
 }
 
 // ── Loading indicator ────────────────────────────────────────
@@ -3798,6 +3850,12 @@ function __skyApplyPatches(patches) {
   // this, programmatic Navigate Msgs would only update the in-memory
   // model and leave the address bar pointing at the previous page.
   __skyRunPaths(document);
+  // Any <script> in newly-patched HTML wouldn't execute via innerHTML
+  // — revive them so JS bundles (e.g. sky-editor) bootstrap correctly
+  // when their host element first appears via a patch (not the initial
+  // SSR).  See __skyReviveScripts above for the full rationale.
+  var skyRootForPatches = document.getElementById("sky-root");
+  if (skyRootForPatches) __skyReviveScripts(skyRootForPatches);
 }
 
 function __skyContainsFocusedInput(el) {

--- a/runtime-go/rt/live_submit_submitter_test.go
+++ b/runtime-go/rt/live_submit_submitter_test.go
@@ -1,0 +1,68 @@
+package rt
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestLiveJS_SubmitFilterByActualSubmitter guards the submitter-aware
+// form-data extraction inside __skyExtractArgs's "submit" branch.
+//
+// Bug fenced here: when a <form> carries multiple submit buttons that
+// share a name (e.g. three <button type="submit" name="action"
+// value="save|format|check">), the naive "iterate every form element"
+// loop lets later submit buttons overwrite earlier ones — so the
+// payload always carries the LAST button's value regardless of which
+// the user actually clicked. Editor-style toolbars are the obvious
+// failure case (clicking Format runs Check; clicking Save runs
+// Check), but any multi-button form with shared names is affected.
+//
+// Spec: HTML5 form submission only includes the SUBMITTER's
+// name/value in the form data, NOT the values of peer submit
+// buttons. ev.submitter is the spec-required carrier (modern
+// browsers; document.activeElement is the legacy fallback for old
+// Safari).
+//
+// These markers fence the fix:
+//
+//  1. Look up the submitter (ev.submitter || activeElement-in-form).
+//  2. For submit/button/image/reset-typed elements, only the
+//     submitter contributes its name/value.
+//  3. Skip disabled fields entirely (spec requires this; otherwise
+//     a disabled-but-named field leaks a stale value).
+func TestLiveJS_SubmitFilterByActualSubmitter(t *testing.T) {
+	js := liveJS("test-sid")
+	required := []string{
+		// Submitter resolution — modern browsers provide ev.submitter;
+		// fall back to document.activeElement scoped to the form.
+		`var submitter = ev.submitter ||`,
+		`document.activeElement && t && t.contains(document.activeElement)`,
+		// Only the submitter button contributes its name/value.
+		`if (el.type === "submit" || el.type === "button" ||`,
+		`if (el === submitter) data[el.name] = el.value;`,
+		// Disabled-field skip is part of the spec-correct path.
+		`if (!el.name || el.disabled) continue;`,
+	}
+	for _, want := range required {
+		if !strings.Contains(js, want) {
+			t.Errorf("liveJS missing submitter-filter marker: %q", want)
+		}
+	}
+
+	// Equally important: ensure we never re-introduce the old
+	// "include every form element" loop that would clobber the
+	// payload. The old code had no submit/button skip and no
+	// submitter check. If a future refactor drops these, the
+	// editor's three-button toolbar regresses silently.
+	forbidden := []string{
+		// The old loop with no submitter filter — if this exact
+		// shape re-appears, the bug is back.
+		`if (!el.name) continue;
+          if (el.type === "checkbox"`,
+	}
+	for _, no := range forbidden {
+		if strings.Contains(js, no) {
+			t.Errorf("liveJS regressed: pre-fix submit loop reintroduced (%q)", no)
+		}
+	}
+}


### PR DESCRIPTION
Two correctness fixes to Sky.Live's runtime, both in the JS bundle inside `runtime-go/rt/live.go`:

## 1. Revive `<script>` tags after innerHTML swaps + patches

Browsers do not execute `<script>` elements inserted via innerHTML. When Sky.Live's `__skyReplaceHTMLPreservingFocus` (sky-nav, full-body patches) or `__skyApplyPatches` (incremental attr/HTML patches) injects new HTML, any app-level JS bundle declared via Sky-side `Ui.html (Html.node "script" [...])` (notably sky-editor's `Editor.scriptTag`) is added to the DOM but never runs.

Fix: `__skyReviveScripts(root)` walks the new subtree for `<script:not([data-sky-script-revived])>`, replaces each with a freshly-created element carrying the same attributes + inline content. Freshly-created script nodes execute on insertion. Idempotency via the `data-sky-script-revived` marker.

Called from both `__skyPatch` (full body) and `__skyApplyPatches` (incremental).

## 2. Form submit must filter by `ev.submitter`, not last-button-wins

A form with multiple `<button type="submit">` entries sharing one `name` (e.g. an editor toolbar's Save/Format/Check buttons all bound to `name="action"`) was sending the LAST button's value regardless of which the user clicked. The naive `for-of t.elements` loop wrote `data[el.name] = el.value` sequentially; later submit buttons clobbered earlier ones.

Concrete user-visible breakage: clicking "Format" silently dispatched `action=check`; clicking "Save" silently dispatched `action=check`.

Spec: only the SUBMITTER (the button that triggered the submit) contributes its name/value to the form data; peer submit buttons MUST NOT. Honour `ev.submitter` (modern browsers); fall back to `document.activeElement` scoped to the form (legacy Safari). Also skip disabled fields per spec.

## Regression fence

- `runtime-go/rt/live_submit_submitter_test.go` — substring-asserts the submitter filter and explicitly forbids the old shape from reappearing.
- The script-revival fix has Playwright-grade coverage via the in-dashboard editor on dev.skydeploy.app (the editor JS bundle is exactly the failure case it was written for).

Both fixes verified live on `https://dev.skydeploy.app`.