### PR TITLE
fix(compile): coerceArg structural-fallback for parametric-alias cross-instantiation (Gap A1 / P1)

### DIFF
--- a/docs/v0.15.x-hardening/CYCLE_LOG.md
+++ b/docs/v0.15.x-hardening/CYCLE_LOG.md
@@ -1,0 +1,5 @@
+# v0.15.x hardening — cycle log
+
+| cycle | timestamp (UTC) | gap closed | PR | branch state |
+|---|---|---|---|---|
+| CYCLE-01-P1 | (filled on PR open) | Gap A1 + prior fragility-audit #3 CLOSED | (filled on PR open) | branch ready for tag v0.15.7 |

--- a/docs/v0.15.x-hardening/implementations/CYCLE-01-developer.md
+++ b/docs/v0.15.x-hardening/implementations/CYCLE-01-developer.md
@@ -1,0 +1,110 @@
+# CYCLE-01 — Developer record (Plan Item P1)
+
+**Closes:** Audit Gap A1 + fragility-audit-v0.15.3.md item #3.
+
+**Branch:** `feat/v0.15.x-hardening-P1-coerce-parametric-alias-gate`
+
+**Target patch tag:** v0.15.7 (push is the human's gate — branch +
+PR is the developer's finish line).
+
+## Architectural diagnosis
+
+`coerceArg`'s parametric-alias short-circuit (Compile.hs ~8499 pre-
+fix) was gated on `Just srcTy <- goExprGoType e`.  For expression
+shapes whose Go-static type isn't tracked in the lambda-types
+registry, that returned Nothing and the arm didn't fire.  Codegen
+then fell through to the wrap path, which emits
+`any(arg).(Foo_R[any])` — a nominal type assertion across Go
+generic instantiations.  When the source's actual runtime type was
+`Foo_R[int]` / `Foo_R[Msg]`, the assertion panicked at runtime with
+`interface conversion: Foo_R[int], not Foo_R[any]`.
+
+The lambda-types registry doesn't cover three shapes that exercise
+this bug:
+
+1. Let-bindings whose RHS is a polymorphic-call result
+   (`let cfg1 = forwardCfg cfg0`).  `forwardCfg : Cfg msg -> Cfg msg`
+   doesn't register `cfg1` because `letBindingType`'s `canRouteTyped`
+   gate rejects `Can.Call` body shapes.
+2. VarLocal references that pre-date the current scope's
+   `withScopedLambdaTypes` push.
+3. Field selectors whose underlying record's Go-static type isn't
+   tracked.
+
+For all three the HM solver still has the type — the structural-
+fallback arm reads it via `inferExprType` against
+`Solve.SolvedTypes`, recognises the `T.TAlias _ aliasName _ _`
+shape, and short-circuits when the alias's emitted struct name
+(`aliasName ++ "_R"`) matches the target's parametric base.
+
+## Sequenced steps
+
+1. **Failing-test-first.** `test/Sky/Build/CoerceArgParametricSpec.hs`
+   builds a project-style fixture (let-bound concrete alias through
+   polymorphic forwarder) and asserts:
+   - generated Go contains no `.(Cfg_R[any])` nominal assertion,
+   - emitted binary runs to completion without panicking.
+   Confirmed both assertions FAIL on the starting worktree.
+2. **Stress fixture.**
+   `test-files/v0.15-stress/src/Widget/CrossInstanceCfg.sky` mirrors
+   the reproducer as an importable dep module; Main.sky exercises
+   it via `XCfg.roundTripInt 42`.
+3. **Signature extension.** `coerceArg :: Maybe Can.Expr -> GoIr.GoExpr -> String -> GoIr.GoExpr`.
+   Callers updated:
+   - `coerceCallArgsAt` (two `coerceOne` / `coerceFallback` arms) —
+     pass `Just e`.
+   - `kernelCoerceArg` — pass `Just e`.
+   - `lowerArgExpect` — pass `Just e`.
+   - over-application call-site (`extraIdents` zipWith) — pass
+     `Nothing` (synthesised `__p<i>` identifiers).
+   - TCO jump (`tcoJump` in entry/dep function bodies) — thread the
+     original `Can.Expr` per-position via `zip4tco` so the structural
+     fallback can recognise let-bound cross-instantiation in tail
+     calls.
+4. **Structural-fallback arm.** New `coerceArg` clause:
+
+   ```haskell
+   | Just targetBase <- parametricAliasBase ty
+   , Just src <- mSrc
+   , Just aliasName <- aliasBaseFromCanExpr src
+   , aliasName ++ "_R" == targetBase
+       = e
+   ```
+
+   Helper `aliasBaseFromCanExpr` routes through `inferExprType` +
+   the env's `_cg_recordAliases` set.  Critical detail: it accepts
+   BOTH the unqualified alias name (entry-module compile path) AND
+   the module-prefixed name (dep-module path) so a let-binding in a
+   dep function resolves cleanly when the dep module is compiled
+   under its own `_cg_aliases` namespace.
+
+5. **Updated the comment block.** Compile.hs ~8485 now describes
+   the two-path soundness: (a) lambda-types registry, (b)
+   structural fallback via `inferExprType`.  References to the new
+   regression spec + the new stress fixture inserted.
+
+## Test rationale
+
+- **Spec is project-style** (vs single-file), mirroring
+  `TaskResultBridgesSpec` and `HofTypedMsgSpec` shape, so the build
+  exercises the full Sky.Stdlib + module-graph + monomorphisation
+  flow.
+- **Two assertions** (codegen-shape + runtime) catch both the
+  pre-fix wrap-shape regressions AND the codegen-emits-different-
+  thing-but-still-panics class.
+
+## Verification evidence
+
+- `cabal test --match=CoerceArgParametric` — 2/2 PASS post-fix
+  (was 2/2 FAIL pre-fix).
+- Full cabal-test (excluding `Sky.Build.EmbeddedRuntime`'s pre-
+  existing tree-mismatch failure unrelated to this work) — 312
+  examples, 0 failures, 1 pending.
+- v0.15-stress runtime — `ALL 24 PASS` (24 sections including the
+  new `XCfg` round-trip).
+- Clean-build sweep (29 example dirs, 27 numbered + 2 fixtures) —
+  100% green.
+- `scripts/verify-cli.sh` — 13/13 pass, 1 GUI skip.
+- `scripts/verify-all-web.sh` — 10/10 pass + console e2e green.
+- `sky check` on examples/12-skyvote — `No errors found.`
+- `sky fmt` on the new .sky fixture — two-pass byte-identical.

--- a/sky-compiler.cabal
+++ b/sky-compiler.cabal
@@ -272,6 +272,7 @@ test-suite sky-tests
       Sky.Build.RecordFieldOrderSpec
       Sky.Build.RecordCtorEmptyListSpec
       Sky.Build.HofTypedMsgSpec
+      Sky.Build.CoerceArgParametricSpec
       Sky.Build.AnonLambdaSpec
       Sky.Build.AnonRecordSpec
       Sky.Build.Issue52Spec

--- a/src/Sky/Build/Compile.hs
+++ b/src/Sky/Build/Compile.hs
@@ -7750,7 +7750,7 @@ emitPartialCtor func suppliedArgs missing =
         -- parametric-record passing on partial-applied ctors.
         suppliedGo  = zipWithDefaultExpect suppliedTys suppliedArgs
         extraNames  = [ "__p" ++ show i | i <- [0 .. missing - 1] ]
-        extraIdents = zipWith (\n ty -> coerceArg (GoIr.GoIdent n) ty)
+        extraIdents = zipWith (\n ty -> coerceArg Nothing (GoIr.GoIdent n) ty)
                               extraNames sanitisedExtras
         finalCall = GoIr.GoCall (exprToGo func) (suppliedGo ++ extraIdents)
         -- Wrap outer-first (last extra wrapped first) so the chain is
@@ -8069,7 +8069,7 @@ coerceCallArgsAt region qualName args =
                             _ ->
                                 if subbed == "any" && containsTypeParam orig
                                     then GoIr.GoCall (GoIr.GoIdent "any") [exprToGo e]
-                                    else coerceArg (exprToGo e) subbed
+                                    else coerceArg (Just e) (exprToGo e) subbed
                 in zipWith3Default coerceOne paramTypes substituted args
         _ ->
             -- v0.13 Phase A5+: when no CSI is captured at this call
@@ -8216,7 +8216,7 @@ coerceCallArgsAt region qualName args =
                         _ ->
                             if subbed == "any" && containsTypeParam orig
                                 then GoIr.GoCall (GoIr.GoIdent "any") [exprToGo e]
-                                else coerceArg (exprToGo e) subbed
+                                else coerceArg (Just e) (exprToGo e) subbed
             in zipWith3Default coerceFallback paramTypes substituted args
 
 
@@ -8452,8 +8452,21 @@ splitFuncTypeStr s
 -- (e.g. `SkyResult[any,any]` vs `SkyResult[IoError,string]`), use the
 -- runtime coerce helpers that reconstruct the value with target
 -- generic params.
-coerceArg :: GoIr.GoExpr -> String -> GoIr.GoExpr
-coerceArg e ty
+--
+-- v0.15.x hardening / Gap A1 — accepts an optional source `Can.Expr`.
+-- The parametric-alias short-circuit historically gated on
+-- `goExprGoType e` returning Just; for expression shapes whose Go-
+-- static type isn't tracked in the lambda-types registry (let-
+-- bindings holding a polymorphic-call result, VarLocal references
+-- to outer-scope bindings), `goExprGoType` returns Nothing.  The
+-- structural-fallback arm uses `inferExprType` on the source to
+-- recover the alias identity directly from the HM-solved type and
+-- short-circuits when the alias base names match.  Callers that
+-- don't have an underlying `Can.Expr` (synthesised
+-- `__p0 / __tco_t0` identifiers in over-application + TCO jumps)
+-- pass `Nothing` and the new arm cleanly no-ops.
+coerceArg :: Maybe Can.Expr -> GoIr.GoExpr -> String -> GoIr.GoExpr
+coerceArg mSrc e ty
     | ty == "any" || null ty = e
     -- Generic type parameter (T1, T2, ...) — when the arg's static
     -- Go type is concrete (`int`, `string`, `[]T1`, `rt.SkyResult
@@ -8483,23 +8496,52 @@ coerceArg e ty
     -- same generic struct are distinct nominal types, so the
     -- assertion panics for any T ≠ any at runtime.
     --
-    -- Soundness: we only apply when the SOURCE's static Go type
-    -- matches the target's parametric base.  When the source is
-    -- `any`-typed (rt.Field / rt.SkyCall result, unannotated
-    -- local), we fall through to the existing wrap path, which
-    -- still works because the runtime value's actual instantiation
-    -- matches the target's `any` slot.
+    -- Two soundness paths — both gated on the SOURCE actually
+    -- carrying the same parametric base as the target:
     --
-    -- Regression: test-files/v0.15-stress/src/Widget/Form.sky
-    -- exercises three call sites — view body sibling helpers
-    -- (`body cfg`, `toolbar cfg check`), consumeForm's typed-arg
+    --   (a) Lambda-types-registry path (the original short-circuit).
+    --       When `goExprGoType e` returns the Go-static type of a
+    --       typed local (let-binding registered via the lowerer's
+    --       `withScopedLambdaTypes`, typed function param, …), the
+    --       structural match is trivial — both sides are Go-type
+    --       strings of shape `Foo_R[<args>]`.
+    --
+    --   (b) v0.15.x hardening / Gap A1 — structural fallback via
+    --       `inferExprType`.  The lambda-types registry doesn't
+    --       cover every shape: let-bindings whose RHS is a
+    --       polymorphic-call result, VarLocal references to
+    --       outer-scope bindings, and other cases where the
+    --       lazy-rendering race leaves the entry unfilled.  But
+    --       `Solve.SolvedTypes` carries the HM-solved type for
+    --       every name in scope, and for record-alias-typed values
+    --       that type is `T.TAlias _ aliasName _ _`.  When the
+    --       target slot is `<aliasName>_R[...]` we can short-
+    --       circuit safely: at runtime the value's actual generic
+    --       instantiation IS the target alias's instantiation
+    --       (HM has already proved it), so Go's call-site type
+    --       inference pins the callee's T from the source.
+    --
+    -- Regression: test-files/v0.15-stress/src/Widget/Form.sky and
+    -- test-files/v0.15-stress/src/Widget/CrossInstanceCfg.sky.  Form
+    -- exercises view-body sibling helpers, consumeForm's typed-arg
     -- forwarding, and main's let-bound record passed to a
-    -- polymorphic view.  All three previously emitted
-    -- `Setup_R[X]` → `Setup_R[any]` assertions and panicked.
+    -- polymorphic view (path (a)).  CrossInstanceCfg exercises a
+    -- let-bound concrete alias passing through a polymorphic
+    -- forwarder, then consumed by a concretely-typed function —
+    -- both call sites pre-fix emitted `any(.).(Cfg_R[any])` casts
+    -- that panicked under Go's nominal generic-type rules
+    -- (path (b)).  See spec
+    -- test/Sky/Build/CoerceArgParametricSpec.hs.
     | Just targetBase <- parametricAliasBase ty
     , Just srcTy <- goExprGoType e
     , Just srcBase <- parametricAliasBase srcTy
     , targetBase == srcBase
+        = e
+    -- (b) Structural fallback gated on the HM-solved source type.
+    | Just targetBase <- parametricAliasBase ty
+    , Just src <- mSrc
+    , Just aliasName <- aliasBaseFromCanExpr src
+    , aliasName ++ "_R" == targetBase
         = e
     -- v0.13 Stage 1 — runtime-kernel HOF arg: when the target slot
     -- expects a typed `func(...) ...` AND the source is a
@@ -8716,6 +8758,57 @@ parametricAliasBase ty =
         _ -> Nothing
 
 
+-- | v0.15.x hardening / Gap A1 — recover an alias base name from a
+-- source `Can.Expr` by routing through `inferExprType` against the
+-- global codegen env's `Solve.SolvedTypes`.
+--
+-- Used by `coerceArg`'s structural-fallback arm.  The lambda-types
+-- registry covers most lowered-expression shapes but misses three:
+--   * Let-bindings whose RHS is a polymorphic-call result
+--     (`let cfg1 = forwardCfg cfg0`).
+--   * VarLocal references that pre-date the current scope's
+--     `withScopedLambdaTypes` push.
+--   * Field selectors whose record's Go-static type isn't tracked.
+-- For all three the HM solver still has the type — we read it,
+-- detect a record-alias-typed value, and return the alias's name.
+-- The caller appends `"_R"` and compares against the target's
+-- parametric base.
+--
+-- Returns Nothing when:
+--   * The expression isn't HM-typed (synthesised identifiers,
+--     `Nothing` from `inferExprType`).
+--   * The type isn't a record alias (primitives, lambdas, ADTs).
+--   * The alias isn't a record alias (raw `type alias X = Int`
+--     style aliases that emit as their underlying Go type, not
+--     `X_R`).
+aliasBaseFromCanExpr :: Can.Expr -> Maybe String
+aliasBaseFromCanExpr src =
+    let env = getCgEnv
+        solved = Rec._cg_solvedTypes env
+    in case inferExprType solved src of
+        Just (T.TAlias homeMod aliasName _ _) ->
+            -- Only RECORD aliases emit as `<name>_R` in Go.  Aliases
+            -- of other shapes (transparent `type alias X = Int`) emit
+            -- as their underlying Go type and never match a parametric
+            -- base check.  Confirm via `_cg_recordAliases`, which
+            -- carries BOTH the entry-module unqualified names AND
+            -- module-prefixed dep names — so this works whether the
+            -- target instantiation renders as `XCfg_R` (entry) or
+            -- `Widget_CrossInstanceCfg_XCfg_R` (dep).  Returns the
+            -- name flavour that matches the in-scope target.
+            let prefix = case ModuleName.toString homeMod of
+                    ""  -> ""
+                    nm  -> map (\c -> if c == '.' then '_' else c) nm
+                                ++ "_"
+                qualified = prefix ++ aliasName
+                isRec = Set.member aliasName (Rec._cg_recordAliases env)
+                isQualRec = Set.member qualified (Rec._cg_recordAliases env)
+            in if isRec then Just aliasName
+               else if isQualRec then Just qualified
+               else Nothing
+        _ -> Nothing
+
+
 -- | v0.13 Stage 1 — extract Go-string param types from a kernel's
 -- HM type, taking N param positions. Returns empty list if the
 -- type isn't a function (the Forall body was a bare value).
@@ -8808,7 +8901,7 @@ kernelCoerceArg _allSubbed _idx subbed e@(A.At _ inner) =
             | isParametricAliasInstantiation subbed
             , not (containsGenericTypeParam subbed) ->
                 exprToGoExpectGo subbed e
-        _ -> coerceArg (exprToGo e) subbed
+        _ -> coerceArg (Just e) (exprToGo e) subbed
 
 
 -- | v0.13 Stage 1 — does a Go-type string contain any generic-param
@@ -9042,7 +9135,7 @@ lowerArgExpect ty e@(A.At _ expr)
     , not (containsGenericTypeParam ty)
     = exprToGoExpectGo ty e
     | otherwise
-    = coerceArg (exprToGo e) ty
+    = coerceArg (Just e) (exprToGo e) ty
 
 
 -- | Over-application: the call supplied MORE args than the callee's
@@ -9131,7 +9224,7 @@ emitPartialUserCall func suppliedArgs missing =
         -- v0.15.2: typed-target call args via `zipWithDefaultExpect`.
         suppliedGo = zipWithDefaultExpect suppliedTypes suppliedArgs
         extraNames = [ "__pp" ++ show i | i <- [0 .. missing - 1] ]
-        extraIdents = zipWith (\n ty -> coerceArg (GoIr.GoIdent n) ty)
+        extraIdents = zipWith (\n ty -> coerceArg Nothing (GoIr.GoIdent n) ty)
                               extraNames extraTypes
         finalCall = GoIr.GoCall (exprToGo func) (suppliedGo ++ extraIdents)
         -- Build the curried wrapper chain from the inside out.
@@ -10134,13 +10227,29 @@ tcoBodyStmts home fnName arity paramNames paramGoTys goRetType = lowerTail
             decls = zipWith
                 (\t a -> GoIr.GoShortDecl t (exprToGo a))
                 tmps args
-            coerceForTco ge ty
+            -- v0.15.x hardening / Gap A1 — pass the underlying
+            -- Can.Expr through to coerceArg so the structural-
+            -- fallback arm can recognise parametric-alias cross-
+            -- instantiation in tail-recursive jumps.  The Go-side
+            -- `__tco_t<i>` identifier hides the source's HM type
+            -- from `goExprGoType`, but `inferExprType` on the
+            -- original arg recovers it.
+            coerceForTco mSrc ge ty
                 | take 5 ty == "func(" = ge
-                | otherwise = coerceArg ge ty
-            assigns = zipWith3
-                (\p t ty ->
-                    GoIr.GoAssign p (coerceForTco (GoIr.GoIdent t) ty))
-                paramNames tmps (paramGoTys ++ repeat "any")
+                | otherwise = coerceArg mSrc ge ty
+            -- Build the (param, tmp, ty, src) tuple list and walk.
+            zip4tco (a:as) (b:bs) (c:cs) (d:ds) =
+                (a, b, c, d) : zip4tco as bs cs ds
+            zip4tco _ _ _ _ = []
+            quadrants =
+                zip4tco paramNames
+                        tmps
+                        (paramGoTys ++ repeat "any")
+                        (map Just args ++ repeat Nothing)
+            assigns =
+                [ GoIr.GoAssign p
+                    (coerceForTco src (GoIr.GoIdent t) ty)
+                | (p, t, ty, src) <- quadrants ]
         in decls ++ assigns ++ [GoIr.GoContinue]
 
     -- Lower an `Can.If` in tail position as a nested GoIf chain

--- a/test-files/v0.15-stress/src/Main.sky
+++ b/test-files/v0.15-stress/src/Main.sky
@@ -13,6 +13,7 @@ import Std.Log exposing (println)
 import Widget.Editor as Editor
 import Widget.Editor exposing (Cfg, Form)
 import Widget.Form as WForm
+import Widget.CrossInstanceCfg as XCfg
 import Inner.Polymorphic as Poly
 
 
@@ -406,6 +407,13 @@ main =
         r_lib = check "L1-L7" (if libInline > 0 then "rendered" else "empty") "rendered"
         r_lib_consumer = check "L1-L7-consumer" (if libConsumer > 0 then "rendered" else "empty") "rendered"
 
+        -- Gap A1 / Plan Item P1 — let-bound concrete alias passes
+        -- through a polymorphic forwarder, then is consumed by a
+        -- concretely-typed function.  Pre-fix, BOTH call sites
+        -- emitted `any(.).(Cfg_R[any])` casts that panicked with
+        -- `interface {} is Cfg_R[int], not Cfg_R[interface {}]`.
+        r_xcfg = check "XCfg" (String.fromInt (XCfg.roundTripInt 42)) "42"
+
         results =
             [ r_s1a, r_s1b, r_s2, r_s4
             , r_s6a, r_s6b, r_s6c
@@ -416,6 +424,7 @@ main =
             , r_s13a, r_s13b, r_s14, r_s14b, r_s14c
             , r_lib
             , r_lib_consumer
+            , r_xcfg
             ]
 
         report = case Result.combine results of

--- a/test-files/v0.15-stress/src/Widget/CrossInstanceCfg.sky
+++ b/test-files/v0.15-stress/src/Widget/CrossInstanceCfg.sky
@@ -1,0 +1,80 @@
+-- ═══════════════════════════════════════════════════════════
+-- Widget.CrossInstanceCfg — Gap A1 / Plan Item P1 regression.
+--
+-- The fragility audit (docs/fragility-audit-v0.15.3.md item #3)
+-- flagged `coerceArg`'s parametric-alias short-circuit as a
+-- backward-gated branch.  The arm gates on
+--   Just srcTy <- goExprGoType e
+-- but for expression shapes whose Go-static type isn't tracked
+-- in the lambda-types registry (let-bindings cross polymorphic
+-- call result, VarLocal references to outer-scope bindings, …)
+-- `goExprGoType` returns Nothing and the short-circuit doesn't
+-- fire.  Codegen falls through to `any(arg).(Foo_R[any])`, a
+-- nominal type assertion that panics at runtime when the
+-- source's actual instantiation is `Foo_R[int]` / `Foo_R[Msg]`.
+--
+-- The structural-fallback arm closes this by inspecting the
+-- source `Can.Expr` directly: when `inferExprType` resolves it
+-- to a `T.TAlias _ aliasName _` whose `aliasName ++ "_R"`
+-- matches the target's parametric base, the arg flows raw.
+-- Go's call-site type inference then pins the callee's T from
+-- the source's local static type — no nominal cast, no
+-- reflect-adapter wrap.
+--
+-- Reproducer pattern:
+--   1. Let-bind a concrete-instantiation alias value (`cfg0`).
+--   2. Pass it to a polymorphic forwarder whose result type
+--      is the same alias parameterised on the same TVar.
+--   3. Bind the result (`cfg1`).
+--   4. Pass `cfg1` to a concretely-typed consumer.
+--
+-- Pre-fix codegen:
+--   cfg1 := forwardCfg(any(cfg0).(Cfg_R[any]))
+--   n    := consumeIntCfg(any(cfg1).(Cfg_R[int]))
+-- Both casts panic — different generic instantiations of the
+-- same struct are distinct nominal types under Go's rules.
+-- ═══════════════════════════════════════════════════════════
+module Widget.CrossInstanceCfg exposing (XCfg, forwardCfg, makeIntCfg, consumeIntCfg, roundTripInt)
+
+import Sky.Core.Prelude exposing (..)
+
+-- Distinct alias name (`XCfg`) avoids field-set collision with
+-- Widget.Editor.Cfg / Widget.Form.Setup.  The bug we're regression-
+-- testing is independent of the alias name — it's the parametric
+-- record-alias cross-instantiation pattern.
+type alias XCfg msg =
+    { xOnSubmit : msg
+    , xLabel : String
+    }
+
+
+-- Polymorphic identity-shaped passthrough.  Returns XCfg msg —
+-- HM types the result region as a polymorphic alias, so the
+-- caller's `Map.lookup` over the lambda-types registry yields
+-- Nothing for the call result expression.
+forwardCfg : XCfg msg -> XCfg msg
+forwardCfg cfg =
+    cfg
+
+
+-- Concrete builder; result is statically `XCfg_R[int]`.
+makeIntCfg : Int -> XCfg Int
+makeIntCfg x =
+    { xOnSubmit = x, xLabel = "i" }
+
+
+-- Concrete consumer; arg is statically `XCfg_R[int]`.
+consumeIntCfg : XCfg Int -> Int
+consumeIntCfg cfg =
+    cfg.xOnSubmit
+
+
+-- Round-trip: make → forward → consume.  Triggers two
+-- coerceArg call sites that pre-fix emitted nominal casts.
+roundTripInt : Int -> Int
+roundTripInt x =
+    let
+        cfg0 = makeIntCfg x
+        cfg1 = forwardCfg cfg0
+    in
+        consumeIntCfg cfg1

--- a/test/Sky/Build/CoerceArgParametricSpec.hs
+++ b/test/Sky/Build/CoerceArgParametricSpec.hs
@@ -1,0 +1,145 @@
+module Sky.Build.CoerceArgParametricSpec (spec) where
+
+-- v0.15.x hardening — Gap A1 / Plan Item P1 closure.
+--
+-- The fragility audit (docs/fragility-audit-v0.15.3.md item #3) flagged
+-- `coerceArg`'s parametric-alias short-circuit as a backward-gated
+-- branch.  The arm gates on `Just srcTy <- goExprGoType e`, but for
+-- expression shapes whose Go-static type isn't tracked in the
+-- lambda-types registry (let-bindings cross polymorphic-call result,
+-- VarLocal references to outer-scope bindings, …) `goExprGoType`
+-- returns Nothing and the arm doesn't fire.  Codegen falls through
+-- to `any(arg).(Foo_R[any])` — a nominal type assertion that panics
+-- at runtime when the source's actual Go-static type is a different
+-- generic instantiation (`Foo_R[int]`, `Foo_R[Msg]`, …).
+--
+-- Reproducer (mirrors test-files/v0.15-stress/src/Widget/CrossInstanceCfg.sky):
+--
+--   type alias Cfg msg = { onSubmit : msg, label : String }
+--   forwardCfg : Cfg msg -> Cfg msg
+--   forwardCfg cfg = cfg
+--   main =
+--     let cfg0 = { onSubmit = 42, label = "i" }
+--         cfg1 = forwardCfg cfg0
+--     in ...
+--
+-- Pre-fix codegen:
+--   cfg1 := forwardCfg(any(cfg0).(Cfg_R[any]))
+--   -- panic: interface {} is main.Cfg_R[int], not main.Cfg_R[interface {}]
+--
+-- Post-fix (structural-fallback arm):
+--   cfg1 := forwardCfg(cfg0)
+--   -- Go infers T1 = int from cfg0's static type; binary runs clean.
+--
+-- This spec asserts both:
+--   1. The emitted Go does NOT contain the panic-inducing
+--      `any(...).(Cfg_R[any])` pattern.
+--   2. The binary runs to completion without panicking.
+
+import Test.Hspec
+import System.Directory (getCurrentDirectory, createDirectoryIfMissing,
+                         doesFileExist)
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import System.Process (readCreateProcessWithExitCode, proc, CreateProcess(..))
+import System.Exit (ExitCode(..))
+import Data.List (isInfixOf)
+
+
+findSky :: IO FilePath
+findSky = do
+    cwd <- getCurrentDirectory
+    let candidate = cwd </> "sky-out" </> "sky"
+    ok <- doesFileExist candidate
+    if ok then return candidate
+          else fail ("sky binary missing at " ++ candidate
+                  ++ " — run cabal install --installdir=./sky-out first")
+
+
+runSky :: FilePath -> [String] -> FilePath -> IO (ExitCode, String, String)
+runSky sky args workDir = do
+    let cp = (proc sky args) { cwd = Just workDir }
+    readCreateProcessWithExitCode cp ""
+
+
+writeFixtureProject :: FilePath -> String -> String -> IO ()
+writeFixtureProject dir name body = do
+    createDirectoryIfMissing True (dir </> "src")
+    writeFile (dir </> "sky.toml")
+        ("name = \"" ++ name ++ "\"\nversion = \"0.0.0\"\nentry = \"src/Main.sky\"\n\n[source]\nroot = \"src\"\n")
+    writeFile (dir </> "src" </> "Main.sky") body
+
+
+reproducerSource :: String
+reproducerSource = unlines
+    [ "module Main exposing (main)"
+    , ""
+    , "import Sky.Core.Prelude exposing (..)"
+    , "import Std.Log exposing (println)"
+    , ""
+    , "type alias Cfg msg ="
+    , "    { onSubmit : msg"
+    , "    , label : String"
+    , "    }"
+    , ""
+    , "-- Polymorphic identity-shaped passthrough."
+    , "forwardCfg : Cfg msg -> Cfg msg"
+    , "forwardCfg cfg ="
+    , "    cfg"
+    , ""
+    , "makeIntCfg : Int -> Cfg Int"
+    , "makeIntCfg x ="
+    , "    { onSubmit = x, label = \"i\" }"
+    , ""
+    , "consumeIntCfg : Cfg Int -> Int"
+    , "consumeIntCfg cfg ="
+    , "    cfg.onSubmit"
+    , ""
+    , "main ="
+    , "    let"
+    , "        cfg0 = makeIntCfg 42"
+    , "        cfg1 = forwardCfg cfg0"
+    , "        n = consumeIntCfg cfg1"
+    , "    in"
+    , "    println (String.fromInt n)"
+    ]
+
+
+spec :: Spec
+spec = do
+    describe "coerceArg structural fallback for parametric-alias cross-instantiation" $ do
+        it "emits no `any(...).(Cfg_R[any])` nominal assertion" $ do
+            sky <- findSky
+            withSystemTempDirectory "sky-coerce-arg-param" $ \tmp -> do
+                writeFixtureProject tmp "coerce-arg-param" reproducerSource
+                (ec, out, err) <- runSky sky ["build", "src/Main.sky"] tmp
+                let combined = out ++ err
+                ec `shouldBe` ExitSuccess
+                ("Build complete" `isInfixOf` combined) `shouldBe` True
+                let mainGo = tmp </> "sky-out" </> "main.go"
+                generated <- readFile mainGo
+                -- Pre-fix codegen emitted `any(cfg0).(Cfg_R[any])` at
+                -- the call site, which panics at runtime under Go's
+                -- nominal generic-type rules.  The structural fallback
+                -- closes this — the arg flows raw.
+                (".(Cfg_R[any])" `isInfixOf` generated) `shouldBe` False
+                -- Defensive: also forbid `rt.Coerce[Cfg_R[any]]` —
+                -- another shape the legacy wrap path could emit when
+                -- the target slot's TVars were erased.
+                ("rt.Coerce[Cfg_R[any]]" `isInfixOf` generated) `shouldBe` False
+
+        it "runs to completion without panicking" $ do
+            sky <- findSky
+            withSystemTempDirectory "sky-coerce-arg-param-run" $ \tmp -> do
+                writeFixtureProject tmp "coerce-arg-param-run" reproducerSource
+                (bec, bout, berr) <- runSky sky ["build", "src/Main.sky"] tmp
+                let bcombined = bout ++ berr
+                bec `shouldBe` ExitSuccess
+                ("Build complete" `isInfixOf` bcombined) `shouldBe` True
+                let appPath = tmp </> "sky-out" </> "app"
+                (rec, rout, rerr) <- readCreateProcessWithExitCode
+                    (proc appPath []) ""
+                let rcombined = rout ++ rerr
+                rec `shouldBe` ExitSuccess
+                ("42" `isInfixOf` rout) `shouldBe` True
+                ("panic" `isInfixOf` rcombined) `shouldBe` False

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -44,6 +44,7 @@ import qualified Sky.Build.CheckIsBuildSpec
 import qualified Sky.Build.RecordFieldOrderSpec
 import qualified Sky.Build.RecordCtorEmptyListSpec
 import qualified Sky.Build.HofTypedMsgSpec
+import qualified Sky.Build.CoerceArgParametricSpec
 import qualified Sky.Build.AnonLambdaSpec
 import qualified Sky.Build.AnonRecordSpec
 import qualified Sky.Build.Issue52Spec
@@ -256,6 +257,17 @@ main = hspec $ do
     -- the inner-function return as `any`, breaking helpers with typed
     -- (String -> Msg) callbacks. Now routes via typeStrWithAliasesReg.
     describe "Sky.Build.HofTypedMsg"        Sky.Build.HofTypedMsgSpec.spec
+    -- v0.15.x hardening / Gap A1 / Plan Item P1 — coerceArg's
+    -- parametric-alias short-circuit was gated on `goExprGoType e`
+    -- returning Just. For let-bound polymorphic-call results the
+    -- registry has no entry; the arm didn't fire; codegen emitted
+    -- `any(arg).(Cfg_R[any])`, panicking with `interface {} is
+    -- main.Cfg_R[int], not main.Cfg_R[interface {}]`. The
+    -- structural-fallback arm closes this by resolving the
+    -- source's `Can.Expr` through `inferExprType` and matching
+    -- alias bases.
+    describe "Sky.Build.CoerceArgParametric"
+                                            Sky.Build.CoerceArgParametricSpec.spec
     -- v0.13 D-Lambda-Lowerer regression: Sky lambdas at user-
     -- defined HOF slots lower to typed `func(X) Y` shapes via
     -- curryLambdaPatTyped (was only kernel HOFs pre-v0.13).


### PR DESCRIPTION
## Closes

- Audit Gap A1 (coerceArg parametric-alias short-circuit gated on `Just srcTy <- goExprGoType e`).
- `docs/fragility-audit-v0.15.3.md` item #3 (the same gap, phrased differently).

## Architectural diagnosis

`coerceArg`'s parametric-alias short-circuit at `Compile.hs ~8499` (pre-fix) was gated on `Just srcTy <- goExprGoType e`. For expression shapes whose Go-static type isn't tracked in the lambda-types registry — let-bindings holding a polymorphic-call result, `VarLocal` references to outer-scope bindings, field selectors over records whose Go-static type isn't tracked — `goExprGoType` returns `Nothing` and the arm doesn't fire. Codegen falls through to the wrap path, which emits `any(arg).(Foo_R[any])` — a nominal type assertion across Go generic instantiations. When the source's actual runtime type is `Foo_R[int]` / `Foo_R[Msg]`, the assertion panics at runtime with `interface conversion: Foo_R[int], not Foo_R[interface {}]`.

The lambda-types registry doesn't cover three shapes that exercise this bug:

1. Let-bindings whose RHS is a polymorphic-call result (`let cfg1 = forwardCfg cfg0`). `letBindingType`'s `canRouteTyped` gate rejects `Can.Call` body shapes, so the binding's type never gets registered.
2. `VarLocal` references that pre-date the current scope's `withScopedLambdaTypes` push.
3. Field selectors whose underlying record's Go-static type isn't tracked.

For all three the HM solver still has the type — the structural-fallback arm reads it via `inferExprType` against `Solve.SolvedTypes`, recognises `T.TAlias _ aliasName _ _`, and short-circuits when the alias's emitted struct name (`aliasName ++ "_R"`) matches the target's parametric base.

## Sequenced steps

1. **Failing-test-first.** `test/Sky/Build/CoerceArgParametricSpec.hs` builds a project-style fixture (let-bound concrete alias through polymorphic forwarder), asserts both codegen-shape and runtime behaviour. Confirmed FAIL on the starting worktree.
2. **Stress fixture.** `test-files/v0.15-stress/src/Widget/CrossInstanceCfg.sky` mirrors the reproducer as an importable dep module; `Main.sky`'s `r_xcfg` assertion drives `XCfg.roundTripInt 42`.
3. **Signature extension.** `coerceArg :: Maybe Can.Expr -> GoIr.GoExpr -> String -> GoIr.GoExpr`. All 8 call sites updated:
   - `coerceCallArgsAt`'s `coerceOne` + `coerceFallback` — `Just e`.
   - `kernelCoerceArg` — `Just e`.
   - `lowerArgExpect` — `Just e`.
   - over-application `extraIdents` (two zipWith sites) — `Nothing`.
   - `tcoJump` — threads the original `Can.Expr` per position via a small `zip4tco` helper so tail-recursive call sites benefit too.
4. **Structural-fallback arm.** New `coerceArg` clause:
   ```haskell
   | Just targetBase <- parametricAliasBase ty
   , Just src <- mSrc
   , Just aliasName <- aliasBaseFromCanExpr src
   , aliasName ++ "_R" == targetBase
       = e
   ```
5. **`aliasBaseFromCanExpr` helper.** Reads through `inferExprType` + the env's `_cg_recordAliases` set. Critically accepts BOTH the unqualified alias name (entry-module compile path) AND the module-prefixed name (dep-module path) — without this the dep-module path's `Widget_CrossInstanceCfg_XCfg` lookup misses (the alias name from `inferExprType` is the bare `XCfg`).
6. **Comment block updated.** `Compile.hs` ~8485 now describes both soundness paths: (a) the original lambda-types registry path, (b) the new structural fallback. References the new spec + the new stress fixture.

## New tests

- `test/Sky/Build/CoerceArgParametricSpec.hs` — 2 assertions per the failing-test-first contract.
- `test-files/v0.15-stress/src/Widget/CrossInstanceCfg.sky` — dep-module reproducer.
- `r_xcfg` assertion appended to `test-files/v0.15-stress/src/Main.sky` (`ALL 24 PASS` post-fix, was `ALL 23 PASS` pre-this-change).

## Verification

### `cabal test` (new spec)

```
Sky.Build.CoerceArgParametric
  coerceArg structural fallback for parametric-alias cross-instantiation
    emits no `any(...).(Cfg_R[any])` nominal assertion [✔]
    runs to completion without panicking [✔]

Finished in 4.7538 seconds
2 examples, 0 failures
```

### `cabal test` (full sweep, `SKY_SKIP_SWEEP=1` to defer the example-sweep wrapper which `scripts/verify-*` already covers)

```
312 examples, 0 failures, 1 pending
```

The Lsp suite separately: `40 examples, 0 failures`. `EmbeddedRuntime` has 1 pre-existing failure unrelated to this work (tree-mismatch on `runtime-go/rt/*.go` enumeration; reproduces on `main` without the fix).

### Clean-build sweep — 29 example dirs (27 numbered + 2 fixtures)

```
00-standard-libs: Build complete
01-hello-world: Build complete
…
26-ui-showcase: Build complete
simple: Build complete
test_pkg: Build complete
===FAILED===
(empty)
```

### `scripts/verify-cli.sh`

```
✓ 01-hello-world (output matched 'Hello')
…
✓ 24-tui-kitchen-sink (no panic)
⊘ 11-fyne-stopwatch — GUI app, skipped (needs X11)
VERIFY: 13 pass / 0 fail / 1 skip
```

### `scripts/verify-all-web.sh`

```
✓ 05-mux-server (port 8000, mux-routes)
…
✓ 19-skyforum (port 8019, skyforum)
VERIFY: 10 pass / 0 fail (out of 10)
PASS console-e2e — all 4 assertion groups green
✓ console-e2e
```

### `sky check` on examples/12-skyvote

```
-- Discovering modules
   Found 36 module(s)
-- Incremental: source unchanged, reusing cached output
Running go build...
No errors found.
```

### Codegen comparison

Reproducer Sky source generates the following entry-module Go.

Pre-fix:
```go
cfg1 := forwardCfg(any(cfg0).(Cfg_R[any]))
n    := consumeIntCfg(any(cfg1).(Cfg_R[int]))
// PANIC: interface {} is main.Cfg_R[int], not main.Cfg_R[interface {}]
```

Post-fix:
```go
cfg1 := forwardCfg(cfg0)
n    := consumeIntCfg(cfg1)
// runs clean, prints 42
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
