### PR TITLE
fix(live): TTL accepts Go-duration strings + sky.toml ttl key honoured

### DIFF
--- a/runtime-go/rt/live.go
+++ b/runtime-go/rt/live.go
@@ -1618,12 +1618,22 @@ func liveAppRun(cfg any) any {
 	// fallback is memory.
 	storeKind := stringField(cfg, "Store")
 	storePath := stringField(cfg, "StorePath")
-	ttl := 30 * time.Minute
-	if v := skyGetenv("LIVE_TTL"); v != "" {
-		if secs, err := strconv.Atoi(v); err == nil && secs > 0 {
-			ttl = time.Duration(secs) * time.Second
-		}
-	}
+	// TTL resolution order:  env > sky.toml > default (30m).
+	// Two value shapes accepted at BOTH layers, per CLAUDE.md
+	// docs ("30m" default form):
+	//
+	//   1. Go-duration string — "30m", "24h", "1h30m", "45s"
+	//      (anything time.ParseDuration handles, the documented
+	//      shape).
+	//   2. Bare integer — interpreted as SECONDS for backward-
+	//      compatibility with the original env-only path.
+	//
+	// Empty / unparseable values fall through to the next layer;
+	// the final fallback is 30m.  The previous implementation only
+	// read the env var AND only accepted bare-integer seconds, so
+	// `SKY_LIVE_TTL=24h` and any `ttl = "24h"` in sky.toml were
+	// both silently ignored.
+	ttl := parseTTL(skyGetenv("LIVE_TTL"), stringField(cfg, "Ttl"), 30*time.Minute)
 	app.store = chooseStore(storeKind, storePath, ttl)
 	app.sessionTTL = ttl
 

--- a/runtime-go/rt/live_store.go
+++ b/runtime-go/rt/live_store.go
@@ -13,7 +13,7 @@
 //   storePath = "sessions.db"                    (sqlite)
 //            = "postgres://user:pass@host/db"    (postgres)
 //            = "redis://:password@host:6379/0"   (redis; or bare "host:6379")
-//   ttl       = 1800                             (seconds; default 30m)
+//   ttl       = "30m"                            (Go duration or bare-int seconds; default 30m)
 
 package rt
 
@@ -29,6 +29,7 @@ import (
 	"log"
 	"os"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -209,6 +210,39 @@ func stringField(cfg any, name string) string {
 		return s
 	}
 	return fmt.Sprintf("%v", v)
+}
+
+
+// parseTTL — resolve a TTL value from env > sky.toml > default in
+// precedence order. Each layer accepts EITHER a Go-duration string
+// ("30m", "24h", "1h30m") OR a bare integer interpreted as seconds.
+// Empty or unparseable values fall through to the next layer.
+//
+// History: the pre-fix implementation read only the env var AND
+// accepted only bare-integer seconds via strconv.Atoi.  So both
+// `SKY_LIVE_TTL=24h` AND any `ttl = "24h"` in sky.toml's [live]
+// section silently fell back to the 30-minute default — at odds
+// with the documented `30m`-style default in CLAUDE.md.  This
+// helper makes the documented shape the canonical one while
+// preserving bare-integer-seconds for backward compatibility.
+func parseTTL(envVal, tomlVal string, def time.Duration) time.Duration {
+	for _, raw := range []string{envVal, tomlVal} {
+		s := strings.TrimSpace(raw)
+		if s == "" {
+			continue
+		}
+		// Duration-string form first (more specific — "24h" parses
+		// as duration, NOT as the integer 24).
+		if d, err := time.ParseDuration(s); err == nil && d > 0 {
+			return d
+		}
+		// Bare-integer fallback — interpreted as seconds.
+		if secs, err := strconv.Atoi(s); err == nil && secs > 0 {
+			return time.Duration(secs) * time.Second
+		}
+		// Unparseable at this layer — fall through to the next.
+	}
+	return def
 }
 
 

--- a/runtime-go/rt/live_ttl_parse_test.go
+++ b/runtime-go/rt/live_ttl_parse_test.go
@@ -1,0 +1,66 @@
+package rt
+
+import (
+	"testing"
+	"time"
+)
+
+// TestParseTTL — locks the env > sky.toml > default precedence AND
+// the dual-shape acceptance (Go-duration string OR bare-int seconds)
+// at each layer.
+//
+// Pre-fix bug: TTL was only read from `SKY_LIVE_TTL` env via
+// strconv.Atoi, so `SKY_LIVE_TTL=24h` and any sky.toml `ttl = "24h"`
+// silently fell back to the 30-minute default. The sky.toml `ttl`
+// key was completely unread. CLAUDE.md documents `30m` as the
+// default form, so duration strings MUST work at both layers.
+func TestParseTTL(t *testing.T) {
+	def := 30 * time.Minute
+	cases := []struct {
+		name     string
+		env      string
+		toml     string
+		expected time.Duration
+	}{
+		// ── env wins over toml ─────────────────────────────────
+		{"env-duration-wins-over-toml", "24h", "5m", 24 * time.Hour},
+		{"env-int-seconds-wins-over-toml", "60", "5m", 60 * time.Second},
+
+		// ── env duration string accepted ───────────────────────
+		{"env-30m", "30m", "", 30 * time.Minute},
+		{"env-24h", "24h", "", 24 * time.Hour},
+		{"env-1h30m", "1h30m", "", 90 * time.Minute},
+		{"env-45s", "45s", "", 45 * time.Second},
+
+		// ── env bare-int seconds accepted (backward compat) ────
+		{"env-1800-seconds", "1800", "", 30 * time.Minute},
+		{"env-86400-seconds", "86400", "", 24 * time.Hour},
+
+		// ── toml fallback when env unset ───────────────────────
+		{"toml-duration-30m", "", "30m", 30 * time.Minute},
+		{"toml-duration-24h", "", "24h", 24 * time.Hour},
+		{"toml-int-1800", "", "1800", 30 * time.Minute},
+
+		// ── empty + whitespace → default ───────────────────────
+		{"both-empty", "", "", def},
+		{"both-whitespace", "  ", " \t ", def},
+
+		// ── unparseable at one layer falls through to next ─────
+		{"env-garbage-toml-good", "abc", "10m", 10 * time.Minute},
+		{"env-good-toml-garbage", "10m", "abc", 10 * time.Minute},
+		{"both-garbage", "abc", "xyz", def},
+
+		// ── zero / negative rejected at each layer, fall through ─
+		{"env-zero-toml-good", "0", "5m", 5 * time.Minute},
+		{"env-negative-toml-good", "-1", "5m", 5 * time.Minute},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := parseTTL(c.env, c.toml, def)
+			if got != c.expected {
+				t.Errorf("parseTTL(%q, %q, %v) = %v; want %v",
+					c.env, c.toml, def, got, c.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## The bug

User report: `SKY_LIVE_TTL=24h` (or `ttl = "24h"` in sky.toml's `[live]` section) silently falls back to the 30-minute default — looked like "TTL accepted seconds only" but was actually rejecting duration strings entirely.

## Root cause

`runtime-go/rt/live.go:1623` did:
```go
ttl := 30 * time.Minute
if v := skyGetenv("LIVE_TTL"); v != "" {
    if secs, err := strconv.Atoi(v); err == nil && secs > 0 {
        ttl = time.Duration(secs) * time.Second
    }
}
```

Two issues:

1. **`strconv.Atoi("24h")` returns an error**, the if-arm is skipped, and `ttl` remains the 30-minute default. CLAUDE.md documents `30m` as the default form, so duration strings MUST work.
2. **No read from `sky.toml`**. Only env var. The `ttl` field documented in CLAUDE.md (`SKY_LIVE_TTL | ttl | 30m`) was a dead reference.

## Fix

New `parseTTL(envVal, tomlVal, def)` helper in `live_store.go`:
- Resolves in env > toml > default precedence.
- Each layer accepts EITHER a Go-duration string ("30m", "24h", "1h30m") OR a bare integer interpreted as seconds (backward-compatibility).
- Empty / unparseable values fall through to next layer.

`live.go:1621` now does:
```go
ttl := parseTTL(skyGetenv("LIVE_TTL"), stringField(cfg, "Ttl"), 30*time.Minute)
```

## Regression fence

`runtime-go/rt/live_ttl_parse_test.go` — 18 cases locking precedence + dual-shape acceptance + fallback semantics. **18/18 PASS** locally including the specific `SKY_LIVE_TTL=24h` reported case.

| Test | Input | Result |
|---|---|---|
| env-24h | env="24h" | 24h ✓ (the original bug) |
| env-30m | env="30m" | 30m ✓ |
| toml-duration-24h | toml="24h" | 24h ✓ (toml key now honoured) |
| env-1800-seconds | env="1800" | 30m ✓ (backward compat) |
| env-zero-toml-good | env="0", toml="5m" | 5m ✓ (zero rejected, falls through) |

## No behavioural regression

- Bare-integer-seconds (`SKY_LIVE_TTL=1800`) still works as before.
- Default 30m unchanged.
- Order-preserving (env > toml > default).