### PR TITLE
fix(live): diff Events + Cmd.perform suppression — multi-shape keypress regression + idle flicker

### DIFF
--- a/runtime-go/rt/live.go
+++ b/runtime-go/rt/live.go
@@ -675,6 +675,68 @@ func diffNodes(old, new_ *VNode, clientState map[string]string, out *[]Patch) {
 			attrChanges[k] = ""
 		}
 	}
+	// Events diff — VNode.Events stores DOM event handlers separately
+	// from Attrs, but renderVNode emits them as `sky-<event>` /
+	// `data-sky-ev-<event>` attributes plus a `data-sky-hid` companion.
+	// Without diffing Events, an element that toggles handlers (a
+	// canvas-wrap gaining `Events.onKeyDown` when an edit overlay
+	// closes, a button losing its onClick when a permission changes)
+	// produces no patch for those attributes — the previous bound
+	// listeners stay attached but the runtime's per-event lookup via
+	// `target.getAttribute("sky-<event>")` returns null, so no Msg is
+	// dispatched and the user's keypress / click is silently dropped.
+	//
+	// Repro that surfaced this: sky-diagram's canvas-wrap conditionally
+	// includes `Events.onKeyDown (keyDown model)` only when
+	// `editingShapeId == Nothing`. After CommitText flips back to
+	// Nothing, the HTTP diff used to emit only a `p.html` patch on the
+	// canvas child div (overlay removed), never touching canvas-wrap's
+	// own attrs. Result: every subsequent keypress on canvas-wrap was a
+	// no-op. Pre-v0.15.13 the full-body SSE frame following Cmd
+	// completions accidentally re-rendered #sky-root and restored the
+	// attribute; v0.15.13's Tick suppression + v0.15.14's runPerform
+	// suppression both peeled away that safety net and exposed the
+	// genuine diff bug.
+	for ev, newMsg := range new_.Events {
+		attrName := "sky-" + ev
+		if strings.HasPrefix(ev, "sky-") {
+			attrName = "data-sky-ev-" + ev
+		}
+		newMsgName := msgDisplayName(newMsg)
+		if oldMsg, ok := old.Events[ev]; !ok || msgDisplayName(oldMsg) != newMsgName {
+			if attrChanges == nil {
+				attrChanges = map[string]string{}
+			}
+			attrChanges[attrName] = newMsgName
+			// data-sky-hid encodes the sky-id + event suffix the runtime
+			// expects when routing the user gesture back to its handler.
+			// Re-emit it on any event change so a stale hid (from a
+			// previous render that bound a different handler) can't
+			// outlive the new wiring.
+			attrChanges["data-sky-hid"] = new_.SkyID + "." + ev
+		}
+	}
+	for ev := range old.Events {
+		if _, ok := new_.Events[ev]; !ok {
+			attrName := "sky-" + ev
+			if strings.HasPrefix(ev, "sky-") {
+				attrName = "data-sky-ev-" + ev
+			}
+			if attrChanges == nil {
+				attrChanges = map[string]string{}
+			}
+			attrChanges[attrName] = ""
+			// If the element has lost ALL its events the data-sky-hid
+			// companion is now stale; clear it. When other events
+			// remain, the new_.Events loop above will have rewritten
+			// data-sky-hid to one of them already (last-write wins,
+			// matching renderVNode's HTML emission order over the
+			// sorted event keys).
+			if len(new_.Events) == 0 {
+				attrChanges["data-sky-hid"] = ""
+			}
+		}
+	}
 	if attrChanges != nil && old.SkyID != "" {
 		*out = append(*out, Patch{ID: old.SkyID, Attrs: attrChanges})
 	}
@@ -2643,9 +2705,10 @@ func (app *liveApp) runPerformBody(sess *liveSession, task any, toMsg any) {
 	// the same lock as dispatch means the seq reflects the actual
 	// mutation order even when other goroutines dispatch concurrently.
 	sess.mu.Lock()
+	prevBody := sess.prevBody
 	body := app.dispatch(sess, msg)
 	var frame string
-	if body != "" {
+	if body != "" && body != prevBody {
 		frame = encodeSSEFrame(sess, body)
 	}
 	sess.mu.Unlock()

--- a/runtime-go/rt/live_events_diff_test.go
+++ b/runtime-go/rt/live_events_diff_test.go
@@ -1,0 +1,147 @@
+package rt
+
+// v0.15.14 — diffNodes must diff VNode.Events alongside VNode.Attrs.
+//
+// VNode stores DOM event handlers in a separate Events map but
+// renderVNode emits them as `sky-<event>` + `data-sky-hid`
+// attributes in the produced HTML. The pre-fix diffNodes only
+// compared Attrs, which meant an element gaining or losing an
+// event handler (without any other attr change) produced no patch
+// for those rendered attributes. The previously-bound JS listener
+// stayed attached, but the runtime's per-event Msg lookup via
+// `target.getAttribute("sky-<event>")` returned null, so user
+// gestures were silently dropped.
+//
+// This file pins three properties:
+//
+//   1. New event added → diff emits `sky-<event>` and `data-sky-hid`.
+//   2. Event removed → diff emits `sky-<event>=""` (and clears
+//      `data-sky-hid` when no events remain).
+//   3. Event's Msg constructor changed (same key, different value)
+//      → diff emits an updated `sky-<event>` value.
+
+import (
+	"testing"
+)
+
+// findAttrPatch returns the first Patch in `patches` whose ID
+// matches `id` and which carries Attrs (no HTML, no Text).
+func findAttrPatch(patches []Patch, id string) *Patch {
+	for i := range patches {
+		if patches[i].ID == id && patches[i].Attrs != nil {
+			return &patches[i]
+		}
+	}
+	return nil
+}
+
+func TestDiffNodes_EventAdded_EmitsAttrPatch(t *testing.T) {
+	// Two VNodes with the same attrs but different events:
+	// old has no keydown handler; new has one.
+	old := VNode{
+		Kind:   "element",
+		Tag:    "div",
+		SkyID:  "r.0#div",
+		Attrs:  map[string]string{"class": "canvas-wrap"},
+		Events: map[string]any{},
+	}
+	new_ := VNode{
+		Kind:   "element",
+		Tag:    "div",
+		SkyID:  "r.0#div",
+		Attrs:  map[string]string{"class": "canvas-wrap"},
+		Events: map[string]any{"keydown": SkyADT{SkyName: "KeyDown"}},
+	}
+
+	patches := diffTrees(&old, &new_, nil)
+	p := findAttrPatch(patches, "r.0#div")
+	if p == nil {
+		t.Fatalf("expected attr patch on r.0#div, got: %+v", patches)
+	}
+	if p.Attrs["sky-keydown"] != "KeyDown" {
+		t.Fatalf("expected sky-keydown=KeyDown, got: %v", p.Attrs)
+	}
+	if p.Attrs["data-sky-hid"] != "r.0#div.keydown" {
+		t.Fatalf("expected data-sky-hid=r.0#div.keydown, got: %v", p.Attrs)
+	}
+}
+
+func TestDiffNodes_EventRemoved_EmitsClear(t *testing.T) {
+	old := VNode{
+		Kind:   "element",
+		Tag:    "div",
+		SkyID:  "r.0#div",
+		Attrs:  map[string]string{"class": "canvas-wrap"},
+		Events: map[string]any{"keydown": SkyADT{SkyName: "KeyDown"}},
+	}
+	new_ := VNode{
+		Kind:   "element",
+		Tag:    "div",
+		SkyID:  "r.0#div",
+		Attrs:  map[string]string{"class": "canvas-wrap"},
+		Events: map[string]any{},
+	}
+
+	patches := diffTrees(&old, &new_, nil)
+	p := findAttrPatch(patches, "r.0#div")
+	if p == nil {
+		t.Fatalf("expected attr patch on r.0#div, got: %+v", patches)
+	}
+	if v, ok := p.Attrs["sky-keydown"]; !ok || v != "" {
+		t.Fatalf("expected sky-keydown=\"\" (clear), got: %v", p.Attrs)
+	}
+	if v, ok := p.Attrs["data-sky-hid"]; !ok || v != "" {
+		t.Fatalf("expected data-sky-hid=\"\" (clear) when no events remain, got: %v", p.Attrs)
+	}
+}
+
+func TestDiffNodes_EventMsgChanged_EmitsUpdate(t *testing.T) {
+	old := VNode{
+		Kind:   "element",
+		Tag:    "button",
+		SkyID:  "r.0#button",
+		Attrs:  map[string]string{},
+		Events: map[string]any{"click": SkyADT{SkyName: "Save"}},
+	}
+	new_ := VNode{
+		Kind:   "element",
+		Tag:    "button",
+		SkyID:  "r.0#button",
+		Attrs:  map[string]string{},
+		Events: map[string]any{"click": SkyADT{SkyName: "Cancel"}},
+	}
+
+	patches := diffTrees(&old, &new_, nil)
+	p := findAttrPatch(patches, "r.0#button")
+	if p == nil {
+		t.Fatalf("expected attr patch on r.0#button, got: %+v", patches)
+	}
+	if p.Attrs["sky-click"] != "Cancel" {
+		t.Fatalf("expected sky-click=Cancel, got: %v", p.Attrs)
+	}
+	if p.Attrs["data-sky-hid"] != "r.0#button.click" {
+		t.Fatalf("expected data-sky-hid=r.0#button.click, got: %v", p.Attrs)
+	}
+}
+
+func TestDiffNodes_EventUnchanged_NoPatch(t *testing.T) {
+	old := VNode{
+		Kind:   "element",
+		Tag:    "button",
+		SkyID:  "r.0#button",
+		Attrs:  map[string]string{"class": "primary"},
+		Events: map[string]any{"click": SkyADT{SkyName: "Save"}},
+	}
+	new_ := VNode{
+		Kind:   "element",
+		Tag:    "button",
+		SkyID:  "r.0#button",
+		Attrs:  map[string]string{"class": "primary"},
+		Events: map[string]any{"click": SkyADT{SkyName: "Save"}},
+	}
+
+	patches := diffTrees(&old, &new_, nil)
+	if findAttrPatch(patches, "r.0#button") != nil {
+		t.Fatalf("expected no attr patch for unchanged events, got: %+v", patches)
+	}
+}


### PR DESCRIPTION
Two coupled Sky.Live fixes that together close today's sky-diagram regression report (multi-shape keypress after Enter) AND the idle-polling flicker the user disabled polling for.

## The root cause

`diffNodes` was only diffing `VNode.Attrs`, never `VNode.Events`. Events are stored separately on the VNode but render as `sky-<event>` / `data-sky-ev-<event>` HTML attributes plus a `data-sky-hid` companion. When a node toggled event handlers without other attr changes, the diff produced no patch, and the runtime's per-event Msg lookup via `target.getAttribute("sky-<event>")` returned null — gestures silently dropped.

**sky-diagram's exact path:** canvas-wrap conditions `Events.onKeyDown (keyDown model)` on `editingShapeId == Nothing`. After committing the first shape's label, the HTTP CommitText diff emitted only a `p.html` patch on the canvas child div (overlay removed), never touching canvas-wrap's attrs. `sky-keydown` stayed missing — subsequent keypresses no-op.

**Why v0.15.13 'worked' before today's investigation:** the redundant full-body SSE frame following Cmd.perform completions re-rendered `#sky-root` via `__skyPatch`'s innerHTML replacement, accidentally restoring the missing attr. v0.15.13's Tick suppression and v0.15.14's runPerformBody suppression both peeled away that accidental safety net and exposed the genuine diff bug.

## What this PR changes

1. **`diffNodes` Events diff** (the real fix). Iterates `new_.Events` and `old.Events`, emitting `sky-<event>` / `data-sky-ev-<event>` and `data-sky-hid` attr changes when handlers add/remove/change. Last-write-wins on `data-sky-hid` matches the existing `renderVNode` HTML emission order (sorted event keys).

2. **`runPerformBody` identical-view suppression** (the flicker fix). Now that the Events diff is correct, it's safe to suppress SSE frames whose dispatch produces a byte-identical body — capture prevBody before dispatch, compare after.

## Verification

- **Playwright probe (sky-diagram on :8765):**
  - **pre-fix:** `canvasHasSkyKeydown: false` after commit → second '1' press is a no-op → `shapeCount: 1`
  - **post-fix:** `canvasHasSkyKeydown: true, canvasSkyKeydownBound: true` → second '1' adds overlay → `shapeCount: 2`
- **Lock tests:**
  - `TestDiffNodes_EventAdded_EmitsAttrPatch`
  - `TestDiffNodes_EventRemoved_EmitsClear`
  - `TestDiffNodes_EventMsgChanged_EmitsUpdate`
  - `TestDiffNodes_EventUnchanged_NoPatch`
- **rt suite:** all tests pass except 2 pre-existing TestTime_* timezone flakes unrelated to this change.

## Relation to Cycle 3 audit

The Auditor agent independently identified this as part of **Gap C1** (`prevTree` split-brain). This PR is the patch-layer fix; Gap C11 (full SSE diff-then-patch transport overhaul) remains the larger architectural cleanup that subsumes both fixes here.

Target tag: **v0.15.14**

🤖 Generated with [Claude Code](https://claude.com/claude-code)