### PR TITLE
fix(live): preserve SVG/MathML namespace through __skyReplaceHTMLPreservingFocus

### DIFF
--- a/runtime-go/rt/live.go
+++ b/runtime-go/rt/live.go
@@ -3376,8 +3376,39 @@ function __skyReplaceHTMLPreservingFocus(container, newHTML) {
 
   // Parse the new HTML into a detached element so we can splice
   // preserved live nodes into it before committing.
-  var tmp = document.createElement("div");
-  tmp.innerHTML = newHTML;
+  //
+  // Namespace correctness: when the container element is in a foreign-
+  // content namespace (SVG or MathML), parsing the new HTML via a
+  // plain document.createElement("div") + .innerHTML = ... uses the
+  // HTML insertion mode, so element names like <g>, <rect>, <text>
+  // (which the diff emits as direct children when it replaces the
+  // children of an <svg> element) end up in the XHTML namespace
+  // rather than SVG. The elements appear in the DOM but the browser
+  // doesn't lay them out as SVG primitives — the canvas silently goes
+  // blank after a shape add/remove with no JS error to point at.
+  //
+  // Range.createContextualFragment parses HTML using the namespace
+  // context of the range's container, preserving SVG/MathML element
+  // namespaces correctly. The downstream code accepts either an
+  // Element or a DocumentFragment via the same .firstChild /
+  // .querySelectorAll / .parentNode.replaceChild surface, so no
+  // other changes are needed.
+  //
+  // Repro before this fix: any Sky.Live view that emits an HTML
+  // patch at a sky-id pointing at an <svg> element (the diff does
+  // this whenever the SVG's children-count changes, or a child
+  // tag/kind mismatches between renders) leaves the SVG with HTML-
+  // namespaced children. Drawing tools, charts, and apps that swap
+  // inline-SVG icon <path> children are the common victims.
+  var tmp;
+  if (container.namespaceURI && container.namespaceURI !== "http://www.w3.org/1999/xhtml") {
+    var range = document.createRange();
+    range.selectNodeContents(container);
+    tmp = range.createContextualFragment(newHTML);
+  } else {
+    tmp = document.createElement("div");
+    tmp.innerHTML = newHTML;
+  }
 
   // Snapshot focused-state BEFORE any DOM mutation. Selection read
   // throws on some input types, so catch.


### PR DESCRIPTION
Lands an offline-session diagnosis + patch after Playwright regression verification.

## The bug

`__skyReplaceHTMLPreservingFocus` parses new HTML by assigning to a synthetic `<div>`'s `.innerHTML`, which puts the HTML parser into the HTML insertion mode. When the container being patched is an `<svg>` element (because `diffNodes` emitted a `p.html` patch at an SVG sky-id — happens whenever the SVG's children-count changes or a child tag/kind mismatches between renders), the resulting elements land in the **XHTML namespace** instead of SVG.

Elements appear in the DOM tree but the browser doesn't lay them out as SVG primitives. The canvas silently goes blank with no JS error to point at.

## The fix

Use `Range.createContextualFragment(newHTML)`, which parses HTML in the namespace context of the range's container. The downstream code (`.firstChild`, `.querySelectorAll`, `.parentNode.replaceChild`) accepts the resulting `DocumentFragment` identically to the synthetic `<div>`. Pure namespace correctness fix; no semantic change for non-SVG containers (default branch keeps the old `<div>` + `.innerHTML` path).

## Verification

**Playwright probe** against sky-diagram with the v0.15.14 binary:

| Property | Pre-fix | Post-fix |
|---|---|---|
| SVG children in SVG namespace | 0/N | 7/7 ✓ |
| SVG children in XHTML namespace | N | 0 |
| `svgRendered` (bounding box > 0) | false | true ✓ |

**Combined-fix regression:** the v0.15.14 multi-shape add flow continues to pass (`second shape ADDED — multi-shape WORKS` from the keypress repro).

**rt unit tests:** all pass except 2 pre-existing TestTime_* timezone flakes unrelated to this change.

## Scope

Affects every Sky.Live app rendering inline SVG that swaps children via patches — drawing tools, charts, custom icon panels. The diff produces an HTML patch at an SVG sky-id whenever the SVG's structural shape changes between renders.

Target tag: **v0.15.16**

🤖 Generated with [Claude Code](https://claude.com/claude-code)