### PR TITLE
feat(solver): SolvedTypes carries region-types map as pure data (Cycle 3 P37a / v0.15.19)

### DIFF
--- a/sky-compiler.cabal
+++ b/sky-compiler.cabal
@@ -277,6 +277,7 @@ test-suite sky-tests
       Sky.Parse.MultiLineCaseSubjectSpec
       Sky.Parse.MultiLineSignatureSpec
       Sky.Type.InstanceCaptureSpec
+      Sky.Type.SolvedTypesRegionMapSpec
       Sky.Format.FormatSpec
       Sky.Build.GoKeywordCollisionSpec
       Sky.Build.NestedPatternSpec

--- a/src/Sky/Build/Compile.hs
+++ b/src/Sky/Build/Compile.hs
@@ -66,7 +66,7 @@ import qualified Debug.Trace
 -- | Global codegen environment (set once per compilation, read during codegen)
 {-# NOINLINE globalCgEnv #-}
 globalCgEnv :: IORef Rec.CodegenEnv
-globalCgEnv = unsafePerformIO $ newIORef (Rec.CodegenEnv Map.empty Map.empty Map.empty Set.empty Set.empty Set.empty Set.empty Map.empty Map.empty Map.empty Map.empty Map.empty Map.empty Map.empty)
+globalCgEnv = unsafePerformIO $ newIORef (Rec.CodegenEnv Solve.emptySolvedTypes Map.empty Map.empty Set.empty Set.empty Set.empty Set.empty Map.empty Map.empty Map.empty Map.empty Map.empty Map.empty Map.empty)
 
 
 -- | v0.13 A2 follow-up: dedicated, eagerly-populated union-name
@@ -952,7 +952,7 @@ continueCompile config entryPath outDir moduleOrder srcHash = do
                 r  <- Solve.solve cs
                 case r of
                     Solve.SolveOk t -> return (modName, t)
-                    Solve.SolveError _ -> return (modName, Map.empty)
+                    Solve.SolveError _ -> return (modName, Solve.emptySolvedTypes)
             -- Pass 2: re-solve each dep with cross-module externals
             -- from pass 1. Serialised (mapM not Async.forConcurrently)
             -- because the external-ref write is global — parallel
@@ -1046,7 +1046,13 @@ continueCompile config entryPath outDir moduleOrder srcHash = do
             let solveRound prevSolved = do
                     let externals =
                             filterToTopLevel
-                                (buildCrossModuleExternalsWithMods validDeps prevSolved)
+                                -- v0.15.x P37a: `prevSolved` carries
+                                -- the new `Solve.SolvedTypes` records;
+                                -- the externals helper still consumes
+                                -- the bare `Map.Map String T.Type`
+                                -- view, so extract `_stEnv` here.
+                                (buildCrossModuleExternalsWithMods validDeps
+                                    [(mn, Solve._stEnv s) | (mn, s) <- prevSolved])
                     -- v0.13 Phase A5: use `solveWithInstances` so per-call
                     -- instance capture flows through dep-module callsites
                     -- (used by monomorphisation).
@@ -1065,7 +1071,7 @@ continueCompile config entryPath outDir moduleOrder srcHash = do
                             Solve.SolveError err
                                 | isForeignErr err -> return (modName, Left err)
                                 | otherwise -> case lookup modName prevSolved of
-                                    Just p | not (Map.null p) ->
+                                    Just p | not (Map.null (Solve._stEnv p)) ->
                                         return (modName, Right (p, csi, regionTys, Just err))
                                     _ -> return (modName, Left err)) validDeps
                 depTypesOf results =
@@ -1082,7 +1088,12 @@ continueCompile config entryPath outDir moduleOrder srcHash = do
                          ++ [ (mn, e)
                             | (mn, Right (_, _, _, Just e)) <- finalResults
                             ]
-                depSolved = [(mn, t) | (mn, Right (t, _, _, _)) <- finalResults]
+                -- v0.15.x P37a: `t` is the new `Solve.SolvedTypes`
+                -- record; helpers downstream (`buildAnnotMap`,
+                -- `buildCrossModuleExternalsWithMods`) take the raw
+                -- `Map.Map String T.Type` view.  Extract `_stEnv`
+                -- here so the existing helper signatures stay put.
+                depSolved = [(mn, Solve._stEnv t) | (mn, Right (t, _, _, _)) <- finalResults]
                 depCsiByMod = [(mn, csi) | (mn, Right (_, csi, _, _)) <- finalResults]
                 -- v0.15 Stage A/B: merge per-region types from every
                 -- dep into one map.  Entry-module region types added
@@ -1193,7 +1204,7 @@ continueCompile config entryPath outDir moduleOrder srcHash = do
                     _                  -> Nothing
             types <- case solveResult of
                 Solve.SolveOk t -> do
-                    putStrLn $ "   Types OK (" ++ show (length (Map.keys t)) ++ " bindings)"
+                    putStrLn $ "   Types OK (" ++ show (length (Map.keys (Solve._stEnv t))) ++ " bindings)"
                     -- v0.13 Phase A3: log the captured instance table.
                     -- Format: "<N> instances across <M> functions".
                     -- Set SKY_MONO_TRACE=1 to dump every instance.
@@ -1214,7 +1225,7 @@ continueCompile config entryPath outDir moduleOrder srcHash = do
                     -- generateGoMulti to consume when emitting
                     -- per-instance specialisations.
                     let defMap = buildDefMap canMod validDeps
-                        annotMap = buildAnnotMap t depSolved
+                        annotMap = buildAnnotMap (Solve._stEnv t) depSolved
                         csiMapForReach = Map.fromList
                             [ ( ( A._line (A._start (Solve._cs_region csi))
                                 , A._col  (A._start (Solve._cs_region csi)) )
@@ -1329,7 +1340,7 @@ continueCompile config entryPath outDir moduleOrder srcHash = do
                             let diag = Solve.solveErrorToDiagnostic entryPath err
                             rendered <- Render.renderCli diag
                             putStrLn rendered
-                    return Map.empty
+                    return Solve.emptySolvedTypes
             -- P3: exhaustiveness — walk the entry + every dep's canonical
             -- tree for non-exhaustive case expressions. A miss is a
             -- compile-time error with source context; the `panic("non-
@@ -1543,8 +1554,16 @@ continueCompile config entryPath outDir moduleOrder srcHash = do
                     -- Conflict-detection merge with TVar normalisation.
                     -- See typesWithDepsBuilder below for the algorithm.
                     typesWithDeps =
-                        let entryKeys = Map.keysSet types
-                            allMaps = types : [t | (_, t) <- depSolved]
+                        -- v0.15.x P37a: `types` is now the new
+                        -- `Solve.SolvedTypes` record.  The merge logic
+                        -- below works over the `_stEnv` Map view;
+                        -- after merging, we re-wrap with the
+                        -- `mergedRegionTys` region map computed
+                        -- earlier so `generateGoMulti` continues to
+                        -- receive a full `Solve.SolvedTypes` value.
+                        let typesEnv = Solve._stEnv types
+                            entryKeys = Map.keysSet typesEnv
+                            allMaps = typesEnv : [t | (_, t) <- depSolved]
                             keyToTypes = Map.unionsWith (++)
                                 [ Map.map (:[]) m | m <- allMaps ]
                             isResolved (T.TVar _) = False
@@ -1570,7 +1589,7 @@ continueCompile config entryPath outDir moduleOrder srcHash = do
                             -- pipeline (treat as cross-scope conflict).
                             resolveKey k tys
                                 | k `Set.member` entryKeys =
-                                    let entryTy = Map.findWithDefault (T.TVar "_unbound") k types
+                                    let entryTy = Map.findWithDefault (T.TVar "_unbound") k typesEnv
                                         depTys  = [ t | (_, m) <- depSolved
                                                       , Just t <- [Map.lookup k m]
                                                       , isResolved t ]
@@ -1592,7 +1611,8 @@ continueCompile config entryPath outDir moduleOrder srcHash = do
                                                  (t:_) -> t
                                                  []    -> T.TVar "_unresolved"
                                         _   -> T.TVar "_ambig"
-                        in Map.mapWithKey resolveKey keyToTypes
+                            mergedEnv = Map.mapWithKey resolveKey keyToTypes
+                        in Solve.SolvedTypes mergedEnv mergedRegionTys
                     goCodeRaw = generateGoMulti canMod entrySrcMod config typesWithDeps depDecls depRecAliases depUnionNames depEnumNames depArities depParamTypes depRetTypes depUltRetTypes depInferredParams depInferredRets depInferredSigs depAliasPairs
                     -- v0.13 Layer 2: collect Sky-name → source-region
                     -- for every top-level declaration so the post-emit
@@ -1617,9 +1637,14 @@ continueCompile config entryPath outDir moduleOrder srcHash = do
                     authDiagsDeps =
                         [ d
                         | (modName, depMod) <- validDeps
+                        -- v0.15.x P37a: `depSolved` was extracted via
+                        -- `Solve._stEnv` at the assembly site; wrap
+                        -- back into a `SolvedTypes` record for the
+                        -- auth-boundary helper (region map empty —
+                        -- the gate only consults the env).
                         , let depTypesMap = case lookup modName depSolved of
-                                Just ts -> ts
-                                Nothing -> Map.empty
+                                Just ts -> Solve.SolvedTypes ts Map.empty
+                                Nothing -> Solve.emptySolvedTypes
                         , d <- authBoundaryDiagnostics entryPath depTypesMap depMod
                         ]
                     authDiags = authDiagsEntry ++ authDiagsDeps
@@ -1713,13 +1738,14 @@ parseSingle config entryPath outDir = do
                     solveResult <- Solve.solve constraints
                     let solvedTypes = case solveResult of
                             Solve.SolveOk types -> do
-                                putStrLn $ "   Types OK (" ++ show (length (Map.keys types)) ++ " bindings)"
-                                mapM_ (\(n, t) -> putStrLn $ "     " ++ n ++ " : " ++ Solve.showType t) (Map.toList types)
+                                let envMap = Solve._stEnv types
+                                putStrLn $ "   Types OK (" ++ show (length (Map.keys envMap)) ++ " bindings)"
+                                mapM_ (\(n, t) -> putStrLn $ "     " ++ n ++ " : " ++ Solve.showType t) (Map.toList envMap)
                                 return types
                             Solve.SolveError err -> do
                                 putStrLn $ "   TYPE WARNING: " ++ err
                                 -- Still return empty types — codegen falls back to any
-                                return Map.empty
+                                return Solve.emptySolvedTypes
                     types <- solvedTypes
 
                     -- Phase 5: Generate Go (using solved types)
@@ -2521,8 +2547,11 @@ typecheckWorkspace config entryPath = do
             Right canMod -> do
                 cs <- Constrain.constrainModule canMod
                 (r, localTys) <- Solve.solveWithLocals cs
+                -- v0.15.x P37a: `SolvedTypes` is now a record; extract
+                -- the bare env map for the `_wm_types` field (which
+                -- carries the pre-P37a shape `Map.Map String T.Type`).
                 let envTypes = case r of
-                        Solve.SolveOk t -> t
+                        Solve.SolveOk t -> Solve._stEnv t
                         _               -> Map.empty
                     -- Match Solve.solve's merge: take the innermost
                     -- (first) type from each local, merge under
@@ -3154,14 +3183,18 @@ generateGoMulti canMod srcMod config solvedTypes depDecls depRecAliases depUnion
             -- (e.g. `init : a -> …` where the body narrows `a` to a
             -- concrete Dict — call sites would omit the `[any]`
             -- instantiation that the declaration still needs).
-            let sigTypeFor n =
+            -- v0.15.x P37a: `solvedTypes` is the new `SolvedTypes`
+            -- record; the lookup / iteration here works against the
+            -- env-map projection.  Extract once for readability.
+            let solvedEnv = Solve._stEnv solvedTypes
+                sigTypeFor n =
                     case Map.lookup n (declsByName canMod) of
                         Just (Can.TypedDef _ _ typedPats _ retTy) ->
                             Just (foldr T.TLambda retTy (map snd typedPats))
-                        _ -> Map.lookup n solvedTypes
+                        _ -> Map.lookup n solvedEnv
                 entryInferredSigs = Map.fromList
                     [ (goSafeName n, splitInferredSigWithReg earlyRecAliases earlyFieldIdx (countParamsFor n canMod) ty)
-                    | (n, _) <- Map.toList solvedTypes
+                    | (n, _) <- Map.toList solvedEnv
                     , Just ty <- [sigTypeFor n]
                     ]
                 entryInferredParams = Map.map (\(_, ps, _) -> ps) entryInferredSigs
@@ -3185,7 +3218,7 @@ generateGoMulti canMod srcMod config solvedTypes depDecls depRecAliases depUnion
                             earlyRecAliases earlyFieldIdx
                             (countParamsFor n canMod)
                             (renameTypeForExternal' ty) )
-                    | (n, _) <- Map.toList solvedTypes
+                    | (n, _) <- Map.toList solvedEnv
                     , Just ty <- [sigTypeFor n]
                     ]
             -- Gather the FULL record-alias set (entry + dep modules,
@@ -3851,7 +3884,9 @@ generateDef home def solvedTypes =
         -- Prefer the user's annotation when present, else use HM-
         -- inferred type. TVars in the inferred type become Go type
         -- params (T4b) via splitInferredSig.
-        mSolvedType = Map.lookup name solvedTypes
+        -- v0.15.x P37a: `SolvedTypes` is a record; consult the env
+        -- field for the name lookup.
+        mSolvedType = Solve.lookupSolvedVar name solvedTypes
         mAnnotTy = case def of
             Can.TypedDef _ _ _ _ ty -> Just ty
             _                       -> Nothing
@@ -4401,7 +4436,7 @@ goExprGoType mSrc e = case shapeClassified of
         go seen t = case t of
             T.TVar name
                 | Set.member name seen -> True
-                | otherwise -> case Map.lookup name solved of
+                | otherwise -> case Solve.lookupSolvedVar name solved of
                     Just t' | t' /= t -> go (Set.insert name seen) t'
                     _                 -> True
             T.TType _ _ args         -> any (go seen) args
@@ -10043,7 +10078,7 @@ letToGo mExpectedGo def body =
             Can.Def (A.At _ name) pats _
                 | not (null pats)
                 , name /= "_"
-                , Just t <- Map.lookup name solved
+                , Just t <- Solve.lookupSolvedVar name solved
                 , case t of { T.TLambda _ _ -> True; _ -> False } ->
                     Map.singleton name t
             _ -> Map.empty
@@ -10370,7 +10405,7 @@ defToStmts def = case def of
         -- adapters (e.g. 18-job-queue's `insertRow db ts = …`
         -- inside saveSnapshot).
         let solved = Rec._cg_solvedTypes getCgEnv
-            inferredTy = Map.lookup name solved
+            inferredTy = Solve.lookupSolvedVar name solved
             (paramTys, retTy) = case inferredTy of
                 Just ty -> splitTLambda (length params) ty
                 Nothing -> (replicate (length params) Nothing, Nothing)
@@ -11556,7 +11591,7 @@ exprToGoMain _types = exprToGo
 
 -- | Legacy untyped main stmts (kept for reference)
 exprToMainStmts :: Can.Expr -> [GoIr.GoStmt]
-exprToMainStmts = exprToMainStmtsTyped Map.empty
+exprToMainStmts = exprToMainStmtsTyped Solve.emptySolvedTypes
 
 
 -- ═══════════════════════════════════════════════════════════
@@ -11584,7 +11619,7 @@ exprToGoTyped types retType (A.At _ expr) = case expr of
 
     Can.VarLocal name ->
         -- If we have a solved type for this var and it's concrete, use type assertion
-        case Map.lookup name types of
+        case Solve.lookupSolvedVar name types of
             Just ty | isConcreteType ty -> GoIr.GoTypeAssert (GoIr.GoIdent name) (solvedTypeToGo ty)
             _ -> GoIr.GoIdent name
     Can.VarTopLevel _ name -> GoIr.GoIdent (goSafeName name)
@@ -11608,7 +11643,7 @@ exprToGoTyped types retType (A.At _ expr) = case expr of
                 Just expr -> expr
                 Nothing -> case func of
                     A.At _ (Can.VarLocal name) ->
-                        case Map.lookup name types of
+                        case Solve.lookupSolvedVar name types of
                             Just (T.TLambda _ _) ->
                                 GoIr.GoCall (GoIr.GoRaw (name ++ ".(func(any) any)")) goArgs
                             _ -> GoIr.GoCall goFunc goArgs
@@ -11634,7 +11669,7 @@ exprToGoTyped types retType (A.At _ expr) = case expr of
             -- yields a concrete value and asserting `.(T)` on it would be a Go error.
             calleeInfo = case func of
                 A.At _ (Can.VarTopLevel _ name) ->
-                    case Map.lookup name types of
+                    case Solve.lookupSolvedVar name types of
                         Just ft ->
                             let (argTys, rtTy) = splitFuncType (length args) ft
                                 fullyTyped = length argTys == length args
@@ -11643,7 +11678,7 @@ exprToGoTyped types retType (A.At _ expr) = case expr of
                             in Just (rtTy, fullyTyped)
                         Nothing -> Nothing
                 A.At _ (Can.VarLocal name) ->
-                    case Map.lookup name types of
+                    case Solve.lookupSolvedVar name types of
                         Just ft ->
                             let (_, rtTy) = splitFuncType (length args) ft
                             in Just (rtTy, False)  -- VarLocal calls go through any-dispatch
@@ -11789,7 +11824,7 @@ substTypeVars types = go Set.empty
   where
     go seen ty = case ty of
         T.TVar name | not (Set.member name seen) ->
-            case Map.lookup name types of
+            case Solve.lookupSolvedVar name types of
                 Just resolved | resolved /= ty -> go (Set.insert name seen) resolved
                 _ -> ty
         T.TType home name args -> T.TType home name (map (go seen) args)
@@ -11814,10 +11849,10 @@ inferExprType types (A.At r e) = case e of
     Can.Str _    -> Just ConstrainExpr.stringType
     Can.Chr _    -> Just ConstrainExpr.charType
     Can.Unit     -> Just T.TUnit
-    Can.VarLocal name    -> case Map.lookup name types of
+    Can.VarLocal name    -> case Solve.lookupSolvedVar name types of
         Just t  -> Just t
         Nothing -> lookupLambdaType name
-    Can.VarTopLevel _ n  -> Map.lookup n types
+    Can.VarTopLevel _ n  -> Solve.lookupSolvedVar n types
     -- VarKernel: instantiate the kernel's HM annotation. Strips the
     -- Forall wrapper (kernel sigs are universally quantified) so the
     -- result is the raw type with TVars left in place.
@@ -11980,7 +12015,7 @@ inferExprType types (A.At r e) = case e of
                         [ T.TVar ("_lambda_arg_" ++ show i)
                         | i <- [0 .. length pats - 1]
                         ]
-                    types' = Map.union
+                    types' = Solve.unionSolvedEnv
                         (Map.fromList (zip paramNames paramTVars))
                         types
                 in case inferExprType types' body of
@@ -12050,10 +12085,10 @@ inferExprType types (A.At r e) = case e of
                 Can.Def (A.At _ n) [] valExpr
                     | n /= "_"
                     , Just t <- inferExprType types valExpr ->
-                        Map.insert n t types
+                        Solve.insertSolvedVar n t types
                 Can.TypedDef (A.At _ n) _ [] valExpr _
                     | Just t <- inferExprType types valExpr ->
-                        Map.insert n t types
+                        Solve.insertSolvedVar n t types
                 _ -> types
         in inferExprType types' body
     -- LetRec: same shape as `Can.Let` but with [Def] — register
@@ -12069,10 +12104,10 @@ inferExprType types (A.At r e) = case e of
                 Can.Def (A.At _ n) [] valExpr
                     | n /= "_"
                     , Just t <- inferExprType acc valExpr ->
-                        Map.insert n t acc
+                        Solve.insertSolvedVar n t acc
                 Can.TypedDef (A.At _ n) _ [] valExpr _
                     | Just t <- inferExprType acc valExpr ->
-                        Map.insert n t acc
+                        Solve.insertSolvedVar n t acc
                 _ -> acc
             types' = foldl extend types defs
         in inferExprType types' body

--- a/src/Sky/Build/LowerCtx.hs
+++ b/src/Sky/Build/LowerCtx.hs
@@ -110,7 +110,7 @@ data LowerCtx = LowerCtx
 emptyLowerCtx :: ModuleName.Canonical -> LowerCtx
 emptyLowerCtx home = LowerCtx
     { _lc_module      = home
-    , _lc_solved      = Map.empty
+    , _lc_solved      = Solve.emptySolvedTypes
     , _lc_regionTypes = Map.empty
     , _lc_lambdaTypes = Map.empty
     , _lc_lambdaGoStr = Map.empty
@@ -194,7 +194,7 @@ lookupAnnotation ctx name = Map.lookup name (_lc_annotMap ctx)
 -- `Solve.SolvedTypes` thread now passed alongside `LowerCtx` —
 -- one source of truth for solved types.
 lookupSolved :: LowerCtx -> String -> Maybe T.Type
-lookupSolved ctx name = Map.lookup name (_lc_solved ctx)
+lookupSolved ctx name = Solve.lookupSolvedVar name (_lc_solved ctx)
 
 
 -- | Extend the lambda-types scope.  Returns a NEW ctx — the parent

--- a/src/Sky/Lsp/Server.hs
+++ b/src/Sky/Lsp/Server.hs
@@ -1610,7 +1610,9 @@ solveForName srcMod name =
             (r, localTys) <- Solve.solveWithLocals cs
             case r of
                 Solve.SolveOk types ->
-                    case Map.lookup name types of
+                    -- v0.15.x P37a: SolvedTypes is now a record;
+                    -- consult its env field for var-name lookup.
+                    case Solve.lookupSolvedVar name types of
                         Just t  -> return (Just t)
                         Nothing -> case Map.lookup name localTys of
                             Just (t:_) -> return (Just t)
@@ -1677,7 +1679,7 @@ computeHover text line col = case Parse.parseModule text of
                         cs <- Constrain.constrainModule canMod
                         r  <- Solve.solve cs
                         case r of
-                            Solve.SolveOk types -> case Map.lookup name types of
+                            Solve.SolveOk types -> case Solve.lookupSolvedVar name types of
                                 Just t  -> return (Just (mkHover (name ++ " : " ++ Solve.showType t)))
                                 Nothing -> return (Just (mkHover name))
                             _ -> return (Just (mkHover name))
@@ -2446,8 +2448,11 @@ addAnnotationActions uri _text srcMod = do
         Right canMod -> do
             cs <- Constrain.constrainModule canMod
             r  <- Solve.solve cs
+            -- v0.15.x P37a: extract the env-map view; the rest of
+            -- this code path uses `Map.lookup` directly so we keep
+            -- the bare-map shape locally.
             case r of
-                Solve.SolveOk types -> return types
+                Solve.SolveOk types -> return (Solve._stEnv types)
                 _                   -> return Map.empty
 
     annotAction types (A.At _ v)
@@ -2839,7 +2844,7 @@ computeSignatureHelp text line col = case Parse.parseModule text of
                     r  <- Solve.solve cs
                     case r of
                         Solve.SolveOk types ->
-                            case Map.lookup (simpleName funcName) types of
+                            case Solve.lookupSolvedVar (simpleName funcName) types of
                                 Just t  -> return (Just (mkSignature funcName (Solve.showType t) paramIdx))
                                 Nothing -> return (Just (mkSignature funcName "" paramIdx))
                         _ -> return (Just (mkSignature funcName "" paramIdx))

--- a/src/Sky/Type/Solve.hs
+++ b/src/Sky/Type/Solve.hs
@@ -15,7 +15,12 @@ module Sky.Type.Solve
     , solveWithInstances
     , solveWithInstancesAndRegions   -- v0.15 Stage A
     , SolveResult(..)
-    , SolvedTypes
+    , SolvedTypes(..)
+    , emptySolvedTypes               -- v0.15.x P37a
+    , lookupSolvedVar                -- v0.15.x P37a
+    , lookupSolvedRegion             -- v0.15.x P37a
+    , insertSolvedVar                -- v0.15.x P37a
+    , unionSolvedEnv                 -- v0.15.x P37a
     , RegionTypes                    -- v0.15 Stage A
     , CallInstance(..)
     , CallSiteInstance(..)
@@ -57,8 +62,83 @@ data SolveResult
     deriving (Show)
 
 
--- | Solved type environment: maps variable names to their resolved types
-type SolvedTypes = Map.Map String T.Type
+-- | v0.15.x P37a — `SolvedTypes` is now a record that carries BOTH
+-- the resolved per-name HM-type environment AND the per-region HM
+-- type map.  Pre-P37a this was a bare `Map.Map String T.Type` and the
+-- region map was returned alongside via a 4-tuple from
+-- `solveWithInstancesAndRegions`; the lowerer snapshotted the region
+-- map into `scopeStateRef`'s `_lc_regionTypes` slot and consulted it
+-- through `lookupRegionType :: A.Region -> Maybe T.Type` (an
+-- `unsafePerformIO`-wrapped IORef read).  That IORef read sits at the
+-- heart of `letBindingType`'s shared seam with `letToGo` (cycle-3
+-- audit gap C5) and is the load-bearing reason the LowerCtx cascade
+-- can't migrate the remaining record-field / list-element / let-body
+-- slots without GHC blackholing on deferred thunks.
+--
+-- P37a's job is purely SOLVER-SIDE: extend `SolvedTypes` to also
+-- carry the region map (same shape as the pre-P37a `RegionTypes`
+-- value the IORef holds), and populate it at solve time.  P37b will
+-- migrate `letBindingType` to read from this pure value instead of
+-- the IORef and then delete the `_lc_regionTypes` IORef field.  This
+-- PR is a zero-behaviour-change extension: the IORef remains the
+-- source of truth for `lookupRegionType` reads; the new field is
+-- populated but not yet consumed by `letBindingType` /
+-- `lookupRegionType`.
+--
+-- Field naming convention (`_st<thing>`) matches the project's
+-- record-field style (cf. `_lc_*` on `LowerCtx`).
+data SolvedTypes = SolvedTypes
+    { _stEnv     :: !(Map.Map String T.Type)
+        -- ^ Pre-P37a's plain map: maps variable names to their
+        -- resolved HM types.  Every consumer that did
+        -- `Map.lookup name solvedTypes` now goes through this field
+        -- (or the convenience helper `lookupSolvedVar`).
+    , _stRegions :: !RegionTypes
+        -- ^ v0.15 Stage A's per-region type map, now stored as
+        -- pure data alongside the env.  Populated by every solve
+        -- entry point (`solve` / `solveWithLocals` /
+        -- `solveWithInstancesAndRegions`) so the SolvedTypes value
+        -- always carries the full pure snapshot.  P37b consumes
+        -- this to make `letBindingType`'s region lookup pure.
+    }
+    deriving (Eq, Show)
+
+
+-- | An empty `SolvedTypes`.  Used at LSP boundaries where the solver
+-- errored before producing a usable map AND in tests that need a
+-- placeholder.
+emptySolvedTypes :: SolvedTypes
+emptySolvedTypes = SolvedTypes Map.empty Map.empty
+
+
+-- | Look up a top-level / let-bound name's HM-resolved type.
+-- Convenience for the common `Map.lookup name (_stEnv st)` idiom.
+lookupSolvedVar :: String -> SolvedTypes -> Maybe T.Type
+lookupSolvedVar n = Map.lookup n . _stEnv
+
+
+-- | Look up the HM type recorded at a given source region.
+-- Pure substitute for the `lookupRegionType` IORef read that P37b
+-- will migrate `letBindingType` over to.  Today this is consulted
+-- only by the new P37a spec; the lowerer still reads via the
+-- IORef-backed path.
+lookupSolvedRegion :: A.Region -> SolvedTypes -> Maybe T.Type
+lookupSolvedRegion r = Map.lookup r . _stRegions
+
+
+-- | Insert a binding into the env map, leaving the region map
+-- untouched.  Convenience for callers that previously did
+-- `Map.insert n t solved` on the bare-Map shape.
+insertSolvedVar :: String -> T.Type -> SolvedTypes -> SolvedTypes
+insertSolvedVar n t st = st { _stEnv = Map.insert n t (_stEnv st) }
+
+
+-- | Extend the env map with the entries from another map.  The
+-- argument map's entries take precedence on key clash (matches
+-- `Map.union` semantics on `Map.union additions existing`).
+unionSolvedEnv :: Map.Map String T.Type -> SolvedTypes -> SolvedTypes
+unionSolvedEnv additions st =
+    st { _stEnv = Map.union additions (_stEnv st) }
 
 
 -- | v0.15 Stage A — per-region type map.  Every solved constraint's
@@ -391,7 +471,16 @@ solve constraint = do
                 isUnboundTVar _ = False
                 localFirst = Map.map pickType (Map.filter (not . null) localTys)
             let merged = Map.union localFirst envTypes
-            return (SolveOk merged)
+            -- v0.15.x P37a — freeze the per-region var map alongside
+            -- the per-name env so the SolvedTypes record carries
+            -- both as pure data.  Same data the IORef-backed
+            -- `lookupRegionType` reads via the
+            -- `solveWithInstancesAndRegions` path; populating it
+            -- here too means LSP / single-module entry points emit
+            -- a complete SolvedTypes even though they don't yet
+            -- consume the regions field.
+            regionTys <- freezeRegionTypes (_regionVars finalState)
+            return (SolveOk (SolvedTypes merged regionTys))
         Just err -> return (SolveError err)
 
 
@@ -415,8 +504,10 @@ solveWithLocals constraint = do
         mapM variableToType vars) localVars
     case result of
         Nothing -> do
-            solvedTypes <- readSolvedTypes (_env finalState)
-            return (SolveOk solvedTypes, localTypes)
+            envTypes <- readSolvedTypes (_env finalState)
+            -- v0.15.x P37a — same freeze pattern as `solve` above.
+            regionTys <- freezeRegionTypes (_regionVars finalState)
+            return (SolveOk (SolvedTypes envTypes regionTys), localTypes)
         Just err ->
             return (SolveError err, localTypes)
 
@@ -483,7 +574,15 @@ solveWithInstancesAndRegions constraint = do
             records <- readIORef (_callInstances finalState)
             (ci, csi) <- extractInstancesAndSites records
             regionTys <- freezeRegionTypes (_regionVars finalState)
-            return (SolveOk merged, ci, csi, regionTys)
+            -- v0.15.x P37a — the new pure `SolvedTypes` record
+            -- carries the region map alongside the env.  Existing
+            -- consumers (compile.hs, lsp) keep reading `_stEnv`;
+            -- the IORef-backed `lookupRegionType` retains its
+            -- previous semantics until P37b's migration.  The
+            -- fourth tuple slot (`regionTys`) stays for backward
+            -- compatibility — `Compile.hs` still threads it into
+            -- `scopeStateRef._lc_regionTypes` directly today.
+            return (SolveOk (SolvedTypes merged regionTys), ci, csi, regionTys)
         Just err -> do
             -- v0.13 Phase A4: even on error, return whatever
             -- call-site instances were captured BEFORE the error
@@ -892,7 +991,12 @@ solveAll state (c:cs) = do
 -- READ SOLVED TYPES
 -- ═══════════════════════════════════════════════════════════
 
-readSolvedTypes :: Map.Map String T.Variable -> IO SolvedTypes
+-- | v0.15.x P37a: returns the bare env map.  The full `SolvedTypes`
+-- record is constructed at the solver-entry callers (`solve` etc.)
+-- which know whether to attach the region map (only
+-- `solveWithInstancesAndRegions` does — `solve`/`solveWithLocals`
+-- leave it empty).
+readSolvedTypes :: Map.Map String T.Variable -> IO (Map.Map String T.Type)
 readSolvedTypes env =
     Map.traverseWithKey (\_ var -> variableToType var) env
 

--- a/test/Sky/Type/SolvedTypesRegionMapSpec.hs
+++ b/test/Sky/Type/SolvedTypesRegionMapSpec.hs
@@ -1,0 +1,205 @@
+-- | v0.15.x P37a — SolvedTypes carries region map as pure data.
+--
+-- Locks the solver-side surgery shipped in
+-- `feat/v0.15.x-hardening-P37a-solved-types-region-map`:
+-- `Solve.SolvedTypes` is now a record carrying BOTH the per-name
+-- HM-type environment AND the per-region HM-type map (the latter
+-- previously returned only as a 4-tuple slot from
+-- `solveWithInstancesAndRegions`).  This spec is the regression
+-- gate so a future edit cannot silently drop the region field or
+-- mis-populate it from a stale IORef snapshot.
+--
+-- The follow-up PR (P37b) consumes `_stRegions` to make
+-- `letBindingType`'s region lookup pure, eliminating the
+-- IORef-backed reader that today still services `lookupRegionType`.
+-- This spec only locks the populate-time contract — the consume-
+-- time migration ships separately.
+module Sky.Type.SolvedTypesRegionMapSpec (spec) where
+
+import Test.Hspec
+import qualified Data.Map.Strict as Map
+import qualified Sky.Reporting.Annotation as A
+import qualified Sky.Sky.ModuleName as ModuleName
+import qualified Sky.Type.Type as T
+import qualified Sky.Type.Solve as Solve
+
+
+-- ─── helpers ─────────────────────────────────────────────────────
+
+
+tyInt :: T.Type
+tyInt = T.TType ModuleName.basics "Int" []
+
+
+tyString :: T.Type
+tyString = T.TType ModuleName.basics "String" []
+
+
+tyBool :: T.Type
+tyBool = T.TType ModuleName.basics "Bool" []
+
+
+-- | Synthesise an A.Region at a given (line, col).  Non-zero
+-- positions are required: the solver filters synthetic (0, 0)
+-- regions out of `_regionVars` (see `Solve.recordRegionVar`).
+mkRegion :: Int -> Int -> A.Region
+mkRegion line col =
+    A.Region (A.Position line col) (A.Position line (col + 4))
+
+
+-- | Build a `CEqual` constraint at `region`, asserting `actual`
+-- unifies with `expected` (both bare types — no FromAnnotation /
+-- FromContext wrappers).  The `Category` doesn't affect solve
+-- semantics; it only flavours diagnostic output, so we pick the
+-- closest-fitting category for each fixture.
+eq :: A.Region -> T.Category -> T.Type -> T.Type -> T.Constraint
+eq region cat actual expected =
+    T.CEqual region cat actual (T.NoExpectation expected)
+
+
+-- ─── tests ───────────────────────────────────────────────────────
+
+
+spec :: Spec
+spec = do
+
+    describe "Solve.emptySolvedTypes" $ do
+        it "has both env and region maps empty" $ do
+            Solve._stEnv     Solve.emptySolvedTypes `shouldBe` Map.empty
+            Solve._stRegions Solve.emptySolvedTypes `shouldBe` Map.empty
+
+        it "lookupSolvedVar on the empty value returns Nothing" $ do
+            Solve.lookupSolvedVar "anything"
+                Solve.emptySolvedTypes `shouldBe` Nothing
+
+        it "lookupSolvedRegion on the empty value returns Nothing" $ do
+            Solve.lookupSolvedRegion (mkRegion 1 1)
+                Solve.emptySolvedTypes `shouldBe` Nothing
+
+    describe "Solve.SolvedTypes record helpers" $ do
+        it "insertSolvedVar leaves the region map untouched" $ do
+            let st0 = Solve.SolvedTypes
+                        Map.empty
+                        (Map.singleton (mkRegion 5 5) tyInt)
+                st1 = Solve.insertSolvedVar "x" tyString st0
+            Solve.lookupSolvedVar "x" st1 `shouldBe` Just tyString
+            -- Region map preserved bit-for-bit.
+            Solve._stRegions st1 `shouldBe` Solve._stRegions st0
+
+        it "unionSolvedEnv merges with the additions winning on clash" $ do
+            let st0 = Solve.SolvedTypes
+                        (Map.fromList [("a", tyInt), ("b", tyString)])
+                        Map.empty
+                additions = Map.fromList [("b", tyBool), ("c", tyInt)]
+                st1 = Solve.unionSolvedEnv additions st0
+            Solve.lookupSolvedVar "a" st1 `shouldBe` Just tyInt
+            -- 'b' overridden by the additions map.
+            Solve.lookupSolvedVar "b" st1 `shouldBe` Just tyBool
+            Solve.lookupSolvedVar "c" st1 `shouldBe` Just tyInt
+
+    describe "Solve.solveWithInstancesAndRegions" $ do
+        it "populates _stRegions with the same map as the 4-tuple slot" $ do
+            -- Two CEqual constraints at distinct non-zero regions
+            -- exercise the `recordRegionVar` path.  This is the
+            -- shape the solver writes for any non-synthetic
+            -- expression — `let x = 42` and `let y = "abc"` in a
+            -- real module would produce constraints of exactly
+            -- this shape, keyed by the source region of each RHS.
+            let r1 = mkRegion 10 5
+                r2 = mkRegion 20 5
+                c1 = eq r1 T.CNumber tyInt    tyInt
+                c2 = eq r2 T.CString tyString tyString
+                cs = T.CAnd [c1, c2]
+            (res, _, _, regionTysFromTuple)
+                <- Solve.solveWithInstancesAndRegions cs
+            case res of
+                Solve.SolveOk solved -> do
+                    -- The acceptance contract: the SolvedTypes
+                    -- record carries the SAME data as the 4-tuple's
+                    -- regionTys slot.  P37b consumes the record
+                    -- field; today the 4-tuple slot is still the
+                    -- source of truth for `Compile.hs`'s IORef
+                    -- write.  Locking byte-equality here keys both
+                    -- consumers off one populate-time write.
+                    Solve._stRegions solved `shouldBe` regionTysFromTuple
+                    -- And the data isn't empty — the test fixture
+                    -- has two recorded regions.
+                    Map.size (Solve._stRegions solved) `shouldBe` 2
+                Solve.SolveError e ->
+                    expectationFailure ("solve failed: " ++ e)
+
+        it "exposes the per-region types via lookupSolvedRegion" $ do
+            let r1 = mkRegion 7 1
+                r2 = mkRegion 8 1
+                c1 = eq r1 T.CNumber       tyInt  tyInt
+                c2 = eq r2 (T.CCustom "Bool") tyBool tyBool
+                cs = T.CAnd [c1, c2]
+            (res, _, _, _) <- Solve.solveWithInstancesAndRegions cs
+            case res of
+                Solve.SolveOk solved -> do
+                    Solve.lookupSolvedRegion r1 solved `shouldBe` Just tyInt
+                    Solve.lookupSolvedRegion r2 solved `shouldBe` Just tyBool
+                    -- A non-recorded region returns Nothing.
+                    Solve.lookupSolvedRegion (mkRegion 99 99) solved
+                        `shouldBe` Nothing
+                Solve.SolveError e ->
+                    expectationFailure ("solve failed: " ++ e)
+
+        it "filters synthetic (0, 0) regions out of the region map" $ do
+            -- This mirrors the existing filter in
+            -- `Solve.recordRegionVar`: constraint generators emit
+            -- `A.zero` / `A.one` sentinels for let-binding headers,
+            -- lambda-param scopes, etc.  Those should NOT appear in
+            -- the region map (would leak bookkeeping noise into
+            -- `letBindingType`'s lookup once P37b switches to the
+            -- pure path).
+            let zeroR = A.Region (A.Position 0 0) (A.Position 0 0)
+                c     = eq zeroR T.CNumber tyInt tyInt
+            (res, _, _, _) <- Solve.solveWithInstancesAndRegions c
+            case res of
+                Solve.SolveOk solved ->
+                    Map.member zeroR (Solve._stRegions solved)
+                        `shouldBe` False
+                Solve.SolveError e ->
+                    expectationFailure ("solve failed: " ++ e)
+
+    describe "Solve.solve" $ do
+        it "populates _stRegions even when not threading through the regions API" $ do
+            -- AC#1 contract: every solver entry point produces a
+            -- SolvedTypes value whose region map is the same pure
+            -- snapshot that `_regionVars` carries.  The LSP /
+            -- single-binding entry points (`solve` / `solveWithLocals`)
+            -- get it for free since `_regionVars` is populated as
+            -- the constraints unify, independent of the entry
+            -- point.  This keeps P37b's consumer story uniform —
+            -- the consumer doesn't have to ask "which path did this
+            -- SolvedTypes come from?".
+            let r  = mkRegion 3 3
+                c  = eq r T.CString tyString tyString
+            res <- Solve.solve c
+            case res of
+                Solve.SolveOk solved ->
+                    Solve.lookupSolvedRegion r solved
+                        `shouldBe` Just tyString
+                Solve.SolveError e ->
+                    expectationFailure ("solve failed: " ++ e)
+
+    describe "P37b drop-in shape" $ do
+        it "letBindingType-shaped lookup can be expressed as pure data" $ do
+            -- P37b's job is to migrate `letBindingType` from
+            -- `LC.lookupRegionType ctx region` (IORef-backed) to
+            -- a pure projection over `Solve.SolvedTypes`.  This
+            -- assertion is the smoke test for that migration:
+            -- the let-binding's RHS-region lookup, derived purely
+            -- from a `SolvedTypes` value, returns the type the
+            -- solver actually recorded.  No `unsafePerformIO`
+            -- in sight.
+            let rhsRegion = mkRegion 15 9
+                c         = eq rhsRegion T.CNumber tyInt tyInt
+            res <- Solve.solve c
+            case res of
+                Solve.SolveOk solved -> do
+                    let pureLookup = Solve.lookupSolvedRegion rhsRegion solved
+                    pureLookup `shouldBe` Just tyInt
+                Solve.SolveError e ->
+                    expectationFailure ("solve failed: " ++ e)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -61,6 +61,7 @@ import qualified Sky.Build.MonoIntegrationSpec
 import qualified Sky.Reporting.DiagnosticSpec
 import qualified Sky.Diagnostics.CoverageSpec
 import qualified Sky.Type.InstanceCaptureSpec
+import qualified Sky.Type.SolvedTypesRegionMapSpec
 import qualified Sky.Build.KernelSigCoverageSpec
 import qualified Sky.Build.HeapBoundedHmSpec
 import qualified Sky.Build.SolverBudgetSpec
@@ -359,6 +360,14 @@ main = hspec $ do
     -- the solver's CForeign instance-recording mechanism that the
     -- monomorphisation pass consumes downstream.
     describe "Sky.Type.InstanceCapture"      Sky.Type.InstanceCaptureSpec.spec
+    -- v0.15.x P37a: SolvedTypes carries the per-region HM type map
+    -- as pure data.  Locks the populate-time contract so the
+    -- IORef-backed `lookupRegionType` reader (still load-bearing in
+    -- Compile.hs) and the pure `Solve.lookupSolvedRegion` query
+    -- key off ONE solver-side write.  P37b consumes the field via
+    -- `letBindingType` and drops the IORef.
+    describe "Sky.Type.SolvedTypesRegionMap"
+                                            Sky.Type.SolvedTypesRegionMapSpec.spec
     -- v0.13 Phase A2: monomorphisation type-level pieces.  Locks
     -- the mangling encoding + substitution semantics that the
     -- downstream emission pass relies on.


### PR DESCRIPTION
## Summary

Cycle 3 plan item **P37a** (target tag **v0.15.19**) — solver-side surgery
that promotes `Solve.SolvedTypes` from a type alias `Map.Map String T.Type`
to a record carrying BOTH the per-name HM-type env AND the per-region HM-type
map (was previously returned only as a 4-tuple slot from
`solveWithInstancesAndRegions`).

```haskell
data SolvedTypes = SolvedTypes
    { _stEnv     :: !(Map.Map String T.Type)
    , _stRegions :: !RegionTypes
    }
    deriving (Eq, Show)
```

This is **purely solver-side surgery + new field plumbing** — zero behaviour
change.  The `_lc_regionTypes` IORef path still services every consumer in
`Compile.hs`'s lowerer; the new field is populated but **not yet consumed**
by `letBindingType`.

## Why P37a was reframed from "delete scopeStateRef"

The Cycle 3 audit's gap C5 ([CYCLE-03-auditor.md](docs/v0.15.x-hardening/audits/CYCLE-03-auditor.md)
§ Gap C5) showed the cycle-1 P7 framing ("delete `scopeStateRef`
mechanically") was wrong — the IORef is a SYMPTOM; the disease is
`letBindingType`'s region lookup running inside `letToGo`'s `defStmts`
thunk while the body's `lowerBody body` thunk also depends on the same
ctx.  Deleting the IORef without first making `letBindingType` pure
would re-open the GHC blackhole class that v0.15.15 P6 partially worked
around.

The right framing (this PR's): MOVE the region-types map OUT of the
IORef and INTO `Solve.SolvedTypes` as pure data.  Once it lives on
`SolvedTypes`, P37b (next dev) can flip `letBindingType :: Solve.SolvedTypes
-> String -> Can.Expr -> Maybe T.Type` (drop the `LC.LowerCtx`
parameter and the IORef snapshot) and then safely delete the IORef
field.

## Acceptance criteria (from the dev prompt)

| AC | Status |
|---|---|
| 1. `Solve.SolvedTypes` gains a region-types map field, same key/value shape | ✅ `_stRegions :: !RegionTypes` |
| 2. Solver writes the map into the SolvedTypes value at solve time | ✅ every entry point populates it from `freezeRegionTypes (_regionVars finalState)` |
| 3. Lowerer NOT yet refactored — `letBindingType` still reads the IORef | ✅ no change to `letBindingType` / `lookupRegionType` |
| 4. cabal test stays green (was 366/0/1 pass) | ✅ 376/0/1 (366 pre-existing + 10 new spec cases) |
| 5. `scripts/build.sh --self-tests` stays green (was 70/70) | ✅ 70/70 |
| 6. example-sweep stays green (was 19/19) | ✅ covered by `Sky.Build.ExampleSweepSpec` + manual rebuild of 01/12/16/19 |
| 7. examples/13-skyshop main.go byte-identical | ✅ md5 `39b18368f6e1daa254957641fadaea3a` UNCHANGED |
| 8. New cabal spec under test/Sky/Type/ that exercises the populate-time contract | ✅ `Sky.Type.SolvedTypesRegionMapSpec` (10 cases) |

## New spec — Sky.Type.SolvedTypesRegionMapSpec

10 cases lock the P37a contract:

- `emptySolvedTypes` + lookup helpers behave on empty input.
- `insertSolvedVar` leaves the region map untouched (matches the env-only
  extension shape `Compile.hs` needs for `inferExprType` let-body inference).
- `unionSolvedEnv` merges with additions winning on clash.
- `solveWithInstancesAndRegions` populates `_stRegions` **byte-equal** to
  the 4-tuple's region map (so both consumers key off ONE write).
- `lookupSolvedRegion` returns the recorded type for each non-zero
  region; Nothing for unrecorded.
- Synthetic (0, 0) regions are filtered out (matches `recordRegionVar`).
- `solve` (no regions API) ALSO populates `_stRegions` — every entry
  point's `SolvedTypes` carries the full pure snapshot.
- "P37b drop-in" smoke test: the let-binding RHS-region lookup
  expressed as a pure projection over `SolvedTypes`, no `unsafePerformIO`.

## Call-site migrations (mechanical)

- Every `Map.lookup name solved` / `Map.toList solved` / `Map.keys solved` on
  the previous-alias-shape `SolvedTypes` now goes through `Solve._stEnv` or
  the `Solve.lookupSolvedVar` helper.
- The `typesWithDeps` merge wraps the merged env back into a `SolvedTypes`
  value carrying the same `mergedRegionTys` that `Compile.hs` writes to
  `scopeStateRef._lc_regionTypes`.
- `Lsp.Server`'s `runInfer` projects to the bare env-map; per-name LSP
  lookups use `Solve.lookupSolvedVar`.
- Empty-SolvedTypes seed values now use `Solve.emptySolvedTypes` instead of
  `Map.empty` (in `globalCgEnv`, dep solver failures, etc.).

## Standing direction (σ-consensus voter audit)

No `coerceArg` / `goExprGoType` voter changed in this PR — the cascade
voter trio is untouched.  The migration touches only the SolvedTypes
shape + projection helpers.

## Cross-references

- Cycle 3 audit: `docs/v0.15.x-hardening/audits/CYCLE-03-auditor.md` (Gap C5)
- Cycle 3 plan: `docs/v0.15.x-hardening/plans/CYCLE-03-planner.md` (P37a section, lines 162-202)
- Follow-up: P37b (`feat/v0.15.x-hardening-P37b-letBindingType-pure-delete-regionref`, v0.15.24) consumes this field + deletes the IORef.

🤖 Generated with [Claude Code](https://claude.com/claude-code)