### PR TITLE
refactor(live): rename prevBody to clarify rendered vs shipped semantics (Cycle 3 P39)

### DIFF
--- a/runtime-go/rt/live.go
+++ b/runtime-go/rt/live.go
@@ -1257,12 +1257,38 @@ type liveSession struct {
 	model    any
 	handlers map[string]any
 	prevTree *VNode // Last rendered tree; used by the diff protocol.
-	// Last rendered body string. Any dispatch that produces a byte-
-	// identical body is a no-op from the client's perspective; we
-	// suppress the SSE push to avoid flooding the wire when a
-	// Time.every subscription ticks but the model-derived view
-	// hasn't actually changed.
-	prevBody string
+	// View-body bookkeeping for the SSE no-op suppression contract
+	// (Cycle 3 P39 / Gap C2 — split out from the historical single
+	// `prevBody` field whose dual meaning had bitten v0.15.14).
+	//
+	// Two distinct invariants are tracked:
+	//
+	//   * lastComputedBody — every dispatch / renderView / initial-
+	//     mount writes this with the just-rendered HTML. Mirrors the
+	//     `prevTree` field. dispatch's contract is to ALWAYS update
+	//     it (rolled back on a render panic so a partial render
+	//     doesn't poison the next dispatch's diff baseline).
+	//
+	//   * lastShippedBody — only the SSE-producing call sites
+	//     (dispatchBatched, runPerformBody, the Time.every tick
+	//     subscription, handleInitial's HTTP-response push, the SSE
+	//     reconnect-resync push) write this — and ONLY when they
+	//     actually emit a frame to the client (sseCh enqueue or
+	//     direct write to the SSE/HTTP response writer).
+	//
+	// Suppression checks ("a tick whose view byte-equals the last
+	// thing the client saw is a wasted frame — drop it") compare
+	// against `lastShippedBody`. Comparing against `lastComputedBody`
+	// would be a tautology: dispatch wrote it post-render.
+	//
+	// Why the split matters: a future cleanup that made dispatch
+	// skip the write (e.g. "only update on actual ship") would
+	// silently break suppression of every byte-identical view —
+	// because every check would see the SAME value before and
+	// after. Splitting names the two invariants so the contract is
+	// resilient to that refactor class.
+	lastComputedBody string
+	lastShippedBody  string
 	lastSeen time.Time
 	mu       sync.Mutex
 	// SSE outbound channel: any writer goroutine may push a frame.
@@ -2133,7 +2159,11 @@ func (app *liveApp) handleInitial(w http.ResponseWriter, r *http.Request) {
 	assignSkyIDs(&vn, "r")
 	body := renderVNode(vn, sess.handlers)
 	sess.prevTree = &vn
-	sess.prevBody = body
+	// Initial mount writes the full HTML directly into the HTTP
+	// response below — the client receives this body as the page,
+	// so it counts as BOTH "last computed" and "last shipped".
+	sess.lastComputedBody = body
+	sess.lastShippedBody = body
 	app.store.Set(sid, sess)
 
 	setSecurityHeaders(w.Header())
@@ -2380,6 +2410,18 @@ func (app *liveApp) handleEvent(w http.ResponseWriter, r *http.Request) {
 	prev := sess.prevTree
 	body2 := app.dispatch(sess, msg)
 	newTree := sess.prevTree
+	// /_sky/event ships its reply directly down the POST response
+	// (writeEventJSON / writeEventHTML below), so for the suppression
+	// contract this counts as "the client received the new body".
+	// Advance lastShippedBody under sess.mu so any concurrent SSE
+	// producer (tick subscription, runPerformBody) reading
+	// lastShippedBody picks up the post-click value and correctly
+	// suppresses a redundant frame on its next tick. Skip the empty-
+	// body case (no-op dispatch — body2 == "") so the field continues
+	// to reflect whatever the client genuinely last received.
+	if body2 != "" {
+		sess.lastShippedBody = body2
+	}
 	// Capture outgoing protocol metadata before releasing the lock so
 	// the seq reflects this session's true mutation order. Bumped once
 	// per reply (including no-op replies) so the client's cross-channel
@@ -2522,19 +2564,26 @@ func (app *liveApp) dispatchBatched(sess *liveSession, ev batchedEvent) {
 	if _, isSkyAdt := msg.(SkyADT); !isSkyAdt {
 		msg = applyMsgArgs(msg, ev.Args, ev.Value)
 	}
-	// Capture prevBody BEFORE dispatch so we can suppress a byte-
-	// identical view (symmetric with runPerformBody + the Time.every
-	// SSE producer — v0.15.14 / v0.15.17). Without this gate a beacon-
-	// driven tab-unload dispatch that produces no view change still
-	// ships a redundant SSE frame to other observers of the session.
-	prevBody := sess.prevBody
+	// Capture lastShippedBody BEFORE dispatch so we can suppress a
+	// byte-identical view (symmetric with runPerformBody + the
+	// Time.every SSE producer — v0.15.14 / v0.15.17). Comparing
+	// against lastShippedBody (not lastComputedBody) means the
+	// suppression contract is about the wire, not about dispatch's
+	// internal post-render write. Without this gate a beacon-driven
+	// tab-unload dispatch that produces no view change still ships
+	// a redundant SSE frame to other observers of the session.
+	prevShipped := sess.lastShippedBody
 	body2 := app.dispatch(sess, msg)
 	// Bump outSeq once per batched entry so any SSE frame pushed as a
 	// side effect carries a unique seq. Each dispatch that mutates the
 	// view is its own observable event.
 	var frame string
-	if body2 != "" && body2 != prevBody {
+	if body2 != "" && body2 != prevShipped {
 		frame = encodeSSEFrame(sess, body2)
+		// Advance lastShippedBody atomically with the enqueue
+		// decision — done while still holding sess.mu so future
+		// dispatches under the same lock see a coherent value.
+		sess.lastShippedBody = body2
 	}
 	sess.mu.Unlock()
 	// Push to other subscribers (other tabs, SSE listeners). The
@@ -2593,16 +2642,24 @@ func (app *liveApp) dispatch(sess *liveSession, msg any) (body string) {
 	// Snapshot the pre-dispatch view invariants so a panic anywhere in
 	// the body (update, view-render, runCmd, setupSubscriptions) can
 	// roll them back. Without this, a panic AFTER `sess.prevTree = &vn`
-	// (line ~2594) but BEFORE `sess.prevBody = body` (line ~2618) leaves
-	// the two fields desynced: prevTree pointing at the new (possibly
-	// partial) render and prevBody still on the prior-good body. The
-	// next dispatch's suppression check would then compare against a
-	// stale prevBody — typically harmless, but the asymmetry is fragile
-	// and the audit (Cycle 3 P35 residual c) flagged it as obscuring
-	// the intent of the recovery path. We restore BOTH fields so the
-	// failed dispatch is observably a no-op for the suppression layer.
+	// (line ~2594) but BEFORE `sess.lastComputedBody = body` (line
+	// ~2618) leaves the two fields desynced: prevTree pointing at the
+	// new (possibly partial) render and lastComputedBody still on the
+	// prior-good body. The next dispatch's diff baseline would then
+	// use a stale tree — typically harmless, but the asymmetry is
+	// fragile and the audit (Cycle 3 P35 residual c) flagged it as
+	// obscuring the intent of the recovery path. We restore both
+	// fields so the failed dispatch is observably a no-op for the
+	// suppression + diff layers.
+	//
+	// lastShippedBody is NOT snapshotted here because dispatch never
+	// writes it — its contract is "last thing sent to the wire",
+	// owned by the SSE producer callers (dispatchBatched,
+	// runPerformBody, the tick goroutine). A panic mid-dispatch has
+	// definitionally not shipped anything, so lastShippedBody stays
+	// at whatever the last successful SSE emission set it to.
 	prevTreeOnEntry := sess.prevTree
-	prevBodyOnEntry := sess.prevBody
+	prevComputedOnEntry := sess.lastComputedBody
 	defer func() {
 		if r := recover(); r != nil {
 			fmt.Fprintf(os.Stderr,
@@ -2611,11 +2668,11 @@ func (app *liveApp) dispatch(sess *liveSession, msg any) (body string) {
 			body = ""
 			dispatchErr = fmt.Errorf("dispatch panic: %v", r)
 			// Roll back the view invariants. The current dispatch has
-			// failed; the prior valid prevTree / prevBody must remain
-			// the source of truth for the next dispatch's suppression
-			// and diff baseline.
+			// failed; the prior valid prevTree / lastComputedBody must
+			// remain the source of truth for the next dispatch's
+			// suppression and diff baseline.
 			sess.prevTree = prevTreeOnEntry
-			sess.prevBody = prevBodyOnEntry
+			sess.lastComputedBody = prevComputedOnEntry
 		}
 		ObserveMsgLog(msgLogCtx, sess.model, finalCmd, dispatchErr)
 	}()
@@ -2685,7 +2742,12 @@ func (app *liveApp) dispatch(sess *liveSession, msg any) (body string) {
 	// frames per tick, but the client's __skyHandleResponse uses the
 	// seq guard + focus-preserving splice so a redundant frame is a
 	// bandwidth cost (~150 bytes/tick), not a correctness break.
-	sess.prevBody = body
+	//
+	// lastShippedBody is intentionally NOT written here — that's the
+	// SSE producer's job (post-P39 / Gap C2). Suppression callers
+	// compare against the last value the client actually received,
+	// not against this just-computed value.
+	sess.lastComputedBody = body
 	return body
 }
 
@@ -2775,11 +2837,17 @@ func (app *liveApp) runPerformBody(sess *liveSession, task any, toMsg any) {
 	// the same lock as dispatch means the seq reflects the actual
 	// mutation order even when other goroutines dispatch concurrently.
 	sess.mu.Lock()
-	prevBody := sess.prevBody
+	// Compare against lastShippedBody — the last body the client
+	// actually received — so a perform whose dispatch byte-equals
+	// what the client already has doesn't push a redundant frame.
+	prevShipped := sess.lastShippedBody
 	body := app.dispatch(sess, msg)
 	var frame string
-	if body != "" && body != prevBody {
+	if body != "" && body != prevShipped {
 		frame = encodeSSEFrame(sess, body)
+		// Advance lastShippedBody under the same lock as the enqueue
+		// decision; future suppression checks see a coherent value.
+		sess.lastShippedBody = body
 	}
 	sess.mu.Unlock()
 	if frame == "" {
@@ -2837,19 +2905,24 @@ func (app *liveApp) setupSubscriptions(sess *liveSession) {
 				if isFunc(msg) {
 					msg = sky_call(toMsg, t.UnixMilli())
 				}
-				// Capture prevBody BEFORE dispatch so we can detect
-				// a tick whose update produced a byte-identical view
-				// (the typical Time.every shape — heartbeat polling,
+				// Capture lastShippedBody BEFORE dispatch so we can
+				// detect a tick whose update produced a view that
+				// byte-equals what the client already has (the
+				// typical Time.every shape — heartbeat polling,
 				// once-per-second refresh, etc.). Suppression lives
 				// at the SSE callsite (not inside dispatch) because
 				// the HTTP /_sky/event response path needs the body
 				// to compute structural patches; only the SSE tick
 				// can safely silence-drop when the view didn't move.
-				prevBody := sess.prevBody
+				prevShipped := sess.lastShippedBody
 				body := app.dispatch(sess, msg)
 				var frame string
-				if body != "" && body != prevBody {
+				if body != "" && body != prevShipped {
 					frame = encodeSSEFrame(sess, body)
+					// Advance lastShippedBody under sess.mu so the
+					// next tick (or any concurrent dispatcher) sees
+					// the just-enqueued value.
+					sess.lastShippedBody = body
 				}
 				sess.mu.Unlock()
 				// Suppress SSE write when the tick didn't change
@@ -2965,7 +3038,8 @@ func (app *liveApp) handleSSE(w http.ResponseWriter, r *http.Request) {
 	if sess.model != nil {
 		// Recover from any panic in view() so a bad render doesn't tear
 		// down the SSE connection. The recovered SSE just enters its
-		// for-select loop with the legacy prevTree/prevBody untouched.
+		// for-select loop with the legacy prevTree / lastComputedBody /
+		// lastShippedBody untouched.
 		func() {
 			defer func() { _ = recover() }()
 			vn := HtmlToVNode(sky_call(app.view, sess.model))
@@ -2973,7 +3047,12 @@ func (app *liveApp) handleSSE(w http.ResponseWriter, r *http.Request) {
 			sess.handlers = map[string]any{}
 			body := renderVNode(vn, sess.handlers)
 			sess.prevTree = &vn
-			sess.prevBody = body
+			// Reconnect-resync writes the resync frame DIRECTLY to
+			// the SSE response writer below — so this body is both
+			// just-computed AND just-shipped, and the next tick's
+			// suppression must compare against it.
+			sess.lastComputedBody = body
+			sess.lastShippedBody = body
 			frame := encodeSSEFrame(sess, body)
 			// Encode + write while still under lock to avoid interleaving
 			// with concurrent dispatch frames pushed via sess.sseCh.
@@ -2984,8 +3063,9 @@ func (app *liveApp) handleSSE(w http.ResponseWriter, r *http.Request) {
 			}
 		}()
 		sess.mu.Unlock()
-		// Persist the rebuilt prevTree+prevBody so future events diff
-		// against the new-binary view and don't fall back to full-body.
+		// Persist the rebuilt prevTree + lastComputedBody +
+		// lastShippedBody so future events diff against the
+		// new-binary view and don't fall back to full-body.
 		app.store.Set(sid, sess)
 	} else {
 		sess.mu.Unlock()

--- a/runtime-go/rt/live_dispatch_noop_test.go
+++ b/runtime-go/rt/live_dispatch_noop_test.go
@@ -7,7 +7,8 @@ package rt
 // equality check started firing through legitimate keypress dispatch
 // paths, freezing live editing. Suppression of identical-view SSE
 // pushes is now the SSE producer's responsibility (it compares the
-// returned body to sess.prevBody before encoding a frame).
+// returned body to sess.lastShippedBody — Cycle 3 P39 split — before
+// encoding a frame).
 //
 // What this file pins:
 //   * dispatch returns a non-empty body for both the initial dispatch

--- a/runtime-go/rt/live_perform_suppression_test.go
+++ b/runtime-go/rt/live_perform_suppression_test.go
@@ -1,27 +1,41 @@
 package rt
 
 // v0.15.17 — runPerformBody must suppress SSE frames when the post-
-// dispatch body is byte-identical to sess.prevBody, must ship a frame
-// when the view changes, and must advance sess.prevBody coherently
-// across cycles.
+// dispatch body is byte-identical to the body the client last
+// received, must ship a frame when the view changes, and must
+// advance the "last shipped" bookkeeping coherently across cycles.
 //
 // v0.15.14 (PR #85) added the suppression contract to runPerformBody
-// + the Time.every callsite (live.go:2697-2723 / 2745-2787) without a
-// Go-level regression test. Cycle 3 audit gap C1 residual #2 flagged
-// the missing _test.go mate. This file lands the missing tests.
+// + the Time.every callsite (live.go) without a Go-level regression
+// test. Cycle 3 audit gap C1 residual #2 flagged the missing _test.go
+// mate. This file lands the missing tests.
+//
+// Cycle 3 P39 (Gap C2) split the historical single `prevBody` field
+// into two fields with distinct invariants:
+//
+//   - lastComputedBody — written by every dispatch with the just-
+//     rendered HTML. Mirrors prevTree.
+//   - lastShippedBody  — written only by the SSE-producing call
+//     sites, and only when a frame is actually emitted to the wire
+//     (sseCh enqueue or direct SSE response write).
+//
+// Suppression compares against lastShippedBody (what the client
+// actually has), not lastComputedBody (what dispatch happens to
+// have just rendered). This file pins both invariants.
 //
 // Test shapes mirror live_dispatch_noop_test.go but exercise the SSE
 // producer rather than dispatch's return contract:
 //
-//   1. Identical-view perform → no frame queued on sess.sseCh.
-//   2. View-changing perform → frame queued.
-//   3. sess.prevBody advances coherently across consecutive perform
-//      cycles (suppression continues to fire after the first ship).
-//
-// We synthesise the runPerformBody preconditions manually (model,
-// view, dispatch wired up exactly as the production path expects) and
-// then call app.runPerformBody directly with a trivial Task that
-// returns a Msg.
+//   (a) Identical-view perform → no frame queued; lastShippedBody
+//       unchanged; lastComputedBody advanced.
+//   (b) View-changing perform → frame queued; lastShippedBody and
+//       lastComputedBody both advanced to the new body.
+//   (c) lastShippedBody advances coherently across cycles.
+//   (d) Post-panic dispatch preserves lastComputedBody (rollback)
+//       and never touches lastShippedBody.
+//   (e) Suppressed dispatch advances lastComputedBody but leaves
+//       lastShippedBody untouched (the Gap C2 invariant — the two
+//       fields are NOT in lockstep).
 
 import (
 	"testing"
@@ -44,19 +58,28 @@ func performTestApp(view func(model any) any) *liveApp {
 	}
 }
 
-// performTestSession primes the session with a baseline render so
-// sess.prevBody is non-empty (the production initial-mount path at
-// handleInitial does this; the test must mirror it or the first
-// dispatch's suppression check would always pass).
+// performTestSession primes the session with a baseline render and
+// mirrors the production initial-mount path (handleInitial) which
+// writes BOTH lastComputedBody and lastShippedBody — the initial
+// HTML response IS the page the client receives.
+//
+// Without seeding lastShippedBody too, the first runPerformBody's
+// suppression check would compare a non-empty body against an empty
+// lastShippedBody and always fire a frame, masking the suppression
+// contract entirely.
 func performTestSession(app *liveApp) *liveSession {
 	sess := &liveSession{
 		cancelSub: make(chan struct{}),
 		sseCh:     make(chan string, 16),
 		model:     "initial",
 	}
-	// Baseline: dispatch once so prevBody / prevTree match the current
-	// view. Subsequent runPerformBody calls compare against this.
-	_ = app.dispatch(sess, "bootstrap")
+	// Baseline: dispatch once so prevTree + lastComputedBody match
+	// the current view. dispatch writes lastComputedBody; mirror the
+	// initial-mount path by also writing lastShippedBody so the test
+	// starts in the same state as a freshly-mounted production
+	// session would.
+	body := app.dispatch(sess, "bootstrap")
+	sess.lastShippedBody = body
 	return sess
 }
 
@@ -72,7 +95,8 @@ func drainFrame(sess *liveSession, d time.Duration) string {
 	}
 }
 
-// (a) Identical-view dispatch must NOT queue an SSE frame.
+// (a) Identical-view perform must NOT queue an SSE frame, and must
+// leave lastShippedBody unchanged.
 //
 // Time.every and Cmd.perform completions whose update produces the
 // same view (e.g. a heartbeat tick that touches no view-reachable
@@ -84,11 +108,15 @@ func TestRunPerformBody_IdenticalView_SuppressesFrame(t *testing.T) {
 		return velement("div", nil, []any{vtext("static")})
 	})
 	sess := performTestSession(app)
-	// Sanity: baseline body cached.
-	if sess.prevBody == "" {
-		t.Fatalf("baseline dispatch must populate sess.prevBody")
+	// Sanity: baseline body cached in both fields.
+	if sess.lastComputedBody == "" {
+		t.Fatalf("baseline dispatch must populate sess.lastComputedBody")
 	}
-	priorBody := sess.prevBody
+	if sess.lastShippedBody == "" {
+		t.Fatalf("baseline mount must populate sess.lastShippedBody")
+	}
+	priorShipped := sess.lastShippedBody
+	priorComputed := sess.lastComputedBody
 	// Trivial task: returns the literal value 0. toMsg is identity.
 	task := func() any { return 0 }
 	toMsg := func(r any) any { return r }
@@ -97,20 +125,28 @@ func TestRunPerformBody_IdenticalView_SuppressesFrame(t *testing.T) {
 	if frame := drainFrame(sess, 20*time.Millisecond); frame != "" {
 		t.Fatalf("identical-view perform must NOT queue an SSE frame, got %q", frame)
 	}
-	// prevBody must be unchanged (dispatch wrote it back to the same value).
-	if sess.prevBody != priorBody {
-		t.Fatalf("prevBody mutated under identical-view perform: prior %q, now %q",
-			priorBody, sess.prevBody)
+	// lastShippedBody must be unchanged — nothing was actually shipped.
+	if sess.lastShippedBody != priorShipped {
+		t.Fatalf("identical-view perform mutated lastShippedBody: prior %q, now %q",
+			priorShipped, sess.lastShippedBody)
+	}
+	// lastComputedBody must be the same value (dispatch re-rendered the
+	// same view) — pinning that dispatch DID run and DID write the field.
+	if sess.lastComputedBody != priorComputed {
+		t.Fatalf("identical-view perform mutated lastComputedBody: prior %q, now %q",
+			priorComputed, sess.lastComputedBody)
 	}
 }
 
-// (b) View-changing dispatch MUST queue a frame.
+// (b) View-changing perform MUST queue a frame and advance both fields.
 //
 // A Cmd.perform completion whose update changes the view (e.g.
 // fetched data lands in model) ships an SSE frame so the client
-// can re-render.
+// can re-render. Both lastComputedBody (dispatch wrote it) and
+// lastShippedBody (the SSE producer wrote it under the same lock)
+// advance to the new body.
 func TestRunPerformBody_ViewChange_QueuesFrame(t *testing.T) {
-	// Toggle: first view call returns "a", subsequent return "b".
+	// Toggle: first view call returns "first", subsequent return "second".
 	// Bootstrap consumes the first; runPerformBody's view call gets
 	// the second — different body, so suppression should NOT fire.
 	callCount := 0
@@ -122,7 +158,7 @@ func TestRunPerformBody_ViewChange_QueuesFrame(t *testing.T) {
 		return velement("div", nil, []any{vtext("second")})
 	})
 	sess := performTestSession(app)
-	priorBody := sess.prevBody
+	priorShipped := sess.lastShippedBody
 	task := func() any { return 0 }
 	toMsg := func(r any) any { return r }
 	app.runPerformBody(sess, task, toMsg)
@@ -130,20 +166,23 @@ func TestRunPerformBody_ViewChange_QueuesFrame(t *testing.T) {
 	if frame == "" {
 		t.Fatalf("view-changing perform MUST queue an SSE frame; got none")
 	}
-	// Frame is a JSON envelope (seq + body + ackInputs); body should
-	// differ from the baseline.
-	if sess.prevBody == priorBody {
-		t.Fatalf("view changed but prevBody did not advance: %q == %q",
-			sess.prevBody, priorBody)
+	// Both fields must have advanced — and they must agree (the SSE
+	// producer ships whatever dispatch just computed).
+	if sess.lastShippedBody == priorShipped {
+		t.Fatalf("view changed but lastShippedBody did not advance: %q", priorShipped)
+	}
+	if sess.lastShippedBody != sess.lastComputedBody {
+		t.Fatalf("after view-changing ship the two fields must agree: shipped=%q computed=%q",
+			sess.lastShippedBody, sess.lastComputedBody)
 	}
 }
 
-// (c) sess.prevBody advances coherently across cycles.
+// (c) lastShippedBody advances coherently across cycles.
 //
 // Two consecutive view-changing perform cycles followed by a no-op
-// cycle. Pins that prevBody tracks the last rendered body so the
-// suppression check on cycle 3 correctly fires.
-func TestRunPerformBody_PrevBodyAdvancesCoherently(t *testing.T) {
+// cycle. Pins that lastShippedBody tracks the last body the client
+// received so the suppression check on cycle 3 correctly fires.
+func TestRunPerformBody_LastShippedAdvancesCoherently(t *testing.T) {
 	// View cycles through three distinct bodies on calls 1..3, then
 	// repeats body 3 on subsequent calls.
 	calls := 0
@@ -159,61 +198,62 @@ func TestRunPerformBody_PrevBodyAdvancesCoherently(t *testing.T) {
 		}
 	})
 	sess := performTestSession(app)
-	bodyA := sess.prevBody
+	bodyA := sess.lastShippedBody
 	task := func() any { return 0 }
 	toMsg := func(r any) any { return r }
 
-	// Cycle 1: A → B (view changes, frame ships, prevBody = B-body).
+	// Cycle 1: A → B (view changes, frame ships, lastShippedBody = B).
 	app.runPerformBody(sess, task, toMsg)
 	if drainFrame(sess, 100*time.Millisecond) == "" {
 		t.Fatalf("cycle 1: expected frame for A → B")
 	}
-	bodyB := sess.prevBody
+	bodyB := sess.lastShippedBody
 	if bodyB == bodyA {
-		t.Fatalf("cycle 1: prevBody must advance, A=%q B=%q", bodyA, bodyB)
+		t.Fatalf("cycle 1: lastShippedBody must advance, A=%q B=%q", bodyA, bodyB)
 	}
 
-	// Cycle 2: B → C (frame ships, prevBody = C-body).
+	// Cycle 2: B → C (frame ships, lastShippedBody = C).
 	app.runPerformBody(sess, task, toMsg)
 	if drainFrame(sess, 100*time.Millisecond) == "" {
 		t.Fatalf("cycle 2: expected frame for B → C")
 	}
-	bodyC := sess.prevBody
+	bodyC := sess.lastShippedBody
 	if bodyC == bodyB {
-		t.Fatalf("cycle 2: prevBody must advance, B=%q C=%q", bodyB, bodyC)
+		t.Fatalf("cycle 2: lastShippedBody must advance, B=%q C=%q", bodyB, bodyC)
 	}
 
-	// Cycle 3: C → C (view stable, no frame, prevBody stays C).
+	// Cycle 3: C → C (view stable, no frame, lastShippedBody stays C).
 	app.runPerformBody(sess, task, toMsg)
 	if frame := drainFrame(sess, 20*time.Millisecond); frame != "" {
 		t.Fatalf("cycle 3: identical-view perform must suppress; got %q", frame)
 	}
-	if sess.prevBody != bodyC {
-		t.Fatalf("cycle 3: prevBody must remain C, got %q want %q",
-			sess.prevBody, bodyC)
+	if sess.lastShippedBody != bodyC {
+		t.Fatalf("cycle 3: lastShippedBody must remain C, got %q want %q",
+			sess.lastShippedBody, bodyC)
 	}
 }
 
-// (d) Post-panic dispatch preserves the prior prevTree + prevBody.
+// (d) Post-panic dispatch preserves the prior prevTree +
+// lastComputedBody, and never touches lastShippedBody.
 //
 // Cycle 3 audit gap C1 residual #3: when dispatch's recover fires
 // (an update / view / runCmd panic), the prior valid prevTree and
-// prevBody MUST be restored so the next dispatch's suppression check
-// compares against the last successfully-rendered view. Without this
-// preservation, a post-panic dispatch's suppression baseline drifts:
-// prevTree may point at a partial-render new tree (line 2594 ran
-// before the panic) while prevBody is still the older valid body.
+// lastComputedBody MUST be restored so the next dispatch's diff
+// baseline is the last successfully-rendered view. Without this
+// preservation, a post-panic dispatch's baseline drifts: prevTree
+// may point at a partial-render new tree (line 2594 ran before the
+// panic) while lastComputedBody is still the older valid body.
 // The next dispatch would then see desynced fields.
 //
-// This test verifies: pre-panic baseline → panic dispatch (no frame,
-// invariants restored) → post-panic dispatch with the same view as
-// baseline correctly suppresses.
-func TestDispatch_PanicPreservesPrevBodyAndPrevTree(t *testing.T) {
+// lastShippedBody is independent — dispatch never writes it, so
+// the panic-rollback path doesn't touch it either. This test pins
+// that contract.
+func TestDispatch_PanicPreservesPrevTreeAndLastComputed(t *testing.T) {
 	panicArmed := false
 	app := &liveApp{
 		update: func(msg, model any) any {
 			if panicArmed {
-				panic("deliberate panic for prevBody preservation test")
+				panic("deliberate panic for invariant-preservation test")
 			}
 			return SkyTuple2{V0: model, V1: cmdT{kind: "none"}}
 		},
@@ -227,16 +267,20 @@ func TestDispatch_PanicPreservesPrevBodyAndPrevTree(t *testing.T) {
 		model:     "init",
 		handlers:  map[string]any{},
 	}
-	// Baseline dispatch: establishes prevTree + prevBody.
+	// Baseline dispatch: establishes prevTree + lastComputedBody.
 	baselineBody := app.dispatch(sess, "bootstrap")
-	if baselineBody == "" || sess.prevBody != baselineBody {
-		t.Fatalf("baseline must populate prevBody, got body=%q prevBody=%q",
-			baselineBody, sess.prevBody)
+	if baselineBody == "" || sess.lastComputedBody != baselineBody {
+		t.Fatalf("baseline must populate lastComputedBody, got body=%q lastComputedBody=%q",
+			baselineBody, sess.lastComputedBody)
 	}
 	baselineTreePtr := sess.prevTree
 	if baselineTreePtr == nil {
 		t.Fatalf("baseline must populate prevTree")
 	}
+	// Also seed lastShippedBody (mirror the production initial-mount
+	// path) so we can pin "panic recovery doesn't touch it".
+	sess.lastShippedBody = baselineBody
+	shippedSentinel := sess.lastShippedBody
 
 	// Arm the panic and dispatch. Recover catches it; body returns "".
 	panicArmed = true
@@ -244,14 +288,91 @@ func TestDispatch_PanicPreservesPrevBodyAndPrevTree(t *testing.T) {
 	if panicBody != "" {
 		t.Fatalf("panic dispatch must yield empty body, got %q", panicBody)
 	}
-	// Critical invariant: prevTree + prevBody must be preserved.
-	if sess.prevBody != baselineBody {
-		t.Fatalf("post-panic: prevBody must be restored to baseline %q, got %q",
-			baselineBody, sess.prevBody)
+	// Critical invariant: prevTree + lastComputedBody must be restored.
+	if sess.lastComputedBody != baselineBody {
+		t.Fatalf("post-panic: lastComputedBody must be restored to baseline %q, got %q",
+			baselineBody, sess.lastComputedBody)
 	}
 	if sess.prevTree != baselineTreePtr {
 		t.Fatalf("post-panic: prevTree pointer must be restored to baseline %p, got %p",
 			baselineTreePtr, sess.prevTree)
 	}
+	// lastShippedBody is dispatch's no-touch zone — the panic-
+	// recovery path must not clobber it.
+	if sess.lastShippedBody != shippedSentinel {
+		t.Fatalf("post-panic: lastShippedBody is dispatch's no-touch zone; "+
+			"prior %q, now %q", shippedSentinel, sess.lastShippedBody)
+	}
 }
 
+// (e) Suppressed dispatch — dispatch advances lastComputedBody to the
+// just-rendered value, but lastShippedBody stays at whatever the SSE
+// producer last set. This is the Gap C2 invariant: the two fields
+// are NOT in lockstep, and any future cleanup that re-fused them
+// (e.g. "only write lastComputedBody when shipping") would silently
+// break suppression of identical views.
+//
+// Scenario: a runPerformBody whose dispatch re-renders the SAME view
+// the client already has must leave lastShippedBody at its prior
+// value, while lastComputedBody gets the freshly-computed (identical)
+// value. The two fields happen to be byte-equal here, but the
+// SEMANTIC distinction (separate writers) is what the test pins.
+func TestRunPerformBody_SuppressedDispatch_OnlyComputedAdvances(t *testing.T) {
+	app := performTestApp(func(model any) any {
+		return velement("div", nil, []any{vtext("stable-view")})
+	})
+	sess := performTestSession(app)
+	// Force a divergence so we can observe the "shipped is untouched"
+	// invariant clearly: pretend the client last received a DIFFERENT
+	// body. The next perform's dispatch will compute "stable-view"
+	// (same as baseline lastComputedBody), but lastShippedBody is the
+	// sentinel — suppression check (body != lastShippedBody) returns
+	// "differ → ship". After the ship, lastShippedBody advances to
+	// the just-shipped body.
+	//
+	// Then we run a SECOND perform with the same view. dispatch
+	// re-renders the same HTML; lastComputedBody is overwritten with
+	// the same value; suppression check fires (body == lastShippedBody);
+	// lastShippedBody stays put.
+	sess.lastShippedBody = "<sentinel-the-client-actually-has-this>"
+	task := func() any { return 0 }
+	toMsg := func(r any) any { return r }
+
+	// Cycle 1: dispatch's body differs from sentinel → ships.
+	app.runPerformBody(sess, task, toMsg)
+	if drainFrame(sess, 100*time.Millisecond) == "" {
+		t.Fatalf("cycle 1: body differs from sentinel, must ship")
+	}
+	shippedAfterCycle1 := sess.lastShippedBody
+	if shippedAfterCycle1 == "<sentinel-the-client-actually-has-this>" {
+		t.Fatalf("cycle 1: lastShippedBody must advance off the sentinel")
+	}
+	computedAfterCycle1 := sess.lastComputedBody
+	if computedAfterCycle1 != shippedAfterCycle1 {
+		t.Fatalf("cycle 1: post-ship the two fields must agree: shipped=%q computed=%q",
+			shippedAfterCycle1, computedAfterCycle1)
+	}
+
+	// Cycle 2: dispatch re-renders the same view → suppression fires;
+	// lastComputedBody is rewritten with the SAME value; lastShippedBody
+	// is untouched. The distinction matters: if a future refactor made
+	// dispatch skip the lastComputedBody write on suppression, every
+	// subsequent diff baseline would drift. Pin that dispatch always
+	// writes lastComputedBody.
+	preCycle2Computed := sess.lastComputedBody
+	preCycle2Shipped := sess.lastShippedBody
+	app.runPerformBody(sess, task, toMsg)
+	if frame := drainFrame(sess, 20*time.Millisecond); frame != "" {
+		t.Fatalf("cycle 2: identical-view perform must suppress, got frame %q", frame)
+	}
+	// lastShippedBody untouched.
+	if sess.lastShippedBody != preCycle2Shipped {
+		t.Fatalf("cycle 2: suppressed dispatch must NOT mutate lastShippedBody: "+
+			"prior %q, now %q", preCycle2Shipped, sess.lastShippedBody)
+	}
+	// lastComputedBody re-written (to the same value — dispatch always writes).
+	if sess.lastComputedBody != preCycle2Computed {
+		t.Fatalf("cycle 2: dispatch must write lastComputedBody (idempotently): "+
+			"prior %q, now %q", preCycle2Computed, sess.lastComputedBody)
+	}
+}

--- a/runtime-go/rt/live_store_delete_test.go
+++ b/runtime-go/rt/live_store_delete_test.go
@@ -175,7 +175,8 @@ func TestEveryGoroutine_exitsOnDelete(t *testing.T) {
 		sseCh:     make(chan string, 16),
 		cancelSub: make(chan struct{}),
 		done:      make(chan struct{}),
-		prevBody:  "<div>hi</div>",
+		lastComputedBody: "<div>hi</div>",
+		lastShippedBody:  "<div>hi</div>",
 	}
 	app.store.Set("sid-leak", sess)
 
@@ -250,7 +251,8 @@ func TestEveryGoroutine_exitsOnCleanupExpiry(t *testing.T) {
 		sseCh:     make(chan string, 16),
 		cancelSub: make(chan struct{}),
 		done:      make(chan struct{}),
-		prevBody:  "<div>hi</div>",
+		lastComputedBody: "<div>hi</div>",
+		lastShippedBody:  "<div>hi</div>",
 	}
 	app.store.Set("sid-expire", sess)
 	app.setupSubscriptions(sess)


### PR DESCRIPTION
## Cycle 3 P39 — Sky.Live `prevBody` dual-meaning rename

Closes Cycle 3 audit **Gap C2** (high severity). See
`docs/v0.15.x-hardening/audits/CYCLE-03-auditor.md` §C2 and
`docs/v0.15.x-hardening/plans/CYCLE-03-planner.md` §P39 for the full
diagnosis.

### Problem

`sess.prevBody` was overloaded — it served as **both** "the most
recently rendered body" (set by dispatch post-render) **and** "the
most recently shipped body" (compared against in the SSE producer
suppression check). The two meanings coincided today only because
`dispatch` unconditionally wrote `prevBody` after every render; a
future cleanup that made dispatch skip the write (e.g. "only update
on actual ship") would silently break suppression of every
byte-identical view.

This dual meaning bit the v0.15.14 + v0.15.17 suppression work — the
audit flagged it as load-bearing implicit coupling between two
unrelated invariants.

### Fix

Split the field into two distinct invariants:

| Field | Writer | Semantics |
|---|---|---|
| `lastComputedBody` | every `dispatch` / `renderView` / `handleInitial` / SSE reconnect-resync | "just-rendered HTML" — mirrors `prevTree`. Rolled back on dispatch panic so a partial render doesn't poison the next diff baseline. |
| `lastShippedBody` | only the call sites that actually send a body to the client: `sseCh` enqueue from `dispatchBatched` / `runPerformBody` / tick subscription; direct HTTP-response writes from `handleInitial` / `handleEvent` (the `/_sky/event` POST path) / SSE reconnect-resync | "last body the client received" — what suppression compares against. |

Suppression checks now compare against `lastShippedBody` — the value
the client actually received. After every actual ship, both fields
agree; between the two there is now a documented gap that future
refactors must respect.

### Behaviour preservation

Wire behaviour is identical. Every prior site that wrote `prevBody`
now writes whichever field matches its semantic role:

- `handleInitial` / SSE reconnect-resync: **both** (they directly
  push a full body to the client).
- `dispatch` post-render: only `lastComputedBody` (dispatch never
  ships).
- `dispatch` panic-rollback: only `lastComputedBody` (dispatch never
  shipped, so `lastShippedBody` was already correct).
- `dispatchBatched`, `runPerformBody`, tick subscription: write
  `lastShippedBody` **iff** they enqueue a frame to `sseCh`.
- `handleEvent` (`/_sky/event` POST): writes `lastShippedBody` (the
  POST response carries the body straight to the client — equivalent
  to a ship for the suppression contract). Skipped on `body2 == ""`
  no-op dispatches.

### New regression test

`TestRunPerformBody_SuppressedDispatch_OnlyComputedAdvances` pins
the C2 invariant directly: a suppressed dispatch advances
`lastComputedBody` (proving dispatch always writes it) but leaves
`lastShippedBody` untouched (proving the split is real and not
cosmetic).

The four existing perform-suppression tests are reshaped to assert
on the new field names with clear semantics; the test session
helper now mirrors the production initial-mount path by seeding
**both** fields, surfacing a subtle gap the old test had masked.

### Verification

| Gate | Result |
|---|---|
| `cd runtime-go && go test ./rt -count=1 -timeout 60s -run 'Perform\|Dispatch'` | 13/13 pass |
| `cd runtime-go && go test ./rt -count=1` | only pre-existing `TestTime_*` timezone flakes fail — matches baseline on `main` |
| `cd runtime-go && go test ./rt -race -run 'Perform\|Dispatch\|Live\|SSE'` | green |
| `go build ./...` + `go vet ./rt` | clean |

The pre-existing `TestConcurrentEventsSerialise` race at
`live_store.go:288` reproduces on `main` (verified by stashing) — out
of P39 scope, surface for a future audit cycle.

### Release note

**DO NOT TAG** — per the new batched-release cadence
(`docs/v0.15.x-hardening/README.md` §"Release cadence (revised
2026-05-26)"), this PR batches with the rest of the Sky.Live runtime
hardening sweep. Merge to `main` only.

Refs: Cycle 3 audit (a78968e), planner item P39.
