### PR TITLE
refactor(live): commitRender helper unifying render-snapshot-ship pattern (Cycle 3 P40)

### DIFF
--- a/runtime-go/rt/live.go
+++ b/runtime-go/rt/live.go
@@ -1361,6 +1361,45 @@ func (s *liveSession) nextOutSeq() int64 {
 	return s.outSeq
 }
 
+// commitRender writes both `prevTree` and `lastComputedBody` as a single
+// atomic step. Caller MUST hold sess.mu so the two fields are observed
+// in lockstep by any concurrent reader holding the same mutex.
+//
+// Cycle 3 P40 / Gap C7: prior to extraction, this 2-field invariant was
+// fanned out across FIVE call sites (handleInitial, dispatch's late
+// write at the end of the success path, dispatch's handler-rebuild
+// branch in handleEvent, the same rebuild in dispatchBatched, the SSE
+// reconnect-resync in handleSSE, and renderView's guard-rejected path).
+// Each site re-implemented "render → set prevTree → maybe set body"
+// with subtle variations:
+//
+//   - dispatch wrote prevTree EARLY (pre-runCmd) and lastComputedBody
+//     LATE (post-setupSubscriptions), with a panic-rollback snapshot
+//     bracketing both writes.
+//   - renderView wrote ONLY prevTree, leaving lastComputedBody stale
+//     against the freshly-rendered tree — a silent contract break that
+//     the audit (Cycle 3 C7) called out specifically.
+//   - The handler-rebuild branches in handleEvent + dispatchBatched
+//     discarded the rebuilt body entirely, leaving lastComputedBody
+//     pointing at whatever the prior dispatch (potentially in a prior
+//     process, decoded from sqlite/redis/postgres) had written. After
+//     P40 these write the rebuilt body too, strengthening the invariant.
+//
+// `lastShippedBody` is INTENTIONALLY NOT touched here — it tracks "last
+// body the client actually received" (post-P39 / Gap C2), an invariant
+// owned by the SSE-producing call sites (dispatchBatched, runPerformBody,
+// the Time.every tick goroutine, handleInitial's HTTP-response write,
+// handleSSE's reconnect-resync push). Those sites still write
+// `lastShippedBody` explicitly after commitRender so the "computed vs
+// shipped" split stays explicit at every callsite that ships.
+//
+// vn MUST NOT be nil; passing nil would corrupt the diff baseline used
+// by every subsequent dispatch.
+func (s *liveSession) commitRender(vn *VNode, body string) {
+	s.prevTree = vn
+	s.lastComputedBody = body
+}
+
 // ingestInputState absorbs the client's dirty-input snapshot into
 // sess.inputSeqs, retaining the larger seq per id. No state is lost
 // on concurrent events because every caller holds sess.mu.
@@ -2158,11 +2197,10 @@ func (app *liveApp) handleInitial(w http.ResponseWriter, r *http.Request) {
 	vn := HtmlToVNode(sky_call(app.view, model))
 	assignSkyIDs(&vn, "r")
 	body := renderVNode(vn, sess.handlers)
-	sess.prevTree = &vn
 	// Initial mount writes the full HTML directly into the HTTP
 	// response below — the client receives this body as the page,
 	// so it counts as BOTH "last computed" and "last shipped".
-	sess.lastComputedBody = body
+	sess.commitRender(&vn, body)
 	sess.lastShippedBody = body
 	app.store.Set(sid, sess)
 
@@ -2336,8 +2374,13 @@ func (app *liveApp) handleEvent(w http.ResponseWriter, r *http.Request) {
 		sess.handlers = map[string]any{}
 		vn := HtmlToVNode(sky_call(app.view, sess.model))
 		assignSkyIDs(&vn, "r")
-		_ = renderVNode(vn, sess.handlers)
-		sess.prevTree = &vn
+		body := renderVNode(vn, sess.handlers)
+		// Route through commitRender (Cycle 3 P40 / Gap C7) so
+		// the rebuilt-handlers branch keeps prevTree +
+		// lastComputedBody coherent. Previously the body was
+		// discarded, so lastComputedBody pointed at whatever the
+		// prior process (or prior dispatch) had written.
+		sess.commitRender(&vn, body)
 	}
 	msg, ok := sess.handlers[req.HandlerID]
 	if !ok && req.Msg != "" && req.HandlerID == "" {
@@ -2521,8 +2564,12 @@ func (app *liveApp) dispatchBatched(sess *liveSession, ev batchedEvent) {
 		sess.handlers = map[string]any{}
 		vn := HtmlToVNode(sky_call(app.view, sess.model))
 		assignSkyIDs(&vn, "r")
-		_ = renderVNode(vn, sess.handlers)
-		sess.prevTree = &vn
+		body := renderVNode(vn, sess.handlers)
+		// Route through commitRender (Cycle 3 P40 / Gap C7) so
+		// the rebuilt-handlers branch keeps prevTree +
+		// lastComputedBody coherent — same shape as the
+		// handleEvent rebuild above.
+		sess.commitRender(&vn, body)
 	}
 	msg, ok := sess.handlers[ev.HandlerID]
 	if !ok && ev.Msg != "" && ev.HandlerID == "" {
@@ -2670,9 +2717,10 @@ func (app *liveApp) dispatch(sess *liveSession, msg any) (body string) {
 			// Roll back the view invariants. The current dispatch has
 			// failed; the prior valid prevTree / lastComputedBody must
 			// remain the source of truth for the next dispatch's
-			// suppression and diff baseline.
-			sess.prevTree = prevTreeOnEntry
-			sess.lastComputedBody = prevComputedOnEntry
+			// suppression and diff baseline. Route through commitRender
+			// (Cycle 3 P40 / Gap C7) so the rollback path follows the
+			// same atomic-pair contract as every other write site.
+			sess.commitRender(prevTreeOnEntry, prevComputedOnEntry)
 		}
 		ObserveMsgLog(msgLogCtx, sess.model, finalCmd, dispatchErr)
 	}()
@@ -2718,11 +2766,18 @@ func (app *liveApp) dispatch(sess *liveSession, msg any) (body string) {
 	vn := HtmlToVNode(sky_call(app.view, sess.model))
 	assignSkyIDs(&vn, "r")
 	body = renderVNode(vn, sess.handlers)
-	sess.prevTree = &vn
-	// Process Cmds (may spawn goroutines)
-	app.runCmd(sess, cmd)
-	// Re-evaluate subscriptions based on new model
-	app.setupSubscriptions(sess)
+	// Commit prevTree + lastComputedBody as one atomic step (Cycle 3
+	// P40 / Gap C7). Previously this was two separate writes — prevTree
+	// here, lastComputedBody after runCmd + setupSubscriptions — which
+	// left a window where the two fields could be observed desynced
+	// (handled by the panic-rollback snapshot above, but fragile).
+	//
+	// runCmd + setupSubscriptions don't read prevTree or
+	// lastComputedBody synchronously (they spawn goroutines that
+	// acquire sess.mu later), so consolidating the write here is
+	// behaviourally equivalent to the prior split and tightens the
+	// invariant window.
+	//
 	// No-op suppression: previously we short-circuited on
 	// `body == sess.prevBody` (byte-equality) so a Time.every tick
 	// without view-reachable state changes wouldn't push a redundant
@@ -2747,18 +2802,29 @@ func (app *liveApp) dispatch(sess *liveSession, msg any) (body string) {
 	// SSE producer's job (post-P39 / Gap C2). Suppression callers
 	// compare against the last value the client actually received,
 	// not against this just-computed value.
-	sess.lastComputedBody = body
+	sess.commitRender(&vn, body)
+	// Process Cmds (may spawn goroutines)
+	app.runCmd(sess, cmd)
+	// Re-evaluate subscriptions based on new model
+	app.setupSubscriptions(sess)
 	return body
 }
 
 // renderView: re-render from current session model without updating
 // the model (used by dispatch when guard short-circuits).
+//
+// Routes through commitRender (Cycle 3 P40 / Gap C7) so the guard-
+// rejected path keeps prevTree + lastComputedBody coherent.
+// Previously this wrote ONLY prevTree, leaving lastComputedBody
+// pointing at the prior dispatch's body even though the just-
+// rendered tree had just replaced prevTree — a silent contract
+// break the audit explicitly flagged.
 func (app *liveApp) renderView(sess *liveSession) string {
 	sess.handlers = map[string]any{}
 	vn := HtmlToVNode(sky_call(app.view, sess.model))
 	assignSkyIDs(&vn, "r")
 	body := renderVNode(vn, sess.handlers)
-	sess.prevTree = &vn
+	sess.commitRender(&vn, body)
 	return body
 }
 
@@ -3046,12 +3112,11 @@ func (app *liveApp) handleSSE(w http.ResponseWriter, r *http.Request) {
 			assignSkyIDs(&vn, "r")
 			sess.handlers = map[string]any{}
 			body := renderVNode(vn, sess.handlers)
-			sess.prevTree = &vn
 			// Reconnect-resync writes the resync frame DIRECTLY to
 			// the SSE response writer below — so this body is both
 			// just-computed AND just-shipped, and the next tick's
 			// suppression must compare against it.
-			sess.lastComputedBody = body
+			sess.commitRender(&vn, body)
 			sess.lastShippedBody = body
 			frame := encodeSSEFrame(sess, body)
 			// Encode + write while still under lock to avoid interleaving

--- a/runtime-go/rt/live_commit_render_test.go
+++ b/runtime-go/rt/live_commit_render_test.go
@@ -1,0 +1,284 @@
+package rt
+
+// Cycle 3 P40 / Gap C7 — commitRender helper unifies the 5+
+// "render → set prevTree + lastComputedBody" call sites.
+//
+// The audit's diagnosis was that the 2-field invariant (prevTree +
+// lastComputedBody MUST point at the same render) was fanned out across
+// FIVE writes, each with slightly different shapes. v0.15.14's multi-
+// shape regression originated from exactly this fan-out: a refactor
+// touched ONE callsite without recognising the contract bound all of
+// them. After P40 every site routes through a single helper that
+// documents the invariant.
+//
+// This file pins:
+//
+//   (a) commitRender writes BOTH fields with no observable mid-call
+//       torn state (Test_CommitRender_Atomic).
+//   (b) commitRender preserves lastShippedBody (the SSE-producer's
+//       independent invariant per P39 / Gap C2 — Test_CommitRender_
+//       LeavesLastShippedUntouched).
+//   (c) Every consumer of the helper observes the joint write under
+//       sess.mu (Test_CommitRender_PerCallsite_*: handleInitial,
+//       renderView, dispatch, handler-rebuild branches, SSE resync).
+//
+// The contract under test: prevTree and lastComputedBody must update
+// together. A reader holding sess.mu must never see prevTree updated
+// without lastComputedBody also updated (or vice versa).
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Test_CommitRender_Atomic: a parallel reader holding sess.mu
+// briefly should never observe prevTree != lastComputedBody's "expected
+// pair". We assert the helper writes both under the caller's lock so
+// the joint observation is consistent.
+//
+// Under sess.mu, no concurrent reader can ever see the fields desynced
+// because Go's memory model guarantees writes inside a locked region
+// are observed in order by another goroutine acquiring the same lock.
+// The test below exercises that contract: writer goroutine holds the
+// lock through commitRender; reader goroutine acquires the lock and
+// checks both fields. Across many iterations, every observation is
+// either the pre-state OR the post-state — never a partial mix.
+func Test_CommitRender_Atomic(t *testing.T) {
+	sess := &liveSession{}
+	// Pre-state: tree pointer A, body "A".
+	treeA := velement("div", nil, []any{vtext("A")})
+	bodyA := "<div>A</div>"
+	sess.mu.Lock()
+	sess.commitRender(&treeA, bodyA)
+	sess.mu.Unlock()
+	// Post-state to swap to: tree pointer B, body "B".
+	treeB := velement("div", nil, []any{vtext("B")})
+	bodyB := "<div>B</div>"
+
+	var torn atomic.Int64
+	var iters atomic.Int64
+	stop := make(chan struct{})
+
+	// Reader: continually observes the (prevTree, lastComputedBody)
+	// pair under sess.mu. If a torn read ever happens (prevTree from
+	// one render, body from another), torn increments.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			sess.mu.Lock()
+			pt := sess.prevTree
+			lb := sess.lastComputedBody
+			sess.mu.Unlock()
+			iters.Add(1)
+			// Valid pairs: (&treeA, bodyA) or (&treeB, bodyB).
+			okA := pt == &treeA && lb == bodyA
+			okB := pt == &treeB && lb == bodyB
+			if !okA && !okB {
+				torn.Add(1)
+			}
+		}
+	}()
+
+	// Writer: oscillates between the two valid pairs for 200ms,
+	// always under sess.mu — so the reader's lock-held observation
+	// must never catch an intermediate (prevTree updated but body
+	// not, or vice versa).
+	deadline := time.Now().Add(200 * time.Millisecond)
+	useB := true
+	for time.Now().Before(deadline) {
+		sess.mu.Lock()
+		if useB {
+			sess.commitRender(&treeB, bodyB)
+		} else {
+			sess.commitRender(&treeA, bodyA)
+		}
+		sess.mu.Unlock()
+		useB = !useB
+	}
+	close(stop)
+	wg.Wait()
+
+	if torn.Load() != 0 {
+		t.Fatalf("commitRender exposed torn state in %d / %d observations",
+			torn.Load(), iters.Load())
+	}
+	if iters.Load() < 100 {
+		t.Fatalf("reader didn't run enough iterations to exercise the race window: %d", iters.Load())
+	}
+}
+
+// Test_CommitRender_LeavesLastShippedUntouched: commitRender writes the
+// "computed" pair but MUST NOT touch lastShippedBody. That field is
+// owned by the SSE-producing callers (P39 / Gap C2 invariant split).
+func Test_CommitRender_LeavesLastShippedUntouched(t *testing.T) {
+	sess := &liveSession{}
+	// Seed lastShippedBody with a sentinel value.
+	sentinel := "<!-- shipped sentinel -->"
+	sess.lastShippedBody = sentinel
+
+	tree := velement("div", nil, []any{vtext("render")})
+	body := "<div>render</div>"
+	sess.mu.Lock()
+	sess.commitRender(&tree, body)
+	sess.mu.Unlock()
+
+	if sess.prevTree != &tree {
+		t.Fatalf("commitRender did not set prevTree (got %p, want %p)", sess.prevTree, &tree)
+	}
+	if sess.lastComputedBody != body {
+		t.Fatalf("commitRender did not set lastComputedBody (got %q, want %q)",
+			sess.lastComputedBody, body)
+	}
+	if sess.lastShippedBody != sentinel {
+		t.Fatalf("commitRender MUST NOT touch lastShippedBody: sentinel=%q now=%q",
+			sentinel, sess.lastShippedBody)
+	}
+}
+
+// Test_CommitRender_PerCallsite_HandleInitialShape exercises the
+// handleInitial pattern: commitRender followed by an explicit
+// lastShippedBody = body write (since the body IS the HTTP response).
+// Pins that both "computed" and "shipped" fields end up equal — the
+// initial-mount invariant.
+func Test_CommitRender_PerCallsite_HandleInitialShape(t *testing.T) {
+	sess := &liveSession{}
+	tree := velement("div", nil, []any{vtext("initial mount")})
+	body := "<div>initial mount</div>"
+	// Mirror the handleInitial sequence.
+	sess.mu.Lock()
+	sess.commitRender(&tree, body)
+	sess.lastShippedBody = body
+	sess.mu.Unlock()
+	if sess.lastComputedBody != body || sess.lastShippedBody != body {
+		t.Fatalf("initial-mount: computed=%q shipped=%q want both=%q",
+			sess.lastComputedBody, sess.lastShippedBody, body)
+	}
+}
+
+// Test_CommitRender_PerCallsite_RenderViewShape exercises the
+// guard-rejected renderView path: commitRender alone, no
+// lastShippedBody write (the body is returned to dispatch's caller via
+// the HTTP /_sky/event response; the SSE producer doesn't run).
+// Pins that lastShippedBody stays untouched while lastComputedBody
+// advances to the just-rendered body.
+func Test_CommitRender_PerCallsite_RenderViewShape(t *testing.T) {
+	sess := &liveSession{}
+	priorShipped := "<!-- prior shipped -->"
+	sess.lastShippedBody = priorShipped
+
+	tree := velement("div", nil, []any{vtext("guard-rejected re-render")})
+	body := "<div>guard-rejected re-render</div>"
+	sess.mu.Lock()
+	sess.commitRender(&tree, body)
+	sess.mu.Unlock()
+
+	if sess.lastComputedBody != body {
+		t.Fatalf("renderView shape: lastComputedBody must advance to %q, got %q",
+			body, sess.lastComputedBody)
+	}
+	if sess.lastShippedBody != priorShipped {
+		t.Fatalf("renderView shape: lastShippedBody MUST stay at %q, got %q",
+			priorShipped, sess.lastShippedBody)
+	}
+}
+
+// Test_CommitRender_DispatchEndToEnd: drive a real dispatch and verify
+// the commitRender consolidation kept dispatch's invariants intact.
+// dispatch writes both fields via commitRender just before runCmd; the
+// return value matches the just-committed body; lastShippedBody is
+// untouched (dispatch's contract per P39).
+func Test_CommitRender_DispatchEndToEnd(t *testing.T) {
+	app := &liveApp{
+		update: func(msg, model any) any {
+			return SkyTuple2{V0: model, V1: cmdT{kind: "none"}}
+		},
+		view: func(model any) any {
+			return velement("div", nil, []any{vtext("end-to-end")})
+		},
+	}
+	sess := &liveSession{
+		cancelSub: make(chan struct{}),
+		sseCh:     make(chan string, 16),
+		model:     "init",
+		handlers:  map[string]any{},
+	}
+	priorShipped := "<!-- prior shipped, dispatch must not touch -->"
+	sess.lastShippedBody = priorShipped
+
+	body := app.dispatch(sess, "go")
+	if body == "" {
+		t.Fatalf("dispatch returned empty body")
+	}
+	// Both fields written by commitRender must equal the returned body.
+	if sess.lastComputedBody != body {
+		t.Fatalf("dispatch: lastComputedBody (%q) must equal returned body (%q)",
+			sess.lastComputedBody, body)
+	}
+	if sess.prevTree == nil {
+		t.Fatalf("dispatch: prevTree must be set after a successful render")
+	}
+	// dispatch never writes lastShippedBody (Gap C2 invariant).
+	if sess.lastShippedBody != priorShipped {
+		t.Fatalf("dispatch: lastShippedBody must stay at %q, got %q",
+			priorShipped, sess.lastShippedBody)
+	}
+}
+
+// Test_CommitRender_DispatchPanicRollsBackViaHelper: ensure the panic-
+// recovery path inside dispatch routes its rollback through commitRender
+// too — so the rollback observes the same atomic-pair contract as every
+// other write site. Without this, a future maintainer could "optimise"
+// the rollback to write only one field, silently re-introducing the
+// torn-state class.
+func Test_CommitRender_DispatchPanicRollsBackViaHelper(t *testing.T) {
+	armed := false
+	app := &liveApp{
+		update: func(msg, model any) any {
+			if armed {
+				panic("deliberate panic for rollback test")
+			}
+			return SkyTuple2{V0: model, V1: cmdT{kind: "none"}}
+		},
+		view: func(model any) any {
+			return velement("div", nil, []any{vtext("stable view")})
+		},
+	}
+	sess := &liveSession{
+		cancelSub: make(chan struct{}),
+		sseCh:     make(chan string, 16),
+		model:     "init",
+		handlers:  map[string]any{},
+	}
+	// Baseline: commits prevTree + lastComputedBody via the consolidated
+	// commitRender call.
+	baseline := app.dispatch(sess, "bootstrap")
+	baselineTreePtr := sess.prevTree
+	if baseline == "" || baselineTreePtr == nil {
+		t.Fatalf("baseline must populate the pair")
+	}
+
+	// Arm: panic INSIDE update. dispatch's recover should restore both
+	// fields to baseline atomically via commitRender.
+	armed = true
+	if got := app.dispatch(sess, "explode"); got != "" {
+		t.Fatalf("panicking dispatch must return empty body, got %q", got)
+	}
+	// Pair invariant preserved:
+	if sess.lastComputedBody != baseline {
+		t.Fatalf("rollback: lastComputedBody must be restored to baseline %q, got %q",
+			baseline, sess.lastComputedBody)
+	}
+	if sess.prevTree != baselineTreePtr {
+		t.Fatalf("rollback: prevTree pointer must be restored to baseline %p, got %p",
+			baselineTreePtr, sess.prevTree)
+	}
+}


### PR DESCRIPTION
## Cycle 3 P40 — `commitRender` helper unifying render-snapshot-ship pattern

Closes Cycle 3 audit gap **C7** (medium severity).

### Audit diagnosis

`prevTree` + `lastComputedBody` writes were fanned out across **six** call sites:

1. `handleInitial` (live.go:2161-2166) — writes both + `lastShippedBody`.
2. `handleEvent`'s handler-rebuild branch — writes prevTree only, discards rebuilt body.
3. `dispatchBatched`'s handler-rebuild branch — same shape as #2.
4. `dispatch`'s success path — writes prevTree EARLY (pre-runCmd), `lastComputedBody` LATE (post-setupSubscriptions), with a panic-rollback snapshot bracketing both writes.
5. `renderView` (guard-rejected path) — writes prevTree ONLY, leaving `lastComputedBody` stale against the freshly-rendered tree (silent contract break the audit explicitly flagged).
6. `handleSSE` reconnect-resync — writes both + `lastShippedBody`.

Each site re-implemented the same "render → set prevTree → maybe set body" pattern with subtle variations. v0.15.14's multi-shape regression originated in exactly this fan-out: the diff path's attrs-only sweep missed events-toggles because no single shared commit step asserted the invariant.

### Helper signature

```go
// commitRender writes both `prevTree` and `lastComputedBody` as a single
// atomic step. Caller MUST hold sess.mu so the two fields are observed
// in lockstep by any concurrent reader holding the same mutex.
//
// `lastShippedBody` is INTENTIONALLY NOT touched here — it tracks "last
// body the client actually received" (post-P39 / Gap C2), an invariant
// owned by the SSE-producing call sites. Those sites still write
// `lastShippedBody` explicitly after commitRender.
func (s *liveSession) commitRender(vn *VNode, body string)
```

### Before / after callsite count

| Site | Before | After |
|---|---|---|
| handleInitial | `prevTree = &vn; lastComputedBody = body; lastShippedBody = body` (3 lines) | `commitRender(&vn, body); lastShippedBody = body` (2 lines) |
| handleEvent rebuild | `_ = renderVNode(...); prevTree = &vn` (discards body) | `body := renderVNode(...); commitRender(&vn, body)` |
| dispatchBatched rebuild | same as handleEvent | same |
| dispatch success path | split writes pre+post runCmd (2 separate sites) | single `commitRender` after renderVNode, before runCmd |
| dispatch panic rollback | `prevTree = ...; lastComputedBody = ...` (2 lines) | `commitRender(prevTreeOnEntry, prevComputedOnEntry)` |
| renderView | `prevTree = &vn` (one field only — silent contract break) | `commitRender(&vn, body)` (both fields) |
| handleSSE resync | `prevTree = &vn; lastComputedBody = body; lastShippedBody = body` | `commitRender(&vn, body); lastShippedBody = body` |

**Net diff:** +83 / -18 LOC on live.go (mostly doc-comments documenting the invariant); +284 LOC test file.

### Behaviour-preserving notes

- **dispatch consolidation:** previously prevTree wrote pre-runCmd, body wrote post-setupSubscriptions. runCmd + setupSubscriptions don't read either field synchronously (they spawn goroutines that acquire `sess.mu` later), so consolidating the write to a single commitRender call before runCmd is behaviourally equivalent and tightens the panic-rollback window.
- **Rebuild branches:** previously discarded the rebuilt body via `_ = renderVNode(...)`. After P40 they capture the body and call `commitRender`. `lastComputedBody` now reflects the rebuilt view rather than whatever the prior process (decoded from sqlite/redis/postgres) had written. Strengthens the invariant.
- **renderView:** previously wrote ONLY prevTree, leaving `lastComputedBody` stale. After P40 writes both atomically — a correction of the silent contract break the audit explicitly flagged.
- **Panic rollback:** routes through `commitRender` too, so a future maintainer cannot silently regress to one-field rollback.

### Tests

New file `runtime-go/rt/live_commit_render_test.go` (6/6 PASS under `-race`):

- `Test_CommitRender_Atomic` — parallel reader holding `sess.mu` over an oscillating commitRender writer never observes torn state (load-bearing: pins the atomicity contract).
- `Test_CommitRender_LeavesLastShippedUntouched` — `lastShippedBody` sentinel preserved (per the P39 / Gap C2 split).
- `Test_CommitRender_PerCallsite_HandleInitialShape` — initial-mount sequence lands both fields equal.
- `Test_CommitRender_PerCallsite_RenderViewShape` — guard-rejected shape advances `lastComputedBody` but leaves `lastShippedBody` untouched.
- `Test_CommitRender_DispatchEndToEnd` — end-to-end dispatch through the consolidated call site preserves all invariants.
- `Test_CommitRender_DispatchPanicRollsBackViaHelper` — pin that the panic-rollback path routes through `commitRender`.

### Local verification

- `go test -race ./rt -run Test_CommitRender` — 6/6 PASS.
- `go test -race ./rt -run 'RunPerformBody|Dispatch'` — existing 13/13 PASS.
- `go test ./rt` — only pre-existing `TestTime_CalendarAdd` / `TestTime_StartOfDay` / `TestConcurrentEventsSerialise` flakes fail (confirmed identical on `main` without these changes — kept clone for the comparison, baseline matches).
- `cabal test` — **379 examples / 0 failures / 1 pending** (matches prior baseline).
- `examples/09-live-counter`: clean build; HTTP 200 initial render; `Increment` / `Decrement` / `Reset` dispatch + minimal diff patches (`{"id":"r.1#div.1#div.0#div.1#div.0#span","text":"<n>"}`); two consecutive `Reset` events return `{"patches":[]}` (suppression contract preserved); SSE handshake + reconnect-resync push functional.

### Scope

Scoped strictly to `runtime-go/rt/`. No compiler-side changes; no behaviour change for any wire-protocol-observable path.

### Release cadence

**DO NOT TAG** — batches with future Sky.Live runtime hardening per the cadence revision in `docs/v0.15.x-hardening/README.md` (2026-05-26).

---

Audit reference: `docs/v0.15.x-hardening/audits/CYCLE-03-auditor.md` § Gap C7 (line 244).
Plan reference: `docs/v0.15.x-hardening/plans/CYCLE-03-planner.md` § Item P40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
