### PR TITLE
refactor(compile): snapshotCallerCtx helper unifies LowerCtx ref snapshot (Cycle 3 P38)

### DIFF
--- a/sky-compiler.cabal
+++ b/sky-compiler.cabal
@@ -297,6 +297,7 @@ test-suite sky-tests
       Sky.Build.CoerceArgListMapInterplaySpec
       Sky.Build.LowerCtxCascadeSpec
       Sky.Build.LetBodyCascadeResumeSpec
+      Sky.Build.SnapshotCallerCtxSpec
       Sky.Build.SkyshopCompilesSpec
       Sky.Build.AnonLambdaSpec
       Sky.Build.AnonRecordSpec

--- a/src/Sky/Build/Compile.hs
+++ b/src/Sky/Build/Compile.hs
@@ -6541,6 +6541,51 @@ ctxFromIORef :: () -> LC.LowerCtx
 ctxFromIORef () = unsafePerformIO (readIORef scopeStateRef)
 
 
+-- | v0.15.x P38 (Cycle 3 / audit C10) — explicit-snapshot helper for
+-- the P37b-resumed cascade slots (record-field init, list element,
+-- let body).  Reads `scopeStateRef` ONCE at the call site and forces
+-- the resulting `LC.LowerCtx` to WHNF before returning it.
+--
+-- Why a separate helper from `ctxFromIORef`:
+--
+--   1. The cascade-resume slots feed the returned ctx into the
+--      ctx-aware wrappers (`lowerExprExpectGo` / `lowerExpr`).  Those
+--      wrappers `seq` the incoming ctx before writing it back into
+--      `scopeStateRef` — but that `seq` runs at the wrapper's entry,
+--      AFTER any sibling computation that may have built deferred
+--      thunks reading `scopeStateRef`.  Forcing WHNF at THE SNAPSHOT
+--      site closes the secondary thunk race that PR #91 (P37b,
+--      v0.15.19 / merged at c7a31df) called out as the load-bearing
+--      `<<loop>>` reproducer on examples/13-skyshop: the wrapper
+--      writes the not-yet-forced snapshot, downstream reads the
+--      IORef, forces the value, finds "reread me from scopeStateRef",
+--      and loops.  See the PR description's section "P37b — `seq` the
+--      incoming ctx before writing it" for the exhaustive analysis.
+--
+--   2. The Haddock here documents the snapshot semantics explicitly:
+--      the returned ctx is the value installed at the CALL site, NOT
+--      any inner-wrapper-installed value.  Future cascade migrations
+--      (record/list/let-body deepening; eventual full IORef deletion
+--      under Phase 3+) must preserve this contract.  Naming the read
+--      makes the semantic visible at every call site rather than
+--      sprinkled across multiple `unsafePerformIO (readIORef …)`
+--      transliterations.
+--
+--   3. NOINLINE matches `ctxFromIORef`: each call site forces a
+--      fresh IORef read.  Without it GHC may share the snapshot
+--      across nested cascade slots — silently breaking the
+--      "snapshot at call site" contract.
+--
+-- The `seq` here is LOAD-BEARING; do NOT remove it as part of a
+-- "tidy up" refactor.  Removing it re-opens the PR #91 thunk hazard
+-- class.
+{-# NOINLINE snapshotCallerCtx #-}
+snapshotCallerCtx :: () -> LC.LowerCtx
+snapshotCallerCtx () = unsafePerformIO $ do
+    ctx <- readIORef scopeStateRef
+    ctx `seq` return ctx
+
+
 -- | v0.13 typed lowerer: convert a canonical expression to Go IR
 -- WITH a known expected type from the surrounding context.
 --
@@ -6625,7 +6670,11 @@ exprToGoExpectGo goRendering e@(A.At _ expr)
         -- records.
         Can.List items
             | Just elemTy <- stripListType goRendering ->
-                let elemCtx = ctxFromIORef ()
+                -- v0.15.x P38 — list-element slot routes its caller
+                -- ctx through `snapshotCallerCtx` so the snapshot is
+                -- forced to WHNF at the call site (closes the P37b
+                -- PR #91 thunk hazard for the cascade-resume slots).
+                let elemCtx = snapshotCallerCtx ()
                 in GoIr.GoSliceLit elemTy
                     [ lowerExprExpectGo elemCtx elemTy it | it <- items ]
 
@@ -6779,7 +6828,12 @@ lowerRecordLiteralTo targetTy fields =
         -- `letBindingType` is pure, the seam is gone: every field
         -- routes through the explicit-ctx wrapper so threaded ctx
         -- flows into nested record / lambda / list arms.
-        fieldCtx = ctxFromIORef ()
+        --
+        -- v0.15.x P38 — caller ctx now flows through
+        -- `snapshotCallerCtx` so the WHNF force happens at the
+        -- snapshot site, not deferred to the wrapper's entry seq
+        -- (see helper Haddock for the P37b PR #91 thunk hazard).
+        fieldCtx = snapshotCallerCtx ()
         lowerField fn fe =
             let fieldGoTy = Map.findWithDefault "any" fn fieldTypeMap
             in coerceToFieldType fieldGoTy
@@ -10101,7 +10155,12 @@ letToGo mExpectedGo def body =
         -- region lookup reads `Solve.SolvedTypes._stRegions`
         -- directly), the deferred-thunk cycle is broken and the
         -- body can route through the explicit-ctx wrapper.
-        bodyCtx = ctxFromIORef ()
+        --
+        -- v0.15.x P38 — caller ctx now flows through
+        -- `snapshotCallerCtx` so the WHNF force happens at the
+        -- snapshot site (see helper Haddock for the P37b PR #91
+        -- thunk hazard the seq pattern was designed to close).
+        bodyCtx = snapshotCallerCtx ()
         lowerBody = case mExpectedGo of
             Just gt -> lowerExprExpectGo bodyCtx gt
             Nothing -> lowerExpr bodyCtx

--- a/test/Sky/Build/SnapshotCallerCtxSpec.hs
+++ b/test/Sky/Build/SnapshotCallerCtxSpec.hs
@@ -1,0 +1,211 @@
+-- | v0.15.x hardening — Plan Item P38 (Cycle 3 / audit C10).
+--
+-- Cycle 3 audit C10 called out three SEPARATE
+-- `unsafePerformIO (readIORef scopeStateRef)` sites that obtain a
+-- `LC.LowerCtx` snapshot at the function entry of the P37b-resumed
+-- cascade slots (record-field init, list element, let body).  Each
+-- site previously called the bare `ctxFromIORef ()` helper, which
+-- did NOT force the result to WHNF.  The wrappers
+-- (`lowerExprExpectGo` / `lowerExpr`) carry their own
+-- `ctx \`seq\` return ()` defensive force, but that runs at wrapper
+-- entry — AFTER any sibling computation may have built thunks
+-- reading `scopeStateRef`.  The PR #91 (P37b / v0.15.19) commit
+-- message documented this hazard class as the load-bearing
+-- `<<loop>>` reproducer on examples/13-skyshop.
+--
+-- P38 introduces `snapshotCallerCtx :: () -> LC.LowerCtx` that:
+--
+--   1. Reads `scopeStateRef` once.
+--   2. Forces the resulting `LC.LowerCtx` to WHNF before returning
+--      it (the `seq` pattern from PR #91).
+--   3. Carries explicit Haddock documenting that the returned ctx
+--      is the value installed at the CALL site, NOT any inner-
+--      wrapper-installed value.
+--
+-- All three cascade-resume sites now route through this helper.
+-- The structural shape this spec pins:
+--
+--   * `snapshotCallerCtx` is defined exactly once in `Compile.hs`.
+--   * The body forces ctx to WHNF (literal `seq` text on the
+--     binding's value-form line).
+--   * The helper is `{-# NOINLINE #-}` (mirrors `ctxFromIORef`).
+--   * Exactly three call sites (`snapshotCallerCtx ()`) live in
+--     `Compile.hs` — one per cascade-resume slot.
+--   * End-to-end build of the three-slot resume fixture (the same
+--     fixture P37b's `LetBodyCascadeResumeSpec` uses) still
+--     succeeds without `<<loop>>`.  Closes the integration arm:
+--     the helper is wired into the typed-lowerer pipeline, not
+--     just defined-and-unused.
+--
+-- The string-match approach mirrors `IORefBoundarySpec` /
+-- `LetBodyCascadeResumeSpec` — cheap, immune to compiler-internal
+-- renames within the helper's own signature, and the names this
+-- spec pins are themselves the load-bearing semantic.
+module Sky.Build.SnapshotCallerCtxSpec (spec) where
+
+import Data.List (isInfixOf)
+import qualified Data.List as List
+import System.Directory (createDirectoryIfMissing, doesFileExist,
+                         getCurrentDirectory)
+import System.Exit (ExitCode (..))
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import System.Process (CreateProcess (..), proc,
+                       readCreateProcessWithExitCode)
+import Test.Hspec
+
+
+findSky :: IO FilePath
+findSky = do
+    cwd <- getCurrentDirectory
+    let candidate = cwd </> "sky-out" </> "sky"
+    ok <- doesFileExist candidate
+    if ok
+        then return candidate
+        else fail ("sky binary missing at " ++ candidate
+                ++ " — run cabal install --installdir=./sky-out first")
+
+
+runSky :: FilePath -> [String] -> FilePath -> IO (ExitCode, String, String)
+runSky sky args workDir = do
+    let cp = (proc sky args) { cwd = Just workDir }
+    readCreateProcessWithExitCode cp ""
+
+
+writeFixtureProject :: FilePath -> String -> String -> IO ()
+writeFixtureProject dir name body = do
+    createDirectoryIfMissing True (dir </> "src")
+    writeFile (dir </> "sky.toml")
+        ("name = \"" ++ name
+            ++ "\"\nversion = \"0.0.0\"\nentry = \"src/Main.sky\"\n\n[source]\nroot = \"src\"\n")
+    writeFile (dir </> "src" </> "Main.sky") body
+
+
+-- | The three-slot reproducer from `LetBodyCascadeResumeSpec`.
+-- Reused verbatim so this spec ALSO exercises the helper as it sits
+-- inside the typed-lowerer pipeline — the helper isn't just defined,
+-- it's load-bearing for the three cascade-resume slots.
+threeSlotResumeSource :: String
+threeSlotResumeSource = unlines
+    [ "module Main exposing (main)"
+    , ""
+    , "import Sky.Core.Prelude exposing (..)"
+    , "import Std.Log exposing (println)"
+    , ""
+    , "type alias Cfg a ="
+    , "    { value : a"
+    , "    , label : String"
+    , "    }"
+    , ""
+    , "mkCfg : Int -> Cfg Int"
+    , "mkCfg n = { value = n, label = \"x\" }"
+    , ""
+    , "main ="
+    , "    let"
+    , "        cfg = mkCfg 41"
+    , "        xs = [ 1, 2, 3 ]"
+    , "        total ="
+    , "            case xs of"
+    , "                [] -> 0"
+    , "                _  -> cfg.value + 1"
+    , "    in"
+    , "    println (String.fromInt total)"
+    ]
+
+
+-- | Count occurrences of an exact substring in a body.
+countInfix :: String -> String -> Int
+countInfix needle haystack = go haystack
+  where
+    n = length needle
+    go [] = 0
+    go s@(_:rest)
+        | needle `List.isPrefixOf` s = 1 + go (drop n s)
+        | otherwise                  = go rest
+
+
+spec :: Spec
+spec = do
+    describe "Sky.Build.Compile — P38 snapshotCallerCtx helper" $ do
+
+        it "defines `snapshotCallerCtx :: () -> LC.LowerCtx` exactly once" $ do
+            src <- readFile "src/Sky/Build/Compile.hs"
+            -- The helper's source-level signature.  Pinning the
+            -- shape catches a refactor that silently drops the
+            -- unit param (and with it the per-call-site fresh
+            -- IORef read semantic).
+            ("snapshotCallerCtx :: () -> LC.LowerCtx" `isInfixOf` src)
+                `shouldBe` True
+            -- The body's value-form line.  The `seq` is LOAD-BEARING;
+            -- pinning the literal source guards the WHNF force
+            -- against a "cleanup" that re-introduces the PR #91
+            -- thunk hazard.
+            ("ctx `seq` return ctx" `isInfixOf` src) `shouldBe` True
+
+        it "is marked NOINLINE (matches ctxFromIORef contract)" $ do
+            -- Without the pragma GHC can share the snapshot across
+            -- nested cascade slots — silently breaking the
+            -- "snapshot at the call site" semantic the helper's
+            -- Haddock documents.
+            src <- readFile "src/Sky/Build/Compile.hs"
+            ("{-# NOINLINE snapshotCallerCtx #-}" `isInfixOf` src)
+                `shouldBe` True
+
+        it "documents the P37b PR #91 thunk hazard provenance" $ do
+            -- The helper's Haddock must reference the v0.15.19
+            -- P37b PR #91 thunk hazard so the `seq` pattern's
+            -- purpose stays preserved across future cascade work.
+            -- A bare `readIORef` (no provenance comment) is a tell
+            -- that the contract has been forgotten.
+            src <- readFile "src/Sky/Build/Compile.hs"
+            ("P37b" `isInfixOf` src) `shouldBe` True
+            -- PR #91 named explicitly so future archaeologists can
+            -- chase the failure-class back to the load-bearing
+            -- commit (c7a31df).
+            ("PR #91" `isInfixOf` src) `shouldBe` True
+
+        it "is called from exactly three cascade-resume sites" $ do
+            -- The three P37b-resumed slots (record-field init, list
+            -- element, let body) each take ONE snapshot at the
+            -- function entry of their typed-lowerer arm.  A fourth
+            -- call site is a flag — most likely a copy-paste
+            -- regression that needs a second look, or a planned
+            -- cascade extension that needs an updated audit gate.
+            --
+            -- Match the rvalue form `= snapshotCallerCtx ()` so the
+            -- helper's own defining-equation (`snapshotCallerCtx ()
+            -- = …`, which has the parens on the LHS not the RHS)
+            -- doesn't double-count.
+            src <- readFile "src/Sky/Build/Compile.hs"
+            countInfix "= snapshotCallerCtx ()" src `shouldBe` 3
+            -- Total occurrences (definition body line + 3 call
+            -- sites) = 4.  Pinning this catches a stray reference
+            -- (e.g. a leftover `ctxFromIORef ()` rename to
+            -- `snapshotCallerCtx ()` in a Haddock that should
+            -- have stayed pointing at the older helper).
+            countInfix "snapshotCallerCtx ()" src `shouldBe` 4
+
+        it "the cascade fixture still compiles cleanly under the helper" $ do
+            -- End-to-end gate: the three-slot reproducer from
+            -- `LetBodyCascadeResumeSpec` builds, runs, and prints
+            -- the expected `42` (41 from `cfg.value` + 1, via the
+            -- let-body case expression).  If the helper migration
+            -- regressed the cascade — e.g. by reintroducing the
+            -- thunk hazard — this fixture either blackholes
+            -- (`<<loop>>`) or panics; both surface as a Build
+            -- failure.
+            sky <- findSky
+            withSystemTempDirectory "sky-p38-snapshot" $ \tmp -> do
+                writeFixtureProject tmp "p38-snapshot" threeSlotResumeSource
+                (bec, bout, berr) <- runSky sky ["build", "src/Main.sky"] tmp
+                let bcombined = bout ++ berr
+                bec `shouldBe` ExitSuccess
+                ("Build complete" `isInfixOf` bcombined) `shouldBe` True
+                ("<<loop>>" `isInfixOf` bcombined) `shouldBe` False
+                ("panic" `isInfixOf` bcombined) `shouldBe` False
+
+                let appPath = tmp </> "sky-out" </> "app"
+                (rec_, rout, _) <- readCreateProcessWithExitCode
+                    (proc appPath []) ""
+                rec_ `shouldBe` ExitSuccess
+                ("42" `isInfixOf` rout) `shouldBe` True

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -50,6 +50,7 @@ import qualified Sky.Build.InferExprTypeBinopSpec
 import qualified Sky.Build.CoerceArgListMapInterplaySpec
 import qualified Sky.Build.LowerCtxCascadeSpec
 import qualified Sky.Build.LetBodyCascadeResumeSpec
+import qualified Sky.Build.SnapshotCallerCtxSpec
 import qualified Sky.Build.SkyshopCompilesSpec
 import qualified Sky.Build.AnonLambdaSpec
 import qualified Sky.Build.AnonRecordSpec
@@ -322,6 +323,17 @@ main = hspec $ do
     -- (c) the typed-coerce emission shape on a let-body fixture.
     describe "Sky.Build.LetBodyCascadeResume"
                                             Sky.Build.LetBodyCascadeResumeSpec.spec
+    -- v0.15.x hardening / Cycle 3 P38 — audit gap C10 closure.
+    -- The three P37b-resumed cascade slots (record-field init,
+    -- list element, let body) now share a single
+    -- `snapshotCallerCtx` helper that reads scopeStateRef and
+    -- forces the resulting LowerCtx to WHNF before returning it.
+    -- Lock fires on (a) the helper's source-level signature +
+    -- NOINLINE pragma + load-bearing `seq`, (b) exactly three
+    -- call sites, (c) the P37b PR #91 thunk-hazard provenance
+    -- comment, (d) end-to-end build of the three-slot fixture.
+    describe "Sky.Build.SnapshotCallerCtx"
+                                            Sky.Build.SnapshotCallerCtxSpec.spec
     -- v0.15.x hardening / Cycle 1 P2-followup STANDING lock —
     -- examples/13-skyshop is the Stripe-SDK-scale benchmark
     -- (76k FFI symbols) and is the canary that catches


### PR DESCRIPTION
Cycle 3 plan item P38 — closes audit gap **C10**.  Builds on PR #91
(P37b, v0.15.19, merged at c7a31df) which resumed the LowerCtx
cascade for the three deferred slots (record-field init / list
element / let body).  Each of those slots was reading caller ctx
via a bare `ctxFromIORef ()` helper that did NOT force the snapshot
to WHNF.  The existing `lowerExpr` / `lowerExprExpectGo` wrappers
carry their own `ctx \`seq\` return ()` defensive force, but that
runs at wrapper entry — AFTER any sibling computation may have
built thunks reading `scopeStateRef`.

PR #91's commit message documented this hazard class as the
load-bearing `<<loop>>` reproducer on examples/13-skyshop.  P38
extracts a single `snapshotCallerCtx` helper that bakes the WHNF
force into the snapshot site, then unifies the three cascade-
resume call sites onto it.  No behaviour change — refactor only.

## Why this matters

Per the planner's risk register (P38 section):

> Three SEPARATE `unsafePerformIO (readIORef scopeStateRef)` sites
> at the function head of the cascade-resume slots… The current
> code happens to work because the wrappers are only installed on
> the four migrated slots… But if P7 (now P37b) migrates the
> let-body to use a wrapper, `defToStmts` would silently start
> observing the wrapper-installed ctx — and the developer might
> not notice…

Naming the helper documents the snapshot semantic explicitly
(the returned ctx is the value installed at the CALL site, NOT
any inner-wrapper-installed value).  Future cascade migrations
that need a snapshot now call ONE helper instead of hand-rolling
the read-and-force pattern.

## Changes

1. **New helper** `snapshotCallerCtx :: () -> LC.LowerCtx` —
   reads `scopeStateRef` once, forces the resulting `LC.LowerCtx`
   to WHNF (the `seq` pattern from PR #91), returns the value.
   `NOINLINE` so each call site forces a fresh IORef read,
   matching `ctxFromIORef`'s contract.

   ```haskell
   {-# NOINLINE snapshotCallerCtx #-}
   snapshotCallerCtx :: () -> LC.LowerCtx
   snapshotCallerCtx () = unsafePerformIO $ do
       ctx <- readIORef scopeStateRef
       ctx `seq` return ctx
   ```

2. **Three cascade-resume call sites migrated** — all three
   replacements are mechanical:

   | Site | Local | Function |
   |---|---|---|
   | `exprToGoExpectGo` `Can.List` arm | `elemCtx` | list-element typed lowering |
   | `lowerRecordLiteralTo` | `fieldCtx` | record-field-init typed lowering |
   | `letToGo` | `bodyCtx` | let-body typed lowering |

3. **Doc-comment** carries the load-bearing rationale:
   - The `seq` is LOAD-BEARING (do NOT remove in a tidy-up
     refactor).
   - Names the PR #91 thunk hazard provenance + the merged-at
     commit so future archaeologists can chase the failure-class
     to its source.
   - Explains the snapshot-at-call-site semantic so future
     cascade migrations preserve the contract.

## Acceptance criteria

| AC | Status |
|---|---|
| 1. Single `snapshotCallerCtx` helper at the right module location | ✅ `src/Sky/Build/Compile.hs:6585` |
| 2. All 3 hand-rolled snapshot sites replaced | ✅ `elemCtx` + `fieldCtx` + `bodyCtx` |
| 3. Helper Haddock references PR #91 thunk hazard + `seq` purpose | ✅ both named + `seq` marked LOAD-BEARING |
| 4. `cabal test` stays at 379/0/1 | ✅ **384/0/1** (was 379 + 5 new spec cases) |
| 5. `scripts/build.sh --self-tests` stays 70/70 | ✅ 70/70 |
| 6. `examples/13-skyshop` `main.go` byte-identical | ✅ md5 `7b890729c746e8c10b2abcedf012da05` (unchanged from main baseline) |
| 7. `example-sweep --build-only` 19/19 | ✅ 19/19 |
| 8. New cabal spec exercises the helper end-to-end | ✅ `SnapshotCallerCtxSpec` 5/5 |

## Spec coverage (SnapshotCallerCtxSpec — 5 tests)

- Defines `snapshotCallerCtx :: () -> LC.LowerCtx` exactly once.
- `NOINLINE` pragma matches `ctxFromIORef` contract.
- Haddock documents the P37b PR #91 thunk hazard provenance.
- Called from exactly three cascade-resume sites (via the
  `= snapshotCallerCtx ()` rvalue form so the helper's own
  defining-equation doesn't double-count; total occurrences
  also pinned at 4 = 1 def-body + 3 callers).
- End-to-end build of the three-slot fixture (reused from
  `LetBodyCascadeResumeSpec`) compiles cleanly under the helper:
  no `<<loop>>`, no `panic`, app prints `42` (41 from
  `cfg.value` + 1 via the let-body case expression).

## Files touched

- `src/Sky/Build/Compile.hs` — `+62` LOC (helper Haddock + 4 LOC
  of code + 3 in-line provenance comments at the cascade-resume
  sites), `-3` LOC (the three `ctxFromIORef ()` rewrites).
- `test/Sky/Build/SnapshotCallerCtxSpec.hs` — NEW, 195 LOC.
- `sky-compiler.cabal` + `test/Spec.hs` — register the spec.

## Verification log

- `cabal test` — **384 examples, 0 failures, 1 pending** (matches
  prior; 5 new spec cases from `SnapshotCallerCtxSpec` landed).
- `scripts/build.sh --self-tests` — **70/70** pass.
- `scripts/example-sweep.sh --build-only` — **19/19** pass.
- `examples/13-skyshop` `main.go` — byte-identical to main baseline
  at md5 `7b890729c746e8c10b2abcedf012da05` (4351 lines), zero
  behaviour change confirmed.

## Release-cadence note

**DO NOT TAG.**  Per the release-cadence revision in
`docs/v0.15.x-hardening/README.md` (2026-05-26): this batches
with future compiler hardening into a single batched-tag PR.
Merge to main and STOP.  The pre-batched plan allocation had
this under v0.15.25; under the new cadence, the tag fires for
the batch, not per-PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
