### PR TITLE
docs(compile): canRouteTyped whitelist cross-ref comment (Cycle 3 P43)

### DIFF
--- a/src/Sky/Build/Compile.hs
+++ b/src/Sky/Build/Compile.hs
@@ -10352,6 +10352,37 @@ letBindingType solvedTypes _name body@(A.At r _) =
     -- (B) Type gate: the rendered Go type must be emittable AND
     -- not contain the `any` token anywhere (a `func(P) any` slot
     -- typed routing would strip a sharper source `func(P) T1`).
+    --
+    -- v0.15.x cycle-3 audit gap C13 cross-reference -----------
+    --
+    -- The body-shape whitelist below is a WORKAROUND for the
+    -- string-based `coerceArg` machinery (audit Prior #7 / Gap
+    -- A12 in `docs/v0.15.x-hardening/audits/CYCLE-03-auditor.md`).
+    -- Specific failing path on non-whitelisted shapes:
+    --
+    --   coerceArg → coerceToFieldType → rt.AsListT[T]
+    --
+    -- — string-parsing the type slot from a typed-routed call
+    -- whose underlying value is a `Result`-wrapped FFI return
+    -- (e.g. `Ffi.callPure "Money_allocate"`) emits a list-cast
+    -- that strips the `Ok` wrap and yields `[]`, silently
+    -- breaking downstream `List.map` etc.
+    --
+    -- Locked by the live regression gate in
+    -- `examples/00-standard-libs/src/Main.sky:569` (the
+    -- `Money.allocate 3 (Money.fromMajor USD 100)` assertion).
+    -- Drop the whitelist without P10/P11 and that assertion
+    -- silently returns `[]` instead of three parts.
+    --
+    -- Tracking: cycle-1 P9 ("drop canRouteTyped whitelist") is
+    -- DEFERRED to post-P37b per cycle-3 plan
+    -- (`docs/v0.15.x-hardening/plans/CYCLE-03-planner.md` tag
+    -- allocation table).  The proper structural fix is P10/P11
+    -- (structural `GoType` ADT replaces string-based parsing in
+    -- `coerceArg` / `coerceToFieldType`) — once those land, the
+    -- whitelist becomes droppable and `canRouteTyped` can collapse
+    -- to `True` for every shape.  Until then DO NOT broaden this
+    -- list; broaden it and the Money regression returns silently.
     let canRouteTyped = case body of
             A.At _ (Can.Record _) -> True
             A.At _ (Can.Lambda _ _) -> True


### PR DESCRIPTION
Closes cycle-3 audit gap **C13** (`docs/v0.15.x-hardening/audits/CYCLE-03-auditor.md:362`).

## What

Strengthens the existing two-axis-gate comment block above `letBindingType`'s
body-shape `canRouteTyped` whitelist in `src/Sky/Build/Compile.hs`.  No code
change — just a 31-line comment append that crosses the whitelist to its
upstream cause + the live regression gate that locks it in place + the
tracking item for the proper structural fix.

## Why

The whitelist gates typed routing to five `Can.*` body shapes
(`Record`, `Lambda`, `If`, `Case`, `Let`/`LetRec`).  It looks arbitrary
on first read, but it's a deliberate workaround for the string-based
`coerceArg` machinery — audit **Prior #7** / **Gap A12**.  Non-whitelisted
shapes whose underlying value is a `Result`-wrapped FFI return (e.g.
`Ffi.callPure "Money_allocate"`) emit a `rt.AsListT[T]` list-cast that
strips the `Ok` wrap and yields `[]`, silently breaking downstream
`List.map`.

Locked by the live regression gate in
`examples/00-standard-libs/src/Main.sky:569` (the
`Money.allocate 3 (Money.fromMajor USD 100)` Sky.Test assertion).
Drop the whitelist without P10/P11 (structural `GoType` ADT) and that
assertion silently returns `[]` instead of three parts.

## Cross-references added in the comment

| Reference | Status |
|---|---|
| Cycle-1 **P9** (\"drop canRouteTyped whitelist\") | DEFERRED post-P37b per the cycle-3 plan tag-allocation table |
| Cycle-3 **P10/P11** (structural `GoType` ADT) | Proper structural fix — once shipped, `canRouteTyped` collapses to `True` for every shape |
| Cycle-3 **C13** | This PR's gap — comment cross-ref only |

The comment block also adds an explicit **DO NOT broaden this list**
warning so future maintainers don't silently regress the Money.allocate
path.

## Verification

- Zero behaviour change (comment-only).
- `cabal build exe:sky` clean.
- `examples/13-skyshop/sky-out/main.go` md5
  `97570f054df2537dcc5fdf20d9f48e5f` UNCHANGED (matches v0.15.21
  baseline after PR #94 / #95 batched tag).

## Release

**DO NOT TAG** — batches with future compiler-side hardening per the
2026-05-26 cadence revision.