### PR TITLE
fix(compile): parser + codegen hygiene batch (Cycle 4 D2 + D4 + D6)

### DIFF
--- a/sky-compiler.cabal
+++ b/sky-compiler.cabal
@@ -276,7 +276,10 @@ test-suite sky-tests
       Sky.Build.CaseSubjectNameShadowSpec
       Sky.Build.FfiKernelAliasSpec
       Sky.Parse.MultiLineCaseSubjectSpec
+      Sky.Parse.MultiLineCaseKeywordSpec
       Sky.Parse.MultiLineSignatureSpec
+      Sky.Parse.RowPolyRecordAnnotationSpec
+      Sky.Build.CaseCatchallSubjectDiscardSpec
       Sky.Type.InstanceCaptureSpec
       Sky.Type.SolvedTypesRegionMapSpec
       Sky.Format.FormatSpec

--- a/src/Sky/Build/Compile.hs
+++ b/src/Sky/Build/Compile.hs
@@ -10754,6 +10754,16 @@ caseToGo mExpectedGo subject branches =
                 GoIr.GoShortDecl subjectName (coerceSubject typeName goSubject)
             Nothing ->
                 GoIr.GoShortDecl subjectName goSubject
+        -- Cycle 4 D2: a case whose only branch is `_ -> ...` (or
+        -- `var -> ...` where `var` is not referenced in the body)
+        -- never reads `__subject`, and Go rejects the unused
+        -- declaration with `declared but not used: __subject`.
+        -- Always emit a blank-identifier discard right after the
+        -- subject declaration — it both pacifies Go for the
+        -- catchall-only shape and matches Sky's `let _ = TaskExpr`
+        -- auto-force convention for "keep evaluated, ignore result".
+        subjectDiscard = GoIr.GoExprStmt
+            (GoIr.GoRaw ("_ = " ++ subjectName))
         branchStmts = concatMap (caseBranchToStmts subjectName) branches
         -- P3: exhaustiveness is verified before codegen, so this arm is
         -- statically unreachable. Audit P0-5: route through
@@ -10766,7 +10776,7 @@ caseToGo mExpectedGo subject branches =
         unreachableStmt = GoIr.GoExprStmt
             (GoIr.GoRaw ("_ = rt.Unreachable(\"case/" ++ subjectName ++ "\")"))
         raw = GoIr.GoBlock
-                (subjectDecl : branchStmts ++ [unreachableStmt])
+                (subjectDecl : subjectDiscard : branchStmts ++ [unreachableStmt])
                 (GoIr.GoRaw "nil")  -- unreachable, branches return
     in case mExpectedGo of
         Just gt -> typeIIFE gt raw
@@ -10875,13 +10885,19 @@ tcoBodyStmts home fnName arity paramNames paramGoTys goRetType = lowerTail
                         | otherwise ->
                             GoIr.GoTypeAssert (anyWrap rawSubjExpr) typeName
                 subjStmt = GoIr.GoShortDecl subjectName subjExpr
+                -- Cycle 4 D2 (TCO path): mirror the non-TCO caseToGo
+                -- discard so a tail-position `case` whose only branch
+                -- is `_ -> ...` doesn't emit an unused-var Go build
+                -- error.
+                subjDiscardStmt = GoIr.GoExprStmt
+                    (GoIr.GoRaw ("_ = " ++ subjectName))
                 branchStmts = concatMap
                     (caseBranchToStmtsWith subjectName tcoLeaf) branches
                 fallthroughStmt = GoIr.GoExprStmt
                     (GoIr.GoCall
                         (GoIr.GoQualified "rt" "Unreachable")
                         [GoIr.GoStringLit "tco/case"])
-            in subjStmt : branchStmts ++ [fallthroughStmt]
+            in subjStmt : subjDiscardStmt : branchStmts ++ [fallthroughStmt]
 
         Can.If branches elseExpr ->
             ifToTcoStmts branches elseExpr

--- a/src/Sky/Canonicalise/Type.hs
+++ b/src/Sky/Canonicalise/Type.hs
@@ -156,6 +156,16 @@ freeTypeVars srcType =
         Src.TLambda from to -> collectVars from `Set.union` collectVars to
         Src.TType _ _ args -> Set.unions (map collectVars args)
         Src.TTypeQual _ _ args -> Set.unions (map collectVars args)
-        Src.TRecord fields _ -> Set.unions (map (\(_, ty) -> collectVars ty) fields)
+        Src.TRecord fields mExt ->
+            -- Cycle 4 D6: include the row variable name (if any) so
+            -- multi-occurrence row vars (`f : { r | a : Int } ->
+            -- { r | b : String } -> _`) share the same UF var
+            -- through Instantiate's env.  Without this the row var
+            -- would still work (typeToVariable falls back to a fresh
+            -- FlexVar) but each occurrence would be UNSHARED — which
+            -- defeats the purpose of giving the row a name.
+            let fieldVars = Set.unions (map (\(_, ty) -> collectVars ty) fields)
+                rowVars   = maybe Set.empty Set.singleton mExt
+            in Set.union fieldVars rowVars
         Src.TUnit -> Set.empty
         Src.TTuple a b rest -> collectVars a `Set.union` collectVars b `Set.union` Set.unions (map collectVars rest)

--- a/src/Sky/Parse/Expression.hs
+++ b/src/Sky/Parse/Expression.hs
@@ -568,6 +568,15 @@ lambdaParams_ mkError =
 
 exprCase :: (Row -> Col -> x) -> Parser x Src.Expr_
 exprCase mkError = do
+    -- Cycle 4 D4: subject may also start on the next line, as in
+    --     case
+    --         (a, b, c)
+    --     of
+    --         ...
+    -- `exprLet` does the same with `freshLine` at the head — mirror
+    -- it here so `case` accepts both the same-line and next-line
+    -- subject forms.
+    freshLine mkError
     subject <- expression mkError
     -- Accept `of` either on the same line as the subject end (the
     -- common single-line form), or after newlines+indent for the

--- a/src/Sky/Parse/Type.hs
+++ b/src/Sky/Parse/Type.hs
@@ -5,7 +5,7 @@ module Sky.Parse.Type where
 import qualified Data.Text as T
 import Sky.Parse.Primitives
 import Sky.Parse.Space (spaces, freshLine, skipWhitespace)
-import Sky.Parse.Variable (lower, upper)
+import Sky.Parse.Variable (lower, upper, isLowerLike, isIdentChar)
 import qualified Sky.AST.Source as Src
 import qualified Sky.Reporting.Annotation as A
 
@@ -89,6 +89,12 @@ typeAtom mkError =
                          _ -> failParse mkError
 
         , -- Record type: { field : Type, ... }
+          -- Cycle 4 D6: also accept the row-polymorphic form
+          --     { r | field : Type, ... }
+          -- where `r` is a lowercase row variable.  The AST slot
+          -- (`Src.TRecord fields (Maybe String)`), canonicaliser,
+          -- HM Instantiate, and Unify all already support open
+          -- records — the parser was the only missing surface.
           do char mkError '{'
              freshLine mkError  -- field may be on next line
              mc <- peek
@@ -97,10 +103,31 @@ typeAtom mkError =
                      char mkError '}'
                      return (Src.TRecord [] Nothing)
                  _ -> do
-                     fields <- typeRecordFields mkError
-                     freshLine mkError
-                     char mkError '}'
-                     return (Src.TRecord fields Nothing)
+                     -- Use a non-consuming lookahead to decide
+                     -- between the row-poly form (`<lower> |`) and
+                     -- the closed form (`<lower> :`).  `lower`
+                     -- consumes on success, and once a parser has
+                     -- consumed input the surrounding bind converts
+                     -- any later empty-fail into a consumed-fail
+                     -- (Primitives.hs:93-102 `>>=` definition) which
+                     -- `oneOfWithFallback` won't catch — so we must
+                     -- branch BEFORE consuming.
+                     isRowPoly <- peekRowPolyIntro
+                     if isRowPoly
+                         then do
+                             rowVar <- lower mkError
+                             spaces
+                             char mkError '|'
+                             freshLine mkError
+                             fields <- typeRecordFields mkError
+                             freshLine mkError
+                             char mkError '}'
+                             return (Src.TRecord fields (Just rowVar))
+                         else do
+                             fields <- typeRecordFields mkError
+                             freshLine mkError
+                             char mkError '}'
+                             return (Src.TRecord fields Nothing)
 
         , -- Type constructor: Maybe, List, MyType, or qualified: Set.Set
           do name <- upper mkError
@@ -172,3 +199,29 @@ typeRecordFieldsRest mkError = Parser $ \s _ eok _ _ ->
             in p s (\a s2 -> eok a s2) eok (\r c m -> eok [] s) (\r c m -> eok [] s)
         _ ->
             eok [] s
+
+
+-- | Non-consuming lookahead for the row-polymorphic record opener
+-- `<lowerIdent> [whitespace] |`. Used by the record-type parser to
+-- decide between the closed form (`{ field : Type, … }`) and the
+-- row-poly form (`{ r | field : Type, … }`) WITHOUT first consuming
+-- the identifier (consumed input cannot be backtracked through
+-- `oneOfWithFallback`).
+peekRowPolyIntro :: Parser x Bool
+peekRowPolyIntro = Parser $ \s _cok eok _cerr _eerr ->
+    let src = _src s
+    in case T.uncons src of
+        Just (c, _)
+            | isLowerLike c ->
+                let (name, rest) = T.span isIdentChar src
+                    afterName    = T.dropWhile (\ch -> ch == ' ' || ch == '\t') rest
+                in case T.uncons afterName of
+                    -- A '|' immediately (mod inline whitespace) after
+                    -- the lowercase identifier is the row-poly
+                    -- separator.  A '|' from a record-update sigil
+                    -- (`{ rec | field = v }`) is in EXPRESSION land,
+                    -- never TYPE land, so we never see one here for
+                    -- the field-assignment-update meaning.
+                    Just ('|', _) | not (T.null name) -> eok True s
+                    _                                 -> eok False s
+        _ -> eok False s

--- a/src/Sky/Type/Instantiate.hs
+++ b/src/Sky/Type/Instantiate.hs
@@ -84,8 +84,22 @@ buildEnv rank canType env = case canType of
     T.TType _ _ args ->
         foldlM (\e arg -> buildEnv rank arg e) env args
 
-    T.TRecord fields _ ->
-        foldlM (\e (T.FieldType _ ty) -> buildEnv rank ty e) env (Map.elems fields)
+    T.TRecord fields mExt -> do
+        -- Cycle 4 D6: register the row variable so multi-occurrence
+        -- row vars share a single UF var, matching the `T.TVar name`
+        -- treatment above.  `typeToVariable` already prefers env
+        -- lookup over fresh-flex for `Just name` (lines 118-127), so
+        -- this just keeps `freeTypeVars`'s collection in sync.
+        env' <- foldlM (\e (T.FieldType _ ty) -> buildEnv rank ty e)
+                       env (Map.elems fields)
+        case mExt of
+            Just "any" -> return env'
+            Just name -> case Map.lookup name env' of
+                Just _  -> return env'
+                Nothing -> do
+                    v <- UF.fresh (T.Descriptor (T.FlexVar (Just name)) rank T.noMark Nothing)
+                    return (Map.insert name v env')
+            Nothing -> return env'
 
     T.TUnit -> return env
 

--- a/test/Sky/Build/CaseCatchallSubjectDiscardSpec.hs
+++ b/test/Sky/Build/CaseCatchallSubjectDiscardSpec.hs
@@ -1,0 +1,79 @@
+module Sky.Build.CaseCatchallSubjectDiscardSpec (spec) where
+
+import Test.Hspec
+import System.Directory (getCurrentDirectory, doesFileExist,
+                         createDirectoryIfMissing)
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import System.Process (readCreateProcessWithExitCode, proc, CreateProcess(..))
+import System.Exit (ExitCode(..))
+import qualified Data.List as List
+
+
+-- Cycle 4 D2 regression: a `case foo of _ -> Ok ()` (where the
+-- subject is otherwise unused) used to emit Go that declared
+-- `__subject := foo` and never read it.  Go's `declared and not
+-- used` build error rejected the binary.  The fix in
+-- `Sky.Build.Compile.caseToGo` emits a blank-identifier discard
+-- (`_ = __subject`) immediately after the subject declaration so
+-- the catchall-only shape compiles.
+--
+-- This spec asserts BOTH:
+--   1. the fixture builds clean (Go would have rejected the
+--      pre-fix codegen), AND
+--   2. the emitted Go contains the discard line
+--      (`_ = __subject`) so a future refactor that drops the
+--      discard regresses this test.
+spec :: Spec
+spec = describe "case _ -> Ok () compiles + emits the subject discard" $ do
+    it "builds and emits `_ = __subject` for a catchall-only case" $ do
+        sky <- findSky
+        withSystemTempDirectory "sky-case-catchall" $ \tmp -> do
+            writeFixture tmp fixture
+            (ec, _, _) <- runSky sky ["build", "src/Main.sky"] tmp
+            ec `shouldBe` ExitSuccess
+            built <- doesFileExist (tmp </> "sky-out" </> "app")
+            built `shouldBe` True
+            goSrc <- readFile (tmp </> "sky-out" </> "main.go")
+            (List.isInfixOf "_ = __subject" goSrc) `shouldBe` True
+
+  where
+    findSky :: IO FilePath
+    findSky = do
+        cwd <- getCurrentDirectory
+        let candidate = cwd </> "sky-out" </> "sky"
+        ok <- doesFileExist candidate
+        if ok then return candidate
+              else fail ("sky binary missing at " ++ candidate)
+
+    runSky :: FilePath -> [String] -> FilePath -> IO (ExitCode, String, String)
+    runSky sky args workDir = do
+        let cp = (proc sky args) { cwd = Just workDir }
+        readCreateProcessWithExitCode cp ""
+
+    writeFixture :: FilePath -> String -> IO ()
+    writeFixture dir body = do
+        createDirectoryIfMissing True (dir </> "src")
+        writeFile (dir </> "sky.toml")
+            ("name = \"case-catchall\"\nversion = \"0.0.0\"\n"
+             ++ "entry = \"src/Main.sky\"\n\n[source]\nroot = \"src\"\n")
+        writeFile (dir </> "src" </> "Main.sky") body
+
+
+fixture :: String
+fixture = unlines
+    [ "module Main exposing (main)"
+    , ""
+    , "import Sky.Core.Prelude exposing (..)"
+    , "import Std.Log exposing (println)"
+    , ""
+    , "checkValue : Int -> Result Error ()"
+    , "checkValue n ="
+    , "    case n of"
+    , "        _ -> Ok ()"
+    , ""
+    , "main ="
+    , "    case checkValue 5 of"
+    , "        Ok () -> println \"ok\""
+    , "        Err _ -> println \"err\""
+    ]

--- a/test/Sky/Parse/MultiLineCaseKeywordSpec.hs
+++ b/test/Sky/Parse/MultiLineCaseKeywordSpec.hs
@@ -1,0 +1,71 @@
+module Sky.Parse.MultiLineCaseKeywordSpec (spec) where
+
+import Test.Hspec
+import System.Directory (getCurrentDirectory, doesFileExist,
+                         createDirectoryIfMissing)
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import System.Process (readCreateProcessWithExitCode, proc, CreateProcess(..))
+import System.Exit (ExitCode(..))
+
+
+-- Cycle 4 D4 regression: a `case` keyword on its own line with
+-- the subject on the next line failed to parse.  The companion
+-- `MultiLineCaseSubjectSpec` only covered the `<subject>\n of`
+-- transition; D4 is the OTHER half — the `case\n <subject>`
+-- transition.  The fix mirrors `exprLet`: insert
+-- `freshLine mkError` at the head of `exprCase` so the parser
+-- skips the optional newline between the `case` keyword and the
+-- subject expression.
+spec :: Spec
+spec = describe "parser accepts `case` keyword with subject on next line" $ do
+    it "compiles a `case\\n    subject\\n    of` body" $ do
+        sky <- findSky
+        withSystemTempDirectory "sky-multiline-case-kw" $ \tmp -> do
+            writeFixture tmp fixture
+            (ec, _, _) <- runSky sky ["build", "src/Main.sky"] tmp
+            ec `shouldBe` ExitSuccess
+            built <- doesFileExist (tmp </> "sky-out" </> "app")
+            built `shouldBe` True
+
+  where
+    findSky :: IO FilePath
+    findSky = do
+        cwd <- getCurrentDirectory
+        let candidate = cwd </> "sky-out" </> "sky"
+        ok <- doesFileExist candidate
+        if ok then return candidate
+              else fail ("sky binary missing at " ++ candidate)
+
+    runSky :: FilePath -> [String] -> FilePath -> IO (ExitCode, String, String)
+    runSky sky args workDir = do
+        let cp = (proc sky args) { cwd = Just workDir }
+        readCreateProcessWithExitCode cp ""
+
+    writeFixture :: FilePath -> String -> IO ()
+    writeFixture dir body = do
+        createDirectoryIfMissing True (dir </> "src")
+        writeFile (dir </> "sky.toml")
+            ("name = \"multiline-case-kw\"\nversion = \"0.0.0\"\n"
+             ++ "entry = \"src/Main.sky\"\n\n[source]\nroot = \"src\"\n")
+        writeFile (dir </> "src" </> "Main.sky") body
+
+
+fixture :: String
+fixture = unlines
+    [ "module Main exposing (main)"
+    , ""
+    , "import Sky.Core.Prelude exposing (..)"
+    , "import Std.Log exposing (println)"
+    , ""
+    , "classify : Int -> Int -> Int -> String"
+    , "classify a b c ="
+    , "    case"
+    , "        (a, b, c)"
+    , "    of"
+    , "        (0, 0, 0) -> \"zeros\""
+    , "        _ -> \"other\""
+    , ""
+    , "main ="
+    , "    println (classify 1 2 3)"
+    ]

--- a/test/Sky/Parse/RowPolyRecordAnnotationSpec.hs
+++ b/test/Sky/Parse/RowPolyRecordAnnotationSpec.hs
@@ -1,0 +1,75 @@
+module Sky.Parse.RowPolyRecordAnnotationSpec (spec) where
+
+import Test.Hspec
+import System.Directory (getCurrentDirectory, doesFileExist,
+                         createDirectoryIfMissing)
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import System.Process (readCreateProcessWithExitCode, proc, CreateProcess(..))
+import System.Exit (ExitCode(..))
+
+
+-- Cycle 4 D6 regression: a row-polymorphic record annotation
+--     greet : { r | name : String } -> String
+-- previously failed to parse — the AST slot
+-- `Src.TRecord [...] (Maybe String)`, canonicaliser,
+-- `Instantiate.typeToVariable T.TRecord`, AND `Unify.unifyRecords`
+-- all already supported row polymorphism, but the SURFACE PARSER
+-- in `Sky.Parse.Type` had no `{ r | ... }` rule.
+--
+-- The fix adds a non-consuming lookahead (`peekRowPolyIntro`)
+-- followed by a row-poly branch that emits
+-- `Src.TRecord fields (Just rowVar)`.  This spec exercises BOTH:
+--   1. the row-poly annotation parses cleanly, AND
+--   2. the open-record semantics flow through HM correctly — a
+--      caller passing a record with EXTRA fields beyond `name`
+--      type-checks (closed-record would reject it).
+spec :: Spec
+spec = describe "parser accepts row-polymorphic record annotations" $ do
+    it "type-checks `{ r | name : String }` and accepts extra fields" $ do
+        sky <- findSky
+        withSystemTempDirectory "sky-row-poly" $ \tmp -> do
+            writeFixture tmp fixture
+            (ec, _, _) <- runSky sky ["build", "src/Main.sky"] tmp
+            ec `shouldBe` ExitSuccess
+            built <- doesFileExist (tmp </> "sky-out" </> "app")
+            built `shouldBe` True
+
+  where
+    findSky :: IO FilePath
+    findSky = do
+        cwd <- getCurrentDirectory
+        let candidate = cwd </> "sky-out" </> "sky"
+        ok <- doesFileExist candidate
+        if ok then return candidate
+              else fail ("sky binary missing at " ++ candidate)
+
+    runSky :: FilePath -> [String] -> FilePath -> IO (ExitCode, String, String)
+    runSky sky args workDir = do
+        let cp = (proc sky args) { cwd = Just workDir }
+        readCreateProcessWithExitCode cp ""
+
+    writeFixture :: FilePath -> String -> IO ()
+    writeFixture dir body = do
+        createDirectoryIfMissing True (dir </> "src")
+        writeFile (dir </> "sky.toml")
+            ("name = \"row-poly\"\nversion = \"0.0.0\"\n"
+             ++ "entry = \"src/Main.sky\"\n\n[source]\nroot = \"src\"\n")
+        writeFile (dir </> "src" </> "Main.sky") body
+
+
+fixture :: String
+fixture = unlines
+    [ "module Main exposing (main)"
+    , ""
+    , "import Sky.Core.Prelude exposing (..)"
+    , "import Std.Log exposing (println)"
+    , ""
+    , "-- D6: row-polymorphic annotation accepts records carrying extras"
+    , "greet : { r | name : String } -> String"
+    , "greet rec ="
+    , "    \"Hello, \" ++ rec.name"
+    , ""
+    , "main ="
+    , "    println (greet { name = \"World\", age = 99 })"
+    ]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -31,7 +31,10 @@ import qualified Sky.Build.EntryLocalShadowsDepSpec
 import qualified Sky.Build.CaseSubjectNameShadowSpec
 import qualified Sky.Build.FfiKernelAliasSpec
 import qualified Sky.Parse.MultiLineCaseSubjectSpec
+import qualified Sky.Parse.MultiLineCaseKeywordSpec
 import qualified Sky.Parse.MultiLineSignatureSpec
+import qualified Sky.Parse.RowPolyRecordAnnotationSpec
+import qualified Sky.Build.CaseCatchallSubjectDiscardSpec
 import qualified Sky.Format.FormatSpec
 import qualified Sky.Build.GoKeywordCollisionSpec
 import qualified Sky.Build.NestedPatternSpec
@@ -192,7 +195,13 @@ main = hspec $ do
     describe "Sky.Build.CaseSubjectNameShadow" Sky.Build.CaseSubjectNameShadowSpec.spec
     describe "Sky.Build.FfiKernelAlias" Sky.Build.FfiKernelAliasSpec.spec
     describe "Sky.Parse.MultiLineCaseSubject" Sky.Parse.MultiLineCaseSubjectSpec.spec
+    describe "Sky.Parse.MultiLineCaseKeyword"
+        Sky.Parse.MultiLineCaseKeywordSpec.spec
     describe "Sky.Parse.MultiLineSignature" Sky.Parse.MultiLineSignatureSpec.spec
+    describe "Sky.Parse.RowPolyRecordAnnotation"
+        Sky.Parse.RowPolyRecordAnnotationSpec.spec
+    describe "Sky.Build.CaseCatchallSubjectDiscard"
+        Sky.Build.CaseCatchallSubjectDiscardSpec.spec
     -- Closed-record exactness + cross-module externals registration:
     --   1. unifyRecords (Sky.Type.Unify) used to silently merge field-
     --      mismatched closed records under a fresh extension. Now


### PR DESCRIPTION
Three small, independent fixes from the Cycle 4 auditor's
user-surfaced gap list — parser/codegen hygiene. Bundled in
ONE PR per the auditor's recommendation ("Cycle 4 critical
path #3: Land D2 + D4 + D6 as a parser/codegen hygiene batch").

**DO NOT TAG** — accumulates for the next compiler-hardening batch.

## D2 (codegen) — `case _ -> Ok ()` emits unused `__subject`

`caseToGo` always emitted `__subject := <expr>` then ran the
branch arms; a `case` whose only branch is `_ -> Ok ()` never
reads the binding and Go rejects with `declared but not used:
__subject`. Fix: emit `_ = __subject` blank-identifier discard
immediately after the subject declaration in BOTH the regular
`caseToGo` and TCO `tcoBodyStmts` paths.

Audit entry: `docs/v0.15.x-hardening/audits/CYCLE-04-auditor.md`
lines 175-267.

## D4 (parser) — multi-line `case\n    subject\n    of` won't parse

`exprCase` lacked the `freshLine mkError` head that `exprLet`
carries. A `case` keyword followed by the subject on the NEXT
line fell through to `expression`'s default and produced the
misleading `Top-level declaration expected here` error. Mirror
`exprLet` — three-line patch.

Audit entry: lines 368-449.

## D6 (parser + HM env) — row-polymorphic record annotation

`{ r | name : String }` — the AST slot
(`Src.TRecord [...] (Maybe String)`), canonicaliser,
`Instantiate.typeToVariable T.TRecord`, AND `Unify.unifyRecords`
already supported row polymorphism end-to-end (auditor verified).
Only the surface parser was missing.

Fix: add a non-consuming `peekRowPolyIntro` lookahead in
`Sky.Parse.Type` — consumed input cannot backtrack through
`oneOfWithFallback` per Primitives.hs `>>=`, so we peek before
deciding which branch to take. Also register the row variable
name in `freeTypeVars` collection (`Canonicalise.Type`) and
`buildEnv` (`Instantiate`) so multi-occurrence row vars share
a single UF var.

Audit entry: lines 581-671.

## Regression specs

Three new cabal specs lock the behaviour:

- `test/Sky/Build/CaseCatchallSubjectDiscardSpec.hs` — fixture
  compiles + emitted `main.go` contains `_ = __subject`
- `test/Sky/Parse/MultiLineCaseKeywordSpec.hs` — parser accepts
  `case\n    <subject>\n    of` shape
- `test/Sky/Parse/RowPolyRecordAnnotationSpec.hs` — type-checks
  `{ r | name : String }` AND accepts a caller passing a record
  with extra fields (open-record HM end-to-end)

Local verification: 70/70 self-tests + targeted sample of 8
representative examples build clean + the 3 reproducer fixtures
from the audit doc all compile and run correctly. Cabal test
suite is now 388 examples baseline (385 prior + 3 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)