### PR TITLE
fix(canonicalise): dual-import qualifier collision detection (Cycle 4 D5)

### DIFF
--- a/sky-compiler.cabal
+++ b/sky-compiler.cabal
@@ -262,6 +262,7 @@ test-suite sky-tests
       Sky.Canonicalise.KernelFallbackSpec
       Sky.Canonicalise.UnboundSpec
       Sky.Canonicalise.QualifiedTypeAliasSpec
+      Sky.Canonicalise.DualImportCollisionSpec
       Sky.Type.ExhaustivenessSpec
       Sky.Type.AnyWildcardSpec
       Sky.Type.NumericBinopSpec

--- a/src/Sky/Canonicalise/Module.hs
+++ b/src/Sky/Canonicalise/Module.hs
@@ -176,6 +176,14 @@ canonicaliseWithDeps deps srcMod =
         -- P2: reject `import M exposing (name)` when M doesn't export name.
         importHidingErrors = checkImportExposingAgainstDep deps (Src._imports srcMod)
 
+        -- D5 (Cycle 4): reject when two imports bind the SAME qualifier
+        -- but resolve to DIFFERENT canonical modules. Without this guard
+        -- the canonicaliser's `_importAliases` (last-wins) and
+        -- `_qualVars` (union) maps disagree on which module a qualified
+        -- TYPE reference belongs to, producing the dishonest
+        -- "Model vs Model" error at the type checker.
+        importAliasCollisions = detectImportAliasCollisions (Src._imports srcMod)
+
         -- Build environment from imports
         env0 = Env.initialEnv modName
         env1 = foldl (processImportWith deps modName) env0 (Src._imports srcMod)
@@ -216,10 +224,11 @@ canonicaliseWithDeps deps srcMod =
         unboundErrs
             | Map.null deps && hasUserImports = []
             | otherwise = collectUnboundNameErrors env4 srcMod
-    in case (importHidingErrors, collisions, unboundErrs) of
-        (err:_, _, _) -> Left err
-        (_, Just err, _) -> Left err
-        (_, _, err:_) -> Left err
+    in case (importAliasCollisions, importHidingErrors, collisions, unboundErrs) of
+        (err:_, _, _, _) -> Left err
+        (_, err:_, _, _) -> Left err
+        (_, _, Just err, _) -> Left err
+        (_, _, _, err:_) -> Left err
         _ -> Right $ expandModuleAliases depAliasMap Can.Module
             { Can._name    = modName
             , Can._exports = exports
@@ -577,6 +586,134 @@ kernelFunctions :: Map.Map String [String]
 kernelFunctions =
     Map.unionWith (++) staticKernelFunctions
         (unsafePerformIO (readIORef Env.ffiKernelFunctionsRef))
+
+
+-- | Cycle 4 — D5. Detect when two imports bind the SAME qualifier but
+-- resolve to DIFFERENT canonical modules. The dangerous shape is:
+--
+--     import State exposing (Model, initial)
+--     import App.State exposing (defaultModel)
+--
+-- Both imports default their qualifier to `State` (the last segment).
+-- `_importAliases` in the canonicalisation env is a last-wins
+-- `Map String ModuleName.Canonical`, while `_qualVars` is a
+-- union-merged `Map String (Map String VarHome)`. The mismatch causes
+-- qualified TYPE references (`useFn : State.Model`) to silently misroute
+-- to whichever module was imported LAST, while qualified VALUE references
+-- of the SAME qualifier reach BOTH modules' bindings via the unioned map.
+--
+-- Two imports collide ONLY when their canonical-module identity differs.
+-- Kernel modules collapse to their kernel name (so
+-- `import Sky.Core.Time` + `import Std.Time` are both `Time` kernel and
+-- DO NOT collide — they route to the same kernel dispatch table). Two
+-- aliased imports of the SAME module (`import Std.Ui as Ui` plus
+-- `import Std.Ui exposing (Element)`) also resolve to the same canonical
+-- module and do not collide. Only the dishonest cross-module case is
+-- rejected.
+--
+-- The user-facing workaround is `import App.State as AppState`, which
+-- gives each import a distinct qualifier and disambiguates the two
+-- modules at every call site.
+detectImportAliasCollisions :: [Src.Import] -> [String]
+detectImportAliasCollisions imps =
+    let -- For each import, derive (qualifier, canonical-source, region, importPath).
+        -- canonical-source folds kernel modules onto their pseudo-module
+        -- name so multiple kernel paths to the same dispatch table don't
+        -- count as a collision.
+        entries :: [(String, String, A.Region, String)]
+        entries =
+            [ (qualifier, src, region, importPath)
+            | imp <- imps
+            , let segs = case Src._importName imp of A.At _ s -> s
+                  region = case Src._importName imp of A.At r _ -> r
+                  importPath = ModuleName.joinWith "." segs
+                  qualifier = case Src._importAlias imp of
+                      Just alias -> alias
+                      Nothing    -> case segs of
+                          [] -> importPath  -- defensive — parser shouldn't allow
+                          _  -> last segs
+                  src = Map.findWithDefault importPath importPath Env.kernelModules
+            ]
+
+        -- Group entries by qualifier. Earliest-region first per group so
+        -- the error message points at the FIRST import (a stable choice
+        -- for fix-it suggestions).
+        byQualifier :: Map.Map String [(String, A.Region, String)]
+        byQualifier = Map.fromListWith (\old new -> new ++ old)
+            [ (q, [(src, region, importPath)])
+            | (q, src, region, importPath) <- entries
+            ]
+
+        -- Keep only qualifiers where ≥2 DISTINCT canonical sources appear.
+        clashes :: [(String, [(String, A.Region, String)])]
+        clashes =
+            [ (q, group)
+            | (q, group) <- Map.toList byQualifier
+            , length (distinctSources group) >= 2
+            ]
+    in map formatClash clashes
+  where
+    distinctSources :: [(String, A.Region, String)] -> [String]
+    distinctSources xs = Map.keys (Map.fromList [(s, ()) | (s, _, _) <- xs])
+
+    formatClash :: (String, [(String, A.Region, String)]) -> String
+    formatClash (qualifier, group) =
+        let -- Sort by source-region so the leader points at the FIRST
+            -- offending import and the fix suggestion is stable.
+            sorted = sortByRegion group
+            (_, firstRegion, _) = head sorted
+            leader = case firstRegion of
+                A.Region (A.Position r c) _ -> show r ++ ":" ++ show c ++ ": "
+            -- Suggest aliasing the LAST imported colliding module (so
+            -- the user's intent — first import "owns" the qualifier —
+            -- is preserved). Pick a unique alias by camelCasing the
+            -- full canonical path.
+            lastPath = case reverse sorted of
+                ((_, _, p):_) -> p
+                _             -> "Other.Mod"
+            suggestedAlias = camelCasePath lastPath
+            suggestion = "Add `as <Alias>` to one of them, e.g. `import "
+                ++ lastPath ++ " as " ++ suggestedAlias ++ "`."
+            body = "Import error: two imports both bind the qualifier `"
+                ++ qualifier ++ "`:\n"
+                ++ concat
+                    [ "  - import " ++ p
+                       ++ posTag region ++ "\n"
+                    | (_, region, p) <- sorted
+                    ]
+                ++ "  " ++ suggestion
+        in leader ++ body
+
+    -- "App.State" → "AppState"; "Lib.Internal.Foo" → "LibInternalFoo".
+    -- Keeps the alias unique against the dangling last-segment qualifier
+    -- so the user can pick it up verbatim from the error message.
+    camelCasePath :: String -> String
+    camelCasePath p =
+        let segs = splitOnDot p
+        in concat segs
+
+    splitOnDot :: String -> [String]
+    splitOnDot s = case break (== '.') s of
+        (a, "") -> [a]
+        (a, _:rest) -> a : splitOnDot rest
+
+    posTag :: A.Region -> String
+    posTag (A.Region (A.Position r c) _) =
+        "  (at " ++ show r ++ ":" ++ show c ++ ")"
+
+    sortByRegion :: [(String, A.Region, String)] -> [(String, A.Region, String)]
+    sortByRegion = sortBy3
+      where
+        sortBy3 = foldr insertByRegion []
+        insertByRegion x@(_, A.Region (A.Position r c) _, _) acc =
+            case acc of
+                [] -> [x]
+                y@(_, A.Region (A.Position r2 c2) _, _) : ys
+                  | (r, c) <= (r2, c2) -> x : acc
+                  | otherwise -> y : insertByRegion x ys
+
+    distinctPaths :: [(String, A.Region, String)] -> [String]
+    distinctPaths xs = Map.keys (Map.fromList [(p, ()) | (_, _, p) <- xs])
 
 
 -- | Map each unqualified name to the list of distinct canonical sources

--- a/test/Sky/Canonicalise/DualImportCollisionSpec.hs
+++ b/test/Sky/Canonicalise/DualImportCollisionSpec.hs
@@ -1,0 +1,219 @@
+module Sky.Canonicalise.DualImportCollisionSpec (spec) where
+
+-- Cycle 4 — D5 regression fence.
+--
+-- Pre-fix bug: when two imports share the same default qualifier
+-- (e.g. `import State` AND `import App.State` — both last-segment
+-- `State`), the canonicaliser's `_importAliases` map (last-wins) and
+-- `_qualVars` map (union) disagree about which canonical module the
+-- qualifier owns. Qualified TYPE references silently misroute to the
+-- LAST imported module's type, while qualified VALUE references reach
+-- whichever module's binding is in `_qualVars`. The result is the
+-- dishonest type error `Foreign 'State.initial': Model vs Model` —
+-- two same-named aliases from different homes printing identically.
+--
+-- Fix: at canonicalisation time, walk the import list and reject when
+-- two imports bind the SAME qualifier but resolve to DIFFERENT
+-- canonical modules. Kernel modules collapse to their kernel pseudo-
+-- module name (so `Sky.Core.Time` + `Std.Time` both routing to the
+-- `Time` kernel does NOT trigger). Two aliased imports of the SAME
+-- module (`import Std.Ui as Ui` + `import Std.Ui exposing (Element)`)
+-- also do not trigger because both resolve to the same canonical
+-- module.
+
+import Test.Hspec
+import qualified System.Exit as Exit
+import System.Directory (getCurrentDirectory, doesFileExist,
+                         createDirectoryIfMissing)
+import System.FilePath ((</>))
+import System.Process (readCreateProcessWithExitCode, shell)
+import System.IO.Temp (withSystemTempDirectory)
+import Data.List (isInfixOf)
+
+
+findSky :: IO FilePath
+findSky = do
+    cwd <- getCurrentDirectory
+    let c = cwd </> "sky-out" </> "sky"
+    ok <- doesFileExist c
+    if ok then return c else fail ("missing: " ++ c)
+
+
+-- | Build a fixture with multiple source files keyed by relative path
+-- (always under `src/`) plus an empty sky.toml. Returns the build's
+-- exit code + combined stdout/stderr.
+buildFixture :: [(FilePath, String)] -> IO (Int, String)
+buildFixture files =
+    withSystemTempDirectory "sky-d5" $ \tmp -> do
+        sky <- findSky
+        createDirectoryIfMissing True (tmp </> "src")
+        writeFile (tmp </> "sky.toml") "name = \"d5-test\"\n"
+        mapM_ (\(p, c) -> do
+            let dst = tmp </> p
+                dir = reverse (dropWhile (/= '/') (reverse dst))
+            createDirectoryIfMissing True dir
+            writeFile dst c) files
+        let cmd = "cd " ++ tmp ++ " && " ++ sky ++ " build src/Main.sky 2>&1"
+        (ec, sout, serr) <- readCreateProcessWithExitCode (shell cmd) ""
+        let combined = sout ++ serr
+            ecInt = case ec of
+                Exit.ExitSuccess -> 0
+                Exit.ExitFailure n -> n
+        return (ecInt, combined)
+
+
+-- A `State` module with a Model alias + initial value.
+stateModule :: String
+stateModule = unlines
+    [ "module State exposing (Model, initial)"
+    , ""
+    , "type alias Model = { count : Int, label : String }"
+    , ""
+    , "initial : Model"
+    , "initial = { count = 0, label = \"init\" }"
+    ]
+
+
+-- An `App.State` module with a DIFFERENT Model alias + a defaultModel.
+-- Same last-segment as State, so its default qualifier collides.
+appStateModule :: String
+appStateModule = unlines
+    [ "module App.State exposing (Model, defaultModel)"
+    , ""
+    , "type alias Model = { foo : String, bar : Int }"
+    , ""
+    , "defaultModel : Model"
+    , "defaultModel = { foo = \"x\", bar = 99 }"
+    ]
+
+
+-- A second module of `App.State` shape that only re-exports a value
+-- (no Model alias) — used for the workaround test so the test asserts
+-- the `as Alias` rename compiles cleanly without bumping into the
+-- unrelated cross-module alias-name-collision bug class.
+appHelpersModule :: String
+appHelpersModule = unlines
+    [ "module App.Helpers exposing (defaultThing)"
+    , ""
+    , "defaultThing : Int"
+    , "defaultThing = 42"
+    ]
+
+
+spec :: Spec
+spec = describe "Cycle 4 D5: dual-import qualifier collision detection" $ do
+
+    it "rejects two imports that share the same default qualifier" $ do
+        -- Pre-fix: silently miscompiled — type checker emitted
+        -- `Foreign 'State.initial': Model vs Model`. Post-fix: clear
+        -- canonicalise error pointing at the import line.
+        let mainSrc = unlines
+                [ "module Main exposing (main)"
+                , ""
+                , "import Sky.Core.Prelude exposing (..)"
+                , "import Std.Log exposing (println)"
+                , "import State"
+                , "import App.State"
+                , ""
+                , "useFn : State.Model"
+                , "useFn = State.initial"
+                , ""
+                , "main = println (toString useFn.count)"
+                ]
+        (ec, out) <- buildFixture
+            [ ("src/Main.sky", mainSrc)
+            , ("src/State.sky", stateModule)
+            , ("src/App/State.sky", appStateModule)
+            ]
+        ec `shouldNotBe` 0
+        -- The dishonest downstream "Model vs Model" must NOT surface
+        -- now — it has to be intercepted at canonicalisation time.
+        out `shouldNotSatisfy` ("Model vs Model" `isInfixOf`)
+        -- The diagnostic explicitly names BOTH imports + the qualifier.
+        out `shouldSatisfy` ("two imports both bind the qualifier" `isInfixOf`)
+        out `shouldSatisfy` ("`State`" `isInfixOf`)
+        out `shouldSatisfy` ("import State" `isInfixOf`)
+        out `shouldSatisfy` ("import App.State" `isInfixOf`)
+        -- And it points the user at the fix-it.
+        out `shouldSatisfy` ("as " `isInfixOf`)
+
+
+    it "accepts the explicit-alias workaround (`import App.X as AppX`)" $ do
+        -- The user-facing escape hatch: alias one of the colliding
+        -- imports. The two qualifiers are now distinct so there's no
+        -- collision. (Using App.Helpers — a sibling module without a
+        -- Model alias — keeps the test focused on D5's exact contract;
+        -- the cross-module alias-name-collision bug class is separate.)
+        let mainSrc = unlines
+                [ "module Main exposing (main)"
+                , ""
+                , "import Sky.Core.Prelude exposing (..)"
+                , "import Std.Log exposing (println)"
+                , "import State"
+                , "import App.Helpers as AppH"
+                , ""
+                , "useFn : State.Model"
+                , "useFn = State.initial"
+                , ""
+                , "main = println (toString (useFn.count + AppH.defaultThing))"
+                ]
+        (ec, out) <- buildFixture
+            [ ("src/Main.sky", mainSrc)
+            , ("src/State.sky", stateModule)
+            , ("src/App/Helpers.sky", appHelpersModule)
+            ]
+        ec `shouldBe` 0
+        out `shouldNotSatisfy` ("two imports both bind" `isInfixOf`)
+        out `shouldSatisfy` ("Compilation successful" `isInfixOf`)
+
+
+    it "does NOT flag two imports of the SAME module under different aliases" $ do
+        -- `import Std.Ui as Ui` plus `import Std.Ui exposing (Element)`
+        -- both reach the qualifier `Ui` (the explicit alias on the
+        -- first, the last-segment fallback on the second). They
+        -- resolve to the SAME canonical module, so my D5 guard must
+        -- NOT trip — this shape is widespread (every Std.Ui-heavy
+        -- example uses it).
+        let src = unlines
+                [ "module Main exposing (main)"
+                , ""
+                , "import Sky.Core.Prelude exposing (..)"
+                , "import Std.Log exposing (println)"
+                , "import Std.Ui as Ui"
+                , "import Std.Ui exposing (Element)"
+                , ""
+                , "view : Element ()"
+                , "view = Ui.text \"ok\""
+                , ""
+                , "main = let _ = view in println \"ok\""
+                ]
+        (ec, out) <- buildFixture [("src/Main.sky", src)]
+        out `shouldNotSatisfy` ("two imports both bind" `isInfixOf`)
+        -- We don't assert success because the dummy `view` may not
+        -- type-check cleanly under every cabal-test variation —
+        -- the only contract is that D5's collision guard does NOT
+        -- trip on aliased same-module re-imports.
+        ec `seq` return ()
+
+
+    it "does NOT flag kernel imports that share a kernel pseudo-module" $ do
+        -- `Sky.Core.Time` and `Std.Time` both alias to the `Time`
+        -- kernel pseudo-module — they route to the same kernel
+        -- dispatch table. Importing both (or either) under the
+        -- default `Time` qualifier must NOT trigger D5's collision
+        -- guard. This shape is uncommon (users import one or the
+        -- other), but the guard's correctness depends on collapsing
+        -- kernel modules onto their pseudo-module name.
+        let src = unlines
+                [ "module Main exposing (main)"
+                , ""
+                , "import Sky.Core.Prelude exposing (..)"
+                , "import Std.Log exposing (println)"
+                , "import Sky.Core.Time"
+                , "import Std.Time"
+                , ""
+                , "main = println \"ok\""
+                ]
+        (ec, out) <- buildFixture [("src/Main.sky", src)]
+        out `shouldNotSatisfy` ("two imports both bind" `isInfixOf`)
+        ec `seq` return ()

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -16,6 +16,7 @@ import qualified Sky.Canonicalise.ExposingSpec
 import qualified Sky.Canonicalise.KernelFallbackSpec
 import qualified Sky.Canonicalise.UnboundSpec
 import qualified Sky.Canonicalise.QualifiedTypeAliasSpec
+import qualified Sky.Canonicalise.DualImportCollisionSpec
 import qualified Sky.Type.ExhaustivenessSpec
 import qualified Sky.Type.AnyWildcardSpec
 import qualified Sky.Type.NumericBinopSpec
@@ -153,6 +154,14 @@ main = hspec $ do
     -- rejected with the cryptic "Color vs Color" message.
     describe "Sky.Canonicalise.QualifiedTypeAlias"
                                          Sky.Canonicalise.QualifiedTypeAliasSpec.spec
+    -- Cycle 4 D5: two imports with the same default qualifier (e.g.
+    -- `import State` + `import App.State` — both last-segment `State`)
+    -- silently miscompiled — the `_importAliases` last-wins vs
+    -- `_qualVars` union mismatch produced the dishonest "Model vs
+    -- Model" type error. Now rejected at canonicalisation time with
+    -- an explicit fix-it suggesting `as Alias`.
+    describe "Sky.Canonicalise.DualImportCollision"
+                                         Sky.Canonicalise.DualImportCollisionSpec.spec
     describe "Sky.Type.Exhaustiveness"   Sky.Type.ExhaustivenessSpec.spec
     -- Cross-branch HM `any` wildcard fix (compiler bug #3). Distinct
     -- occurrences of `any` in source types must NOT share a single


### PR DESCRIPTION
Cycle 4 audit gap D5 — silent miscompile risk closed.

## The bug

When two imports defaulted to the same qualifier (`import State`
AND `import App.State` — both last-segment `State`), the
canonicaliser's `_importAliases` map (last-wins via `Map.insert`)
and `_qualVars` map (union-merged via `Map.insertWith Map.union`)
disagreed about which canonical module owned the qualifier.
Qualified TYPE references silently misrouted to the LAST imported
module, while qualified VALUE references reached whichever
module's binding sat in `_qualVars`. The result was the dishonest
type error:

```
Foreign 'State.initial': Model vs Model
```

Two same-named aliases from different homes printing identically.

## The fix

New `detectImportAliasCollisions` in `Sky.Canonicalise.Module`
walks the import list at canonicalisation time and rejects when
two imports share a qualifier but resolve to DIFFERENT canonical
modules. Kernel modules collapse to their kernel pseudo-module
name first (so `Sky.Core.Time` + `Std.Time` both reach `Time`
without tripping — they share the kernel dispatch table). Two
aliased imports of the SAME module (`import Std.Ui as Ui` plus
`import Std.Ui exposing (Element)`) also do not trip.

The diagnostic points at the first offending import line and
suggests the workaround verbatim:

```
src/Main.sky:5:8: Import error: two imports both bind the qualifier `State`:
  - import State  (at 5:8)
  - import App.State  (at 6:8)
  Add `as <Alias>` to one of them, e.g. `import App.State as AppState`.
```

The user copies the suggested rename and re-runs.

## Tests

New `test/Sky/Canonicalise/DualImportCollisionSpec.hs` — four
cases:

1. Dual-import collision is detected with a clear NAMING ERROR and
   the dishonest downstream "Model vs Model" is NOT emitted.
2. `as Alias` workaround compiles cleanly (uses `App.Helpers` for
   the rename target to keep the test focused on D5's contract —
   the cross-module alias-name-collision bug class is separate).
3. Two aliased imports of the SAME module under different aliases
   do NOT trip (`import Std.Ui as Ui` + `import Std.Ui exposing
   (Element)` — the canonical Std.Ui-heavy pattern).
4. Two kernel imports targeting the SAME kernel pseudo-module do
   NOT trip (`Sky.Core.Time` + `Std.Time` both → `Time`).

All four cases PASS targeted (`cabal test --test-options="--match
DualImportCollision"` — 4/4 in 9 s).

## Scope

D5 closes ONLY the qualifier-collision detection. The deeper
cross-module alias-name collision in `expandTypeAliases` (when two
distinct modules expose aliases with the same NAME, the alias map
collapses both into one entry — last-wins) is a SEPARATE bug class
not in this PR's contract. It surfaces only AFTER the user
disambiguates the qualifier AND uses the colliding alias-name from
BOTH modules in the same source file. The audit's reproducer
hits D5 first, so D5's fix routes the user to the workaround
before that deeper class becomes relevant for most apps.

## Files

- `src/Sky/Canonicalise/Module.hs` — new `detectImportAliasCollisions`
  function + wired into `canonicaliseWithDeps`'s error-collection
  case-analysis (ahead of `importHidingErrors` / `collisions` /
  `unboundErrs` in the `Left` ordering).
- `test/Sky/Canonicalise/DualImportCollisionSpec.hs` — regression
  fence.
- `test/Spec.hs` + `sky-compiler.cabal` — spec registration.

## Verification

- `cabal test` baseline 393/0/1 (v0.15.25 post-release) → 397/0/1
  expected with the 4 new D5 cases.
- 70/70 self-tests green.
- `scripts/example-sweep.sh --build-only` 20/20 green.
- 13-skyshop + 09-live-counter + 27-multi-session-chat +
  28-streaming-chat clean-build verified.

**DO NOT TAG** — accumulates for the next compiler hardening
batch (per 2026-05-26 release-cadence revision).
