### PR TITLE
fix(parse): backslash escape for triple-quoted string interpolation (Cycle 4 D3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1025,6 +1025,12 @@ Single `{` is literal. Interpolation expressions can be
 identifiers, field access (`{{record.field}}`), qualified names
 (`{{String.fromInt n}}`), or function calls.
 
+Escape with backslash: `\{{` emits a literal `{{` (no interpolation).
+Use this to ship Mustache / Handlebars / shell-script placeholders to
+downstream tooling without Sky hijacking them. `\\` collapses to a
+single literal backslash; other `\X` sequences are preserved verbatim
+(regex `\d+`, paths `\test`, etc).
+
 ## Active limitations
 
 Real current compiler limitations users must work around. v0.15

--- a/docs/language/syntax.md
+++ b/docs/language/syntax.md
@@ -126,6 +126,17 @@ html =
 - Preserves newlines and indentation.
 - `{{expr}}` for interpolation (identifier, qualified name, field access, or function call).
 - Single `{` is literal — safe for CSS, JSON, SQL, JS.
+- Backslash escape: `\{{` emits a literal `{{` (no interpolation). Useful for
+  shipping Mustache / Handlebars / shell-script placeholders verbatim:
+
+  ```elm
+  template =
+      """Hello \{{NAME}}, welcome to {{appName}}!"""
+  -- → "Hello {{NAME}}, welcome to MyApp!"
+  ```
+
+  `\\` collapses to a single literal backslash. Other `\X` sequences are
+  preserved verbatim (so regex / paths like `\d+` / `\test` are unaffected).
 
 ## Operators
 

--- a/sky-compiler.cabal
+++ b/sky-compiler.cabal
@@ -281,6 +281,7 @@ test-suite sky-tests
       Sky.Parse.MultiLineCaseKeywordSpec
       Sky.Parse.MultiLineSignatureSpec
       Sky.Parse.RowPolyRecordAnnotationSpec
+      Sky.Parse.MultilineInterpolationEscapeSpec
       Sky.Build.CaseCatchallSubjectDiscardSpec
       Sky.Type.InstanceCaptureSpec
       Sky.Type.SolvedTypesRegionMapSpec

--- a/src/Sky/Canonicalise/Expression.hs
+++ b/src/Sky/Canonicalise/Expression.hs
@@ -1,6 +1,8 @@
 -- | Canonicalise expressions — resolve all variable references.
 module Sky.Canonicalise.Expression
     ( canonicaliseExpr
+    , Chunk(..)
+    , splitInterpolation
     )
     where
 
@@ -555,16 +557,33 @@ data Chunk = Lit String | ExprChunk String deriving (Show)
 
 
 -- Split a raw multiline string into alternating Lit / ExprChunk parts.
+--
+-- Escape grammar (D3, audit-driven):
+--   `\{{`  → literal `{{` (no interpolation consumed; `}}` later stays literal)
+--   `\\`   → literal `\`
+--   `\X`   → literal `\X` for any other X (backwards-compatible: today the
+--            lexer preserves backslashes verbatim, so `\test`, `\n`, `\d` all
+--            keep flowing through as the user wrote them)
+-- This lets a triple-quoted string ship literal `{{NAME}}` template
+-- placeholders for downstream tooling (Mustache / Handlebars / env-var
+-- substitution / shell scripts) without Sky hijacking them.
 splitInterpolation :: String -> [Chunk]
 splitInterpolation = go ""
   where
     go acc [] = emit acc []
+    -- Escape: \{{ emits literal {{ (no interpolation).
+    go acc ('\\':'{':'{':rest) = go (acc ++ "{{") rest
+    -- Escape: \\ collapses to a single literal \.
+    go acc ('\\':'\\':rest) = go (acc ++ "\\") rest
+    -- Interpolation start.
     go acc ('{':'{':rest) =
         let (inside, after) = span (/= '}') rest
         in case after of
             ('}':'}':after') ->
                 emit acc (ExprChunk inside : go "" after')
             _ -> go (acc ++ "{{") rest  -- unclosed {{; treat as literal
+    -- Any other character (including a `\` not followed by `{{` or `\`) is
+    -- copied verbatim.
     go acc (c:rest) = go (acc ++ [c]) rest
 
     emit "" rest = rest

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -473,6 +473,8 @@ sql =
 
 Single braces `{` are literal — safe for JavaScript, CSS, JSON, SQL. Interpolation expressions support identifiers, field access, qualified names, and function calls.
 
+Escape with backslash: `\{{` emits a literal `{{` (no interpolation). Use this to ship Mustache / Handlebars / shell-script placeholders to downstream tooling without Sky hijacking them. `\\` collapses to a single backslash; other `\X` sequences are preserved (regex `\d+`, paths `\test`, etc).
+
 ### Patterns
 
 Literals, constructors (`Just x`, `Ok v`, `Err e`), tuples `(a, b)`, lists `[]`, `[x]`, `x :: xs`, wildcards `_`, as-patterns `Just x as original`, nested `Ok (Just x)`

--- a/test/Sky/Parse/MultilineInterpolationEscapeSpec.hs
+++ b/test/Sky/Parse/MultilineInterpolationEscapeSpec.hs
@@ -1,0 +1,129 @@
+module Sky.Parse.MultilineInterpolationEscapeSpec (spec) where
+
+import Test.Hspec
+import System.Directory (getCurrentDirectory, doesFileExist,
+                         createDirectoryIfMissing)
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import System.Process (readCreateProcessWithExitCode, proc, CreateProcess(..))
+import System.Exit (ExitCode(..))
+
+import Sky.Canonicalise.Expression (Chunk(..), splitInterpolation)
+
+
+-- Regression: Cycle 4 audit D3 — triple-quoted strings unconditionally
+-- treated `{{NAME}}` as Sky interpolation with no escape hatch. A
+-- template intended as a placeholder for OTHER tooling (Mustache /
+-- Handlebars / env-var substitution / shell scripts) was hijacked into
+-- a Sky variable reference; codegen then emitted `undefined: NAME`
+-- under `go build`.
+--
+-- Fix landed in `src/Sky/Canonicalise/Expression.hs:splitInterpolation`
+-- — added `\{{` as the escape for a literal `{{`, plus `\\` collapsing
+-- to a literal `\` so users can write `\` immediately before an
+-- interpolation. Other `\X` sequences stay verbatim (preserves the
+-- pre-existing "multiline preserves backslashes" contract).
+spec :: Spec
+spec = do
+    describe "splitInterpolation chunk decomposition" $ do
+
+        it "interpolates {{NAME}} unchanged when not escaped" $
+            splitInterpolation "hello {{name}}!"
+                `shouldChunk` [Lit "hello ", ExprChunk "name", Lit "!"]
+
+        it "treats \\{{NAME}} as the literal text {{NAME}}" $
+            splitInterpolation "Hello \\{{NAME}}, welcome"
+                `shouldChunk` [Lit "Hello {{NAME}}, welcome"]
+
+        it "treats \\\\ as literal \\ (single backslash)" $
+            splitInterpolation "path \\\\here"
+                `shouldChunk` [Lit "path \\here"]
+
+        it "double escape: \\\\{{name}} produces \\ + interpolated name" $
+            splitInterpolation "\\\\{{name}}"
+                `shouldChunk` [Lit "\\", ExprChunk "name"]
+
+        it "leaves \\X (non-escape) verbatim — preserves \\test, \\d, \\n" $ do
+            splitInterpolation "\\test" `shouldChunk` [Lit "\\test"]
+            splitInterpolation "\\d+"   `shouldChunk` [Lit "\\d+"]
+            splitInterpolation "\\n"    `shouldChunk` [Lit "\\n"]
+
+        it "mixes literal placeholders with real interpolation in the same string" $
+            splitInterpolation "Run \\{{LITERAL}} and {{var}} together"
+                `shouldChunk` [ Lit "Run {{LITERAL}} and "
+                              , ExprChunk "var"
+                              , Lit " together"
+                              ]
+
+        it "ignores stray { (single brace is literal — pre-existing rule)" $
+            splitInterpolation "use { not {{x}}"
+                `shouldChunk` [Lit "use { not ", ExprChunk "x"]
+
+        it "treats an unclosed {{ as literal (pre-existing rule)" $
+            splitInterpolation "broken {{abc"
+                `shouldChunk` [Lit "broken {{abc"]
+
+    -- End-to-end: the audit D3 reproducer must compile + run with the
+    -- expected literal output once the escape is in place.
+    describe "end-to-end: \\{{NAME}} in a triple-quoted string compiles + outputs literal text" $
+        it "audit D3 reproducer builds + emits the templated placeholders verbatim" $ do
+            sky <- findSky
+            withSystemTempDirectory "sky-multiline-escape" $ \tmp -> do
+                createDirectoryIfMissing True (tmp </> "src")
+                writeFile (tmp </> "sky.toml")
+                    ("name = \"multiline-escape\"\n"
+                     ++ "version = \"0.0.0\"\n"
+                     ++ "entry = \"src/Main.sky\"\n\n"
+                     ++ "[source]\nroot = \"src\"\n")
+                writeFile (tmp </> "src" </> "Main.sky") fixture
+                let buildCp = (proc sky ["build", "src/Main.sky"]) { cwd = Just tmp }
+                (ec, _, _) <- readCreateProcessWithExitCode buildCp ""
+                ec `shouldBe` ExitSuccess
+                built <- doesFileExist (tmp </> "sky-out" </> "app")
+                built `shouldBe` True
+                let runCp = (proc (tmp </> "sky-out" </> "app") []) { cwd = Just tmp }
+                (runEc, runOut, _) <- readCreateProcessWithExitCode runCp ""
+                runEc `shouldBe` ExitSuccess
+                runOut `shouldBe` expectedOutput
+
+
+-- ── helpers ─────────────────────────────────────────────────────────
+
+shouldChunk :: [Chunk] -> [Chunk] -> Expectation
+shouldChunk actual expected = chunkRepr actual `shouldBe` chunkRepr expected
+  where
+    chunkRepr = map repr
+    repr (Lit s) = "Lit " ++ show s
+    repr (ExprChunk s) = "Expr " ++ show s
+
+
+findSky :: IO FilePath
+findSky = do
+    cwd <- getCurrentDirectory
+    let candidate = cwd </> "sky-out" </> "sky"
+    ok <- doesFileExist candidate
+    if ok then return candidate
+          else fail ("sky binary missing at " ++ candidate)
+
+
+fixture :: String
+fixture = unlines
+    [ "module Main exposing (main)"
+    , ""
+    , "import Sky.Core.Prelude exposing (..)"
+    , "import Std.Log exposing (println)"
+    , ""
+    , "template : String"
+    , "template = \"\"\"Hello \\{{NAME}},"
+    , "your account \\{{ACCOUNT_ID}} has balance \\{{BALANCE}}.\"\"\""
+    , ""
+    , "main ="
+    , "    println template"
+    ]
+
+
+expectedOutput :: String
+expectedOutput = unlines
+    [ "Hello {{NAME}},"
+    , "your account {{ACCOUNT_ID}} has balance {{BALANCE}}."
+    ]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -35,6 +35,7 @@ import qualified Sky.Parse.MultiLineCaseSubjectSpec
 import qualified Sky.Parse.MultiLineCaseKeywordSpec
 import qualified Sky.Parse.MultiLineSignatureSpec
 import qualified Sky.Parse.RowPolyRecordAnnotationSpec
+import qualified Sky.Parse.MultilineInterpolationEscapeSpec
 import qualified Sky.Build.CaseCatchallSubjectDiscardSpec
 import qualified Sky.Format.FormatSpec
 import qualified Sky.Build.GoKeywordCollisionSpec
@@ -210,6 +211,12 @@ main = hspec $ do
     describe "Sky.Parse.MultiLineSignature" Sky.Parse.MultiLineSignatureSpec.spec
     describe "Sky.Parse.RowPolyRecordAnnotation"
         Sky.Parse.RowPolyRecordAnnotationSpec.spec
+    -- Cycle 4 D3: `\{{NAME}}` escape for literal `{{NAME}}` placeholders
+    -- in triple-quoted strings (Mustache / Handlebars / shell-script
+    -- templating). Pre-fix the desugarer ate every `{{ident}}` as a Sky
+    -- variable reference; codegen then emitted `undefined: NAME`.
+    describe "Sky.Parse.MultilineInterpolationEscape"
+        Sky.Parse.MultilineInterpolationEscapeSpec.spec
     describe "Sky.Build.CaseCatchallSubjectDiscard"
         Sky.Build.CaseCatchallSubjectDiscardSpec.spec
     -- Closed-record exactness + cross-module externals registration:


### PR DESCRIPTION
## Summary

Cycle 4 audit gap D3 — triple-quoted strings unconditionally treated `{{NAME}}` as Sky interpolation. A template intended as a placeholder for OTHER tooling (Mustache / Handlebars / shell-script env-substitution) was hijacked into a Sky variable reference; codegen then emitted `undefined: NAME` under `go build`.

## Fix

Added a backslash escape in `splitInterpolation` (`src/Sky/Canonicalise/Expression.hs`):

- `\{{` → literal `{{` (no interpolation consumed)
- `\\` → literal `\` (single backslash)
- `\X` for any other X → verbatim `\X` (preserves the pre-existing "multiline preserves backslashes" contract — regex `\d+`, paths `\test`, etc keep working)

## Tests

New `test/Sky/Parse/MultilineInterpolationEscapeSpec.hs` — 9 cases:

1. `{{NAME}}` still interpolates (no regression)
2. `\{{NAME}}` produces literal `{{NAME}}`
3. `\\` collapses to literal `\`
4. `\\{{name}}` produces `\` + interpolated name
5. `\X` (non-escape) stays verbatim for `\test`, `\d+`, `\n`
6. Mixed: `\{{LITERAL}} and {{var}}` produces correct alternating chunks
7. Stray `{` (single brace) is literal (pre-existing rule)
8. Unclosed `{{` is literal (pre-existing rule)
9. End-to-end: audit D3 reproducer compiles + outputs the templated placeholders verbatim

## Verification

- 9/9 D3 specs pass
- 20/20 example sweep (`--build-only`) clean
- Docs updated: `docs/language/syntax.md`, `CLAUDE.md`, `templates/CLAUDE.md`

## Cadence

DO NOT TAG — batches with D5 (#105) into the next compiler safety follow-up tag.