### PR TITLE
feat(stdlib): Std.PubSub.publish — Task-shaped pub/sub for raw handlers (Cycle 4 PT)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -508,8 +508,9 @@ Each binding is either:
 | Module | Path | Key functions |
 |---|---|---|
 | `Task` | `Sky.Core.Task` | succeed, fail, map, andThen, perform, sequence, parallel, lazy, run, fromResult, andThenResult, mapError, onError |
-| `Cmd` | `Std.Cmd` | none, batch, perform |
-| `Sub` | `Std.Sub` | none, every |
+| `Cmd` | `Std.Cmd` | none, batch, perform, publish (pub/sub from update return) |
+| `Sub` | `Std.Sub` | none, every, batch, subscribeTopic (pub/sub receive) |
+| `PubSub` | `Std.PubSub` | publish (Task-shaped — callable from raw `api` handlers / post-init / scheduled jobs; complements `Cmd.publish` which is bound to update-returns) |
 | `Time` | `Sky.Core.Time` | now, sleep, every, unixMillis, format/formatISO8601/formatRFC3339/formatHTTP, addMillis, diffMillis, timeString |
 | `Std.Time` | `Std.Time` | 32 entries. IANA zones, addMonths/Years (month-end CLAMPED), dayOfWeek (ISO Mon=1..Sun=7), weekOfYear (ISO 8601), startOfDay/Week/Month/Year, diffDays/Hours/Minutes/Seconds. |
 | `Random` | `Sky.Core.Random` | int, float |

--- a/docs/skylive/pubsub.md
+++ b/docs/skylive/pubsub.md
@@ -53,14 +53,32 @@ doesn't deprecate polling for use cases that genuinely need it.
 
 ## API
 
-Two primitives, one per side of the TEA loop:
+Three primitives — one per side of the TEA loop, plus a Task-shaped
+escape hatch for non-Live contexts:
 
 ```elm
--- Std.Cmd
+-- Std.Cmd            (update-return tuple side)
 publish : String -> any -> Cmd msg
--- Std.Sub
+-- Std.Sub            (subscriptions side)
 subscribeTopic : String -> (any -> msg) -> Sub msg
+-- Std.PubSub         (Task-shaped — any goroutine)
+publish : String -> any -> Task Error Int
 ```
+
+`Cmd.publish` and `Std.PubSub.publish` route to the same in-process
+broker — a subscriber sees the same `SessionEvent` regardless of
+which side fired it. They differ only in where they can be CALLED
+from:
+
+- `Cmd.publish` lives inside an `update msg model -> (Model, Cmd Msg)`
+  return. Use it for "user clicked → broadcast" or "another Msg
+  triggered a broadcast".
+- `Std.PubSub.publish` returns a `Task Error Int` runnable from ANY
+  goroutine — raw `Sky.Http.Server` `api` handlers, post-init
+  bootstrap, scheduled jobs, callbacks from external systems
+  (webhooks). The `Int` is the broker's delivery count. Errors with
+  `Unavailable` when no `Live.app` is running in this process
+  (CLI tools, isolated unit tests, pure HTTP servers).
 
 ### `Cmd.publish topic payload`
 
@@ -136,6 +154,62 @@ The runtime diff-updates subscriptions on every dispatch: topics in
 the intersection of the old + new sets keep their existing goroutine
 + broker registration (no broadcast loss in the gap); only added
 topics open new subscriptions and only removed topics cancel.
+
+### `Std.PubSub.publish topic payload` — Task-shaped
+
+Same broadcast semantics as `Cmd.publish`, but returns a
+`Task Error Int` you can run from contexts that don't have a `Cmd msg`
+channel:
+
+- Raw `Sky.Http.Server` `api` handlers (webhooks, callbacks from
+  external systems, internal admin endpoints).
+- Post-init bootstrap (e.g. seed-data load that needs to notify
+  warming subscribers).
+- Scheduled jobs (cron handlers, queue workers).
+- Anything else running on a goroutine that's not the Sky.Live
+  update loop.
+
+The Task resolves with the count of subscribers that received the
+broadcast (the same `int` `Cmd.publish` gets in its internal path).
+Errors with `Unavailable` when no `Live.app` is registered in this
+process.
+
+```elm
+import Std.PubSub as PubSub
+
+-- A GitHub webhook lands as a raw api handler — no update tuple
+-- in scope, but we want every dashboard tab watching this repo's
+-- deploys to learn instantly.
+handleGithubWebhook : Dict String any -> Response
+handleGithubWebhook req =
+    case decodeWebhook req of
+        Err _ ->
+            plain 400 "bad webhook payload"
+
+        Ok ev ->
+            let
+                -- 1) durable write first (matches the same pattern
+                --    described below for Cmd.publish — the topic is
+                --    a notification, the DB row is the source of
+                --    truth).
+                _ = Store.recordWebhook ev
+                -- 2) push the notification — Task.run forces the
+                --    Task at the handler boundary.
+                _ = Task.run
+                        (PubSub.publish
+                            ("deploy:status:" ++ ev.appSlug)
+                            (encodeDeployEvent ev))
+            in
+                plain 200 "ok"
+```
+
+Origin is the empty string on the broker side — server-side publishes
+have no originating session and therefore no echo-suppression target.
+Subscribers that filter on `Origin == ownSid` see these as foreign and
+will receive them normally.
+
+The same in-process scope rules as `Cmd.publish` apply (v0.15.x:
+in-process only; v0.16+ cross-process tiers cover both APIs uniformly).
 
 ## The durability pattern: write to DB FIRST, publish SECOND
 

--- a/runtime-go/rt/live.go
+++ b/runtime-go/rt/live.go
@@ -2358,6 +2358,11 @@ func liveAppRun(cfg any) any {
 	// app-wide; the store owns the binding so v0.16+ cross-process
 	// backends can swap implementations without touching call sites).
 	app.topics = app.store.Broker()
+	// Cycle 4 PT: register as the process-global broker so
+	// Std.PubSub.publish (Task-shaped, callable from raw api
+	// handlers / post-init goroutines / scheduled jobs) can find a
+	// *liveApp without an update-tuple context.
+	registerProcessBroker(app)
 
 	// Resolve listen port early so sub-app spawn helpers
 	// (maybeAutoMountConsole below) can pass it to children via

--- a/runtime-go/rt/live_pubsub_task.go
+++ b/runtime-go/rt/live_pubsub_task.go
@@ -1,0 +1,73 @@
+package rt
+
+import "sync/atomic"
+
+// processBroker — the process's active *liveApp, set by Live_app when
+// the broker is wired (see liveAppRun in live.go). Reads happen on the
+// hot path of PubSub_publish so the atomic.Pointer is preferable to a
+// sync.Mutex.
+//
+// Single-app process: works trivially.
+// Multi-app process (rare — each Live.app binds its own port, but a
+// program could orchestrate several): the most-recently-registered app
+// wins. Documented limitation; consistent with the existing port-
+// binding model.
+var processBroker atomic.Pointer[liveApp]
+
+// registerProcessBroker — called once per Live.app startup, after
+// app.topics has been wired from app.store.Broker(). Subsequent
+// callers overwrite the previous registration (last writer wins).
+//
+// Tests use unregisterProcessBroker() to keep package state clean
+// between cases.
+func registerProcessBroker(app *liveApp) {
+	processBroker.Store(app)
+}
+
+// unregisterProcessBroker — test helper; in production the process
+// exits when the Live.app's http.ListenAndServe returns, so manual
+// teardown is unnecessary.
+func unregisterProcessBroker() {
+	processBroker.Store(nil)
+}
+
+// PubSub_publish — Task-shaped publish callable from ANY goroutine.
+//
+// Sky surface:
+//
+//	Std.PubSub.publish : String -> any -> Task Error Int
+//
+// Returns the count of subscribers that received the broadcast.
+// Returns Err(Unavailable) when no Live.app has been registered in
+// this process (CLI tools, isolated unit tests, agent-service-only
+// processes without a Live.app).
+//
+// Unlike Std.Cmd.publish — which requires an update-return tuple
+// and therefore only fires from Sky.Live `update` — PubSub_publish
+// works from raw Sky.Http.Server `api` handlers, post-init
+// goroutines, scheduled jobs, and any other "I need to broadcast
+// state without an update Cmd" context.
+//
+// Origin is the empty string: server-side publishes are not tied to
+// any originating session and therefore have no echo-suppression
+// target. (Subscribers' Origin checks against their own sid will
+// naturally not match "".)
+func PubSub_publish(topicArg, payloadArg any) any {
+	topic := AsString(topicArg)
+	return func() any {
+		app := processBroker.Load()
+		if app == nil {
+			return Err[any, any](ErrUnavailable(
+				"PubSub.publish: no Sky.Live app registered in this process — Task-shaped publish needs Live.app running",
+			))
+		}
+		if app.topics == nil {
+			return Ok[any, any](0)
+		}
+		delivered := app.Publish(topic, SessionEvent{
+			Payload: payloadArg,
+			Origin:  "",
+		})
+		return Ok[any, any](delivered)
+	}
+}

--- a/runtime-go/rt/live_pubsub_task_test.go
+++ b/runtime-go/rt/live_pubsub_task_test.go
@@ -1,0 +1,162 @@
+package rt
+
+import (
+	"testing"
+)
+
+// Cycle 4 PT — Task-shaped Std.PubSub.publish.
+//
+// Pins the contract that publish from any goroutine (i.e. NOT from a
+// Sky.Live update return) reaches every subscriber on the process's
+// active broker, with the same `int` delivery count that runCmd's
+// publish arm sees inside the update loop.
+
+// Test_PubSubPublishTask_NoLiveApp — when no Live.app has been
+// registered in the process, PubSub_publish returns an Err with the
+// Unavailable code. CLI tools / unit tests that never start a
+// Live.app see this; production deploys never should.
+func Test_PubSubPublishTask_NoLiveApp(t *testing.T) {
+	unregisterProcessBroker()
+	t.Cleanup(unregisterProcessBroker)
+
+	taskFn := PubSub_publish("any-topic", "payload").(func() any)
+	result := taskFn()
+
+	// Decode the SkyResult shape — Err carries the Error value.
+	if !isResultErr(result) {
+		t.Fatalf("expected Err, got Ok with value: %v", result)
+	}
+}
+
+// Test_PubSubPublishTask_NilTopicsField — Live.app registered but its
+// topics field is nil (test apps that skip the store.Broker() wiring).
+// PubSub_publish returns Ok(0) without panicking — no subscribers
+// means zero delivery, which is success, not error.
+func Test_PubSubPublishTask_NilTopicsField(t *testing.T) {
+	unregisterProcessBroker()
+	t.Cleanup(unregisterProcessBroker)
+
+	app := &liveApp{} // .topics intentionally nil
+	registerProcessBroker(app)
+
+	taskFn := PubSub_publish("any-topic", "payload").(func() any)
+	result := taskFn()
+
+	if !isResultOk(result) {
+		t.Fatalf("expected Ok(0), got: %v", result)
+	}
+	delivered := resultOkValue(result).(int)
+	if delivered != 0 {
+		t.Fatalf("expected delivery count 0, got %d", delivered)
+	}
+}
+
+// Test_PubSubPublishTask_DeliversToSubscriber — the happy path. A
+// real topicRegistry with one subscriber sees the publish; the
+// returned Ok carries delivery count 1.
+func Test_PubSubPublishTask_DeliversToSubscriber(t *testing.T) {
+	unregisterProcessBroker()
+	t.Cleanup(unregisterProcessBroker)
+
+	app := &liveApp{topics: newTopicRegistry(16)}
+	registerProcessBroker(app)
+
+	// Subscribe before publishing; otherwise the delivery count
+	// is naturally zero (matches in-process broker semantics —
+	// publishes to an empty topic are not buffered).
+	ch, cancel := app.topics.Subscribe("metrics:request")
+	defer cancel()
+
+	taskFn := PubSub_publish("metrics:request", map[string]any{"path": "/healthz"}).(func() any)
+	result := taskFn()
+
+	if !isResultOk(result) {
+		t.Fatalf("expected Ok, got: %v", result)
+	}
+	delivered := resultOkValue(result).(int)
+	if delivered != 1 {
+		t.Fatalf("expected delivery count 1, got %d", delivered)
+	}
+
+	// Confirm the subscriber actually received the payload.
+	select {
+	case ev := <-ch:
+		payload, ok := ev.Payload.(map[string]any)
+		if !ok {
+			t.Fatalf("expected map[string]any payload, got %T (%v)", ev.Payload, ev.Payload)
+		}
+		if payload["path"] != "/healthz" {
+			t.Fatalf("expected path /healthz, got %v", payload["path"])
+		}
+		if ev.Origin != "" {
+			t.Fatalf("expected empty Origin (server-side publish), got %q", ev.Origin)
+		}
+	default:
+		t.Fatal("subscriber did not receive the broadcast")
+	}
+}
+
+// Test_PubSubPublishTask_LastRegisteredWins — a process running
+// multiple Live.app starts (rare but legal) sees PubSub_publish
+// route to the most recently registered app's broker.
+func Test_PubSubPublishTask_LastRegisteredWins(t *testing.T) {
+	unregisterProcessBroker()
+	t.Cleanup(unregisterProcessBroker)
+
+	first := &liveApp{topics: newTopicRegistry(16)}
+	second := &liveApp{topics: newTopicRegistry(16)}
+
+	registerProcessBroker(first)
+	registerProcessBroker(second) // overwrites; last writer wins
+
+	firstCh, firstCancel := first.topics.Subscribe("topic")
+	defer firstCancel()
+	secondCh, secondCancel := second.topics.Subscribe("topic")
+	defer secondCancel()
+
+	taskFn := PubSub_publish("topic", "p").(func() any)
+	_ = taskFn()
+
+	// First app's subscriber must not receive — publish went to
+	// second app's broker.
+	select {
+	case ev := <-firstCh:
+		t.Fatalf("first app's subscriber unexpectedly received: %v", ev.Payload)
+	default:
+	}
+
+	// Second app's subscriber receives.
+	select {
+	case ev := <-secondCh:
+		if ev.Payload != "p" {
+			t.Fatalf("expected payload \"p\", got %v", ev.Payload)
+		}
+	default:
+		t.Fatal("second app's subscriber did not receive the broadcast")
+	}
+}
+
+// ────────────────────────────────────────────────────────────────
+// Result-shape helpers — SkyResult uses {Tag: int, OkValue, ErrValue}
+// with Tag 0=Ok, 1=Err.
+
+func isResultOk(v any) bool {
+	r, ok := v.(SkyResult[any, any])
+	if !ok {
+		return false
+	}
+	return r.Tag == 0
+}
+
+func isResultErr(v any) bool {
+	r, ok := v.(SkyResult[any, any])
+	if !ok {
+		return false
+	}
+	return r.Tag == 1
+}
+
+func resultOkValue(v any) any {
+	r := v.(SkyResult[any, any])
+	return r.OkValue
+}

--- a/sky-compiler.cabal
+++ b/sky-compiler.cabal
@@ -277,6 +277,7 @@ test-suite sky-tests
       Sky.Build.EntryLocalShadowsDepSpec
       Sky.Build.CaseSubjectNameShadowSpec
       Sky.Build.FfiKernelAliasSpec
+      Sky.Build.PubSubPublishTaskSpec
       Sky.Parse.MultiLineCaseSubjectSpec
       Sky.Parse.MultiLineCaseKeywordSpec
       Sky.Parse.MultiLineSignatureSpec

--- a/sky-stdlib/Std/PubSub.sky
+++ b/sky-stdlib/Std/PubSub.sky
@@ -1,0 +1,48 @@
+-- | Std.PubSub — Task-shaped publish, callable from ANY context.
+--
+-- A complement to `Std.Cmd.publish` (which only fires from a
+-- Sky.Live `update` return). `Std.PubSub.publish` returns a
+-- `Task Error Int` you can run from raw `Sky.Http.Server` `api`
+-- handlers, post-init goroutines, scheduled jobs, callbacks from
+-- external systems — anywhere you'd otherwise have no `Cmd msg`
+-- channel to use.
+--
+-- The Task resolves with the count of subscribers that received
+-- the broadcast (the same `Int` `app.Publish` returns inside the
+-- update-loop path), or `Err Unavailable` when no `Live.app` is
+-- running in this process (a CLI tool, an isolated unit test, a
+-- pure `Sky.Http.Server` process).
+--
+-- Scope (matches `Std.Cmd.publish`): in-process only in v0.15.x.
+-- The same `topicRegistry` backs both APIs, so a publish from a
+-- raw handler reaches every subscribed Sky.Live session in the
+-- same process, with identical ordering + echo semantics.
+--
+-- See `docs/skylive/pubsub.md` for the decision matrix and
+-- `examples/29-task-publish` for the canonical pattern.
+module Std.PubSub exposing (publish)
+
+import Sky.Ffi as Ffi
+import Sky.Core.Error exposing (Error)
+import Sky.Core.Task as Task
+
+
+-- | `publish topic payload` — broadcast `payload` on `topic` to
+-- every Sky.Live session in this process whose `subscriptions`
+-- includes `Sub.subscribeTopic topic _`.
+--
+-- Returns the count of subscribers that received the broadcast.
+-- A topic with no live subscribers returns 0 (not an error).
+--
+-- Fire-and-forget by design — no acknowledgement loop, no
+-- delivery guarantee beyond the in-process broker's invariant
+-- (one bump per publish, before fan-out). Pair with a durable
+-- write (DB row, append-only log) when persistence matters.
+--
+-- Errors with `Unavailable` when no `Live.app` is registered in
+-- this process. CLI tools / pure HTTP servers / unit tests that
+-- never start a `Live.app` see this; production deploys never
+-- should.
+publish : String -> any -> Task Error Int
+publish =
+    Ffi.kernel "PubSub_publish"

--- a/src/Sky/Build/EmbeddedRuntime.hs
+++ b/src/Sky/Build/EmbeddedRuntime.hs
@@ -30,6 +30,7 @@
 -- below — so cabal recompiles it and the splice re-walks the tree.
 --
 -- re-embed marker: 2026-05-27 — Cycle 4 HS (rev7): JS comment </script> literal escaped + stream-loop session stamp
+-- re-embed marker: 2026-05-28 — Cycle 4 PT: Std.PubSub.publish (Task-shaped) + Std/PubSub.sky stdlib + live_pubsub_task.go runtime
 module Sky.Build.EmbeddedRuntime
     ( embeddedRuntime
     , embeddedSkyStdlib

--- a/src/Sky/Generate/Go/Kernel.hs
+++ b/src/Sky/Generate/Go/Kernel.hs
@@ -491,6 +491,13 @@ registry = Map.fromList
     , (("HttpStream", "close"),   KernelInfo "rt.HttpStream_close" 1 True)
 
     -- ═══════════════════════════════════════════════════════
+    -- Std.PubSub  (Cycle 4 PT — Task-shaped publish, callable from
+    -- any context; complements Cmd.publish which only fires from
+    -- a Sky.Live update return).
+    -- ═══════════════════════════════════════════════════════
+    , (("PubSub", "publish"),     KernelInfo "rt.PubSub_publish" 2 True)
+
+    -- ═══════════════════════════════════════════════════════
     -- Set
     -- ═══════════════════════════════════════════════════════
     , (("Set", "empty"),          KernelInfo "rt.Set_empty" 0 False)

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -1284,6 +1284,16 @@ every          : Int -> msg -> Sub msg                 -- timer; fires msg every
 subscribeTopic : String -> (any -> msg) -> Sub msg     -- pub/sub receive (Sky.Live only)
 ```
 
+### Std.PubSub
+
+Task-shaped publish for ANY context (raw `Sky.Http.Server` `api` handlers, post-init goroutines, scheduled jobs, webhook callbacks). Complements `Cmd.publish` which only fires from a Sky.Live `update` return — same broker, same subscribers, same in-process semantics.
+
+```elm
+publish : String -> any -> Task Error Int    -- delivery count; Err Unavailable if no Live.app
+```
+
+Both `Cmd.publish` and `Std.PubSub.publish` route to the same in-process topic registry — a subscriber's `Sub.subscribeTopic` receives them identically. Use `Cmd.publish` when you're inside an update return; use `Std.PubSub.publish` (with `Task.run` or `Cmd.perform`) from anywhere else.
+
 ### Std.Time
 
 ```elm

--- a/test/Sky/Build/PubSubPublishTaskSpec.hs
+++ b/test/Sky/Build/PubSubPublishTaskSpec.hs
@@ -1,0 +1,108 @@
+module Sky.Build.PubSubPublishTaskSpec (spec) where
+
+import Test.Hspec
+import System.Directory (getCurrentDirectory, doesFileExist,
+                         createDirectoryIfMissing)
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import System.Process (readCreateProcessWithExitCode, proc, CreateProcess(..))
+import System.Exit (ExitCode(..))
+import Data.List (isInfixOf)
+
+
+-- Cycle 4 PT — Std.PubSub.publish (Task-shaped, callable from any
+-- context, complements Cmd.publish which only fires from a Sky.Live
+-- update return).
+--
+-- This spec pins:
+--
+--   1. Std.PubSub typechecks + builds when imported by user code.
+--
+--   2. The call site routes to rt.PubSub_publish (the kernel entry
+--      registered in src/Sky/Generate/Go/Kernel.hs:494) — NOT to
+--      rt.Ffi_kernel (the panic stub) or any alias-body call.
+--
+--   3. A run with no Sky.Live app registered in this process
+--      surfaces the Err(Unavailable) branch at runtime, not a
+--      panic or silent zero.
+--
+-- The matching runtime contract (PubSub_publish reads
+-- processBroker, returns Ok(deliveryCount) or Err(Unavailable))
+-- is exercised in runtime-go/rt/live_pubsub_task_test.go.
+spec :: Spec
+spec = describe "Std.PubSub.publish (Cycle 4 PT)" $ do
+    it "type-checks + builds + routes to rt.PubSub_publish + runs the Err branch when no Live.app" $ do
+        sky <- findSky
+        withSystemTempDirectory "sky-pubsub-task" $ \tmp -> do
+            writeFixture tmp
+            (ec, out, errOut) <- runSky sky ["build", "src/Main.sky"] tmp
+            if ec /= ExitSuccess
+                then expectationFailure $
+                    "sky build failed.\n" ++ out ++ "\n" ++ errOut
+                else do
+                    built <- doesFileExist (tmp </> "sky-out" </> "app")
+                    built `shouldBe` True
+                    body <- readFile (tmp </> "sky-out" </> "main.go")
+                    -- Call site lowers to rt.PubSub_publish (the
+                    -- registered kernel). The rt.Ffi_kernel panic
+                    -- stub may legitimately appear in the dead
+                    -- alias body declaration — what matters is the
+                    -- call site routes correctly AND the program
+                    -- reaches the runtime branch (verified below).
+                    let routesToKernel = "rt.PubSub_publish(" `isInfixOf` body
+                    routesToKernel `shouldBe` True
+                    -- Run with no Live.app — Err branch fires.
+                    (rc, runOut, _) <- runApp tmp
+                    rc `shouldBe` ExitSuccess
+                    ("no-live-app" `isInfixOf` runOut) `shouldBe` True
+
+  where
+    fixture :: String
+    fixture =
+        "module Main exposing (main)\n\n\
+        \import Sky.Core.Prelude exposing (..)\n\
+        \import Sky.Core.Task as Task\n\
+        \import Sky.Core.Dict as Dict\n\
+        \import Std.PubSub as PubSub\n\
+        \import Std.Log exposing (println)\n\n\n\
+        \main =\n\
+        \    let\n\
+        \        payload = Dict.fromList [( \"k\", \"v\" )]\n\
+        \        result = Task.run (PubSub.publish \"t\" payload)\n\
+        \    in\n\
+        \        case result of\n\
+        \            Ok n ->\n\
+        \                println (\"ok-\" ++ String.fromInt n)\n\
+        \            Err _ ->\n\
+        \                println \"no-live-app\"\n"
+
+    writeFixture :: FilePath -> IO ()
+    writeFixture tmp = do
+        createDirectoryIfMissing True (tmp </> "src")
+        writeFile (tmp </> "sky.toml")
+            ("name = \"pubsub-task\"\n"
+                ++ "version = \"0.0.0\"\n"
+                ++ "entry = \"src/Main.sky\"\n\n"
+                ++ "[source]\nroot = \"src\"\n")
+        writeFile (tmp </> "src" </> "Main.sky") fixture
+
+    findSky :: IO FilePath
+    findSky = do
+        cwd <- getCurrentDirectory
+        let candidate = cwd </> "sky-out" </> "sky"
+        ok <- doesFileExist candidate
+        if ok
+            then return candidate
+            else return "sky"
+
+    runSky :: FilePath -> [String] -> FilePath -> IO (ExitCode, String, String)
+    runSky sky args cwd =
+        readCreateProcessWithExitCode
+            ((proc sky args) { cwd = Just cwd })
+            ""
+
+    runApp :: FilePath -> IO (ExitCode, String, String)
+    runApp tmp =
+        readCreateProcessWithExitCode
+            ((proc (tmp </> "sky-out" </> "app") []) { cwd = Just tmp })
+            ""

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -31,6 +31,7 @@ import qualified Sky.Build.LetForwardRefSpec
 import qualified Sky.Build.EntryLocalShadowsDepSpec
 import qualified Sky.Build.CaseSubjectNameShadowSpec
 import qualified Sky.Build.FfiKernelAliasSpec
+import qualified Sky.Build.PubSubPublishTaskSpec
 import qualified Sky.Parse.MultiLineCaseSubjectSpec
 import qualified Sky.Parse.MultiLineCaseKeywordSpec
 import qualified Sky.Parse.MultiLineSignatureSpec
@@ -204,6 +205,11 @@ main = hspec $ do
     describe "Sky.Build.EntryLocalShadowsDep" Sky.Build.EntryLocalShadowsDepSpec.spec
     describe "Sky.Build.CaseSubjectNameShadow" Sky.Build.CaseSubjectNameShadowSpec.spec
     describe "Sky.Build.FfiKernelAlias" Sky.Build.FfiKernelAliasSpec.spec
+    -- Cycle 4 PT: Task-shaped Std.PubSub.publish — callable from any
+    -- context (raw Sky.Http.Server api handlers / post-init goroutines
+    -- / scheduled jobs), complements Cmd.publish which is bound to
+    -- the Sky.Live update-return tuple.
+    describe "Sky.Build.PubSubPublishTask" Sky.Build.PubSubPublishTaskSpec.spec
     describe "Sky.Parse.MultiLineCaseSubject" Sky.Parse.MultiLineCaseSubjectSpec.spec
     describe "Sky.Parse.MultiLineCaseKeyword"
         Sky.Parse.MultiLineCaseKeywordSpec.spec


### PR DESCRIPTION
## Summary

Adds `Std.PubSub.publish : String -> any -> Task Error Int` — a Task-shaped equivalent to `Std.Cmd.publish` that fires from ANY goroutine, not just a Sky.Live `update` return tuple.

## Motivation

SkyDeploy + similar real apps want to push real-time notifications from raw `Sky.Http.Server` `api` handlers (deploy callbacks, GitHub webhooks, scheduled jobs) into the in-process pub/sub registry that dashboard Live sessions subscribe to. Before this PR there was no Sky-side API for that — every `Cmd.publish` call site needs an `update` tuple, which raw `api` handlers don't have.

The skydeploy-specific concrete win (deferred to that repo): replace the 4-second `Sub.every Tick` polling for deploy-status updates with an event-driven push from `DeployCallback.applyReport`, dropping deploy-completion UI latency from ~2s p50 to ~50ms.

## Mechanics

- `liveAppRun` registers itself as `processBroker` (`atomic.Pointer[*liveApp]`) immediately after wiring `app.topics = store.Broker()`. Single-app process: works trivially. Multi-app process (rare): last writer wins (matches the existing port-binding model).
- `rt.PubSub_publish` kernel reads `processBroker.Load()`, returns a Task body that calls `app.Publish(topic, SessionEvent{Payload, Origin:""})`. Origin is empty because server-side publishes have no originating session and therefore no echo-suppression target.
- Returns `Ok(deliveryCount)` on success, `Err(Unavailable)` when no `Live.app` is registered in the process (CLI tools, isolated unit tests, pure HTTP servers).
- Same in-process broker as `Cmd.publish` — subscribers can't tell the two API surfaces apart by `SessionEvent` shape.

## Surface

```elm
Std.PubSub.publish : String -> any -> Task Error Int
```

```elm
-- From a webhook handler in a Live.app process:
handleWebhook req =
    let
        _ = Store.recordEvent req           -- durable write first
        _ = Task.run                        -- publish second (fire-and-forget)
                (PubSub.publish
                    ("deploy:status:" ++ slug)
                    (encodeEvent req))
    in
        plain 200 "ok"
```

## Tests

- **Go runtime** (`runtime-go/rt/live_pubsub_task_test.go`): 4 cases — no-live-app, nil-topics field, happy-path delivery + payload roundtrip + Origin check, last-registered-wins for multi-app processes. All PASS.
- **Cabal spec** (`test/Sky/Build/PubSubPublishTaskSpec.hs`): end-to-end Sky-source compile → typed Go → run, asserting `rt.PubSub_publish(` appears at the call site and the `Err Unavailable` branch fires correctly when no `Live.app` is registered. PASS.
- **Pubsub-adjacent regression** (`go test ./rt -run "PubSub|Topic|Subscribe|Cmd_publish|Broadcast"`): clean.
- **Pre-existing failure (NOT caused by this PR)**: `TestTime_CalendarAdd` + `TestTime_StartOfDay` panic on `interface{} -> int64` conversion. Reproduces on `main` HEAD; tracked separately.

## Docs

- `docs/skylive/pubsub.md` — API section bumped to three primitives; new "Std.PubSub.publish from raw handlers" subsection with GitHub-webhook example.
- `CLAUDE.md` + `templates/CLAUDE.md` — `Std.PubSub` row added to the stdlib effects table; `Std.Sub` block cross-references the Task-shaped twin.

## Cadence

DO NOT TAG. Accumulates with D3 (#106) + D5 (#105) for the next compiler-side batch — likely v0.15.27 once it's all on `main` and CI is green across the batch.

## Files

- **NEW** `runtime-go/rt/live_pubsub_task.go` — `processBroker` atomic + `PubSub_publish` kernel
- **NEW** `runtime-go/rt/live_pubsub_task_test.go` — 4 Go cases
- **NEW** `sky-stdlib/Std/PubSub.sky` — Sky-side module + `Ffi.kernel "PubSub_publish"` alias
- **NEW** `test/Sky/Build/PubSubPublishTaskSpec.hs` — end-to-end cabal spec
- **MOD** `runtime-go/rt/live.go` — `registerProcessBroker(app)` call after `app.topics` init
- **MOD** `src/Sky/Generate/Go/Kernel.hs` — kernel routing entry
- **MOD** `src/Sky/Build/EmbeddedRuntime.hs` — TH re-embed marker bump
- **MOD** `test/Spec.hs` + `sky-compiler.cabal` — spec registration
- **MOD** `docs/skylive/pubsub.md`, `CLAUDE.md`, `templates/CLAUDE.md` — user-facing docs