### PR TITLE
fix(http-server): implement Server.static via http.StripPrefix + http.FileServer

### DIFF
--- a/runtime-go/rt/rt.go
+++ b/runtime-go/rt/rt.go
@@ -6629,6 +6629,14 @@ type SkyRoute struct {
 	Method  string
 	Path    string
 	Handler any // func(SkyRequest) any (Task that returns SkyResponse)
+
+	// StaticDir — non-empty when the route was created by Server_static.
+	// Server_listen detects it and registers http.FileServer instead of
+	// the Sky-handler dispatch path, so static-file serving gets Go
+	// stdlib's path-traversal protection, Last-Modified handling,
+	// Range requests, and MIME type detection without re-implementing
+	// any of it on the Sky side.
+	StaticDir string
 }
 
 // SkyRequest wraps an HTTP request
@@ -6689,6 +6697,27 @@ func Server_listen(port any, routes any) any {
 		route := r.(SkyRoute)
 		handler := route.Handler
 		pattern := route.Path
+
+		// Static-file routes (registered via Server_static) bypass
+		// the Sky-handler dispatch entirely. http.FileServer +
+		// http.StripPrefix delivers path-traversal protection,
+		// MIME detection, Last-Modified, and Range support — all
+		// the things a hand-rolled static handler in Sky would
+		// have to re-implement.
+		//
+		// Pattern is already prefix-form ("/static/" with trailing
+		// slash) so ServeMux longest-prefix-matches every nested
+		// path. StripPrefix removes the prefix (keeping the
+		// trailing slash) before FileServer maps the rest onto the
+		// directory.
+		if route.StaticDir != "" {
+			stripPattern := pattern
+			if len(stripPattern) > 1 && stripPattern[len(stripPattern)-1] == '/' {
+				stripPattern = stripPattern[:len(stripPattern)-1]
+			}
+			mux.Handle(pattern, http.StripPrefix(stripPattern, http.FileServer(http.Dir(route.StaticDir))))
+			continue
+		}
 
 		mux.HandleFunc(pattern, func(w http.ResponseWriter, req *http.Request) {
 			// Panic recovery — one bad handler mustn't kill the process.
@@ -7641,15 +7670,37 @@ func Server_any(path any, handler any) any {
 	return SkyRoute{Method: "*", Path: fmt.Sprintf("%v", path), Handler: handler}
 }
 
-func Server_static(path any, dir any) any {
+// Server_static returns a Route that serves files from `dir` under
+// the URL prefix `urlPrefix`. Implementation defers to
+// http.FileServer + http.StripPrefix at registration time
+// (see Server_listen's StaticDir branch) — so path-traversal
+// protection (http.Dir refuses `..`), MIME detection (via
+// mime.TypeByExtension), Last-Modified, and Range request support
+// all come for free from Go's stdlib.
+//
+//   - urlPrefix is normalised: a missing leading "/" is added, a
+//     missing trailing "/" is added so ServeMux's longest-prefix
+//     match catches every nested path.
+//   - dir is a filesystem path relative to the process cwd (or
+//     absolute). A nonexistent dir yields 404s at request time,
+//     not an error here — the listing-or-deny behaviour is the
+//     stdlib's.
+func Server_static(urlPrefix any, dir any) any {
+	prefix := fmt.Sprintf("%v", urlPrefix)
+	if prefix == "" || prefix[0] != '/' {
+		prefix = "/" + prefix
+	}
+	if prefix[len(prefix)-1] != '/' {
+		prefix = prefix + "/"
+	}
 	return SkyRoute{
-		Method: "GET",
-		Path:   fmt.Sprintf("%v", path),
-		Handler: func(req any) any {
-			return func() any {
-				return Ok[any, any](SkyResponse{Status: 200, Body: "static:" + fmt.Sprintf("%v", dir)})
-			}
-		},
+		Method:    "GET",
+		Path:      prefix,
+		StaticDir: fmt.Sprintf("%v", dir),
+		// Handler stays nil — the dispatch path checks StaticDir
+		// FIRST and never reaches the handler call site for a
+		// static route.
+		Handler: nil,
 	}
 }
 

--- a/runtime-go/rt/server_static_test.go
+++ b/runtime-go/rt/server_static_test.go
@@ -1,0 +1,145 @@
+package rt
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Cycle 4 follow-up — Sky.Http.Server.static was previously a stub
+// that returned the literal string "static:<dir>" as the body. This
+// test pins the new behaviour: Server_static returns a SkyRoute with
+// StaticDir set; Server_listen registers http.StripPrefix +
+// http.FileServer under the URL prefix, so:
+//
+//   - GET /<prefix>/file.js returns the file body with the right
+//     Content-Type (mime.TypeByExtension).
+//   - GET /<prefix>/missing returns 404.
+//   - GET /<prefix>/../../etc/passwd returns 400 (http.Dir refuses
+//     paths containing ..).
+//   - GET /<prefix>/subdir/nested.css works (prefix matching, not
+//     exact).
+//
+// The Sky-handler dispatch path is NOT exercised for these routes —
+// they go straight to http.FileServer for stdlib-grade serving.
+
+func Test_ServerStatic_NormalisesPrefix(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"/static", "/static/"},
+		{"/static/", "/static/"},
+		{"static", "/static/"},
+		{"static/", "/static/"},
+		{"/assets/v1", "/assets/v1/"},
+	}
+	for _, c := range cases {
+		r := Server_static(c.in, "wherever").(SkyRoute)
+		if r.Path != c.want {
+			t.Errorf("Server_static(%q): got Path=%q, want %q", c.in, r.Path, c.want)
+		}
+		if r.StaticDir != "wherever" {
+			t.Errorf("Server_static(%q): StaticDir=%q, want %q", c.in, r.StaticDir, "wherever")
+		}
+		if r.Handler != nil {
+			t.Errorf("Server_static(%q): Handler should be nil (Server_listen handles static directly), got %T", c.in, r.Handler)
+		}
+		if r.Method != "GET" {
+			t.Errorf("Server_static(%q): Method=%q, want GET", c.in, r.Method)
+		}
+	}
+}
+
+// End-to-end via a real *http.ServeMux — same shape Server_listen
+// builds.  We don't spin up a TCP server; httptest.NewRecorder
+// directly invokes the mux's ServeHTTP.
+func Test_ServerStatic_ServesFiles_WithCorrectContentType(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, dir, "app.js", "console.log('hello');")
+	mustWrite(t, dir, "style.css", "body { color: red; }")
+	mustWrite(t, dir, "sub/nested.svg", "<svg/>")
+
+	mux := http.NewServeMux()
+	r := Server_static("/static", dir).(SkyRoute)
+	// Mirror what Server_listen does for static routes.
+	stripPattern := r.Path
+	if len(stripPattern) > 1 && stripPattern[len(stripPattern)-1] == '/' {
+		stripPattern = stripPattern[:len(stripPattern)-1]
+	}
+	mux.Handle(r.Path, http.StripPrefix(stripPattern, http.FileServer(http.Dir(r.StaticDir))))
+
+	cases := []struct {
+		url             string
+		wantStatus      int
+		wantContentType string // prefix match
+		wantBodySub     string
+	}{
+		{"/static/app.js", 200, "text/javascript", "console.log"},
+		{"/static/style.css", 200, "text/css", "color: red"},
+		{"/static/sub/nested.svg", 200, "image/svg", "<svg"},
+		{"/static/missing.txt", 404, "", ""},
+	}
+	for _, c := range cases {
+		req := httptest.NewRequest("GET", c.url, nil)
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		if w.Code != c.wantStatus {
+			t.Errorf("%s: got status %d, want %d", c.url, w.Code, c.wantStatus)
+		}
+		ct := w.Header().Get("Content-Type")
+		if c.wantContentType != "" && !strings.HasPrefix(ct, c.wantContentType) {
+			t.Errorf("%s: Content-Type %q does not start with %q", c.url, ct, c.wantContentType)
+		}
+		if c.wantBodySub != "" {
+			body, _ := io.ReadAll(w.Body)
+			if !strings.Contains(string(body), c.wantBodySub) {
+				t.Errorf("%s: body does not contain %q\nbody: %s", c.url, c.wantBodySub, body)
+			}
+		}
+	}
+}
+
+// Path traversal: ServeMux normalises `/static/../...` paths BEFORE
+// the route handler ever sees them — typically by emitting a 301
+// redirect to the cleaned URL, which then takes a different route
+// (or 404). Either way the malicious path never reaches our
+// FileServer + http.Dir, which itself also refuses `..` segments.
+// We just assert the request does NOT succeed with the file body
+// of an unrelated route.
+func Test_ServerStatic_RefusesPathTraversal(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, dir, "ok.txt", "served")
+
+	mux := http.NewServeMux()
+	r := Server_static("/static", dir).(SkyRoute)
+	stripPattern := r.Path[:len(r.Path)-1]
+	mux.Handle(r.Path, http.StripPrefix(stripPattern, http.FileServer(http.Dir(r.StaticDir))))
+
+	req := httptest.NewRequest("GET", "/static/../etc/passwd", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	// The status MUST be redirect-or-not-found, never 200.
+	if w.Code == 200 {
+		body, _ := io.ReadAll(w.Body)
+		t.Errorf("path traversal returned 200 with body %q (security regression)", body)
+	}
+}
+
+// ────────────────────────────────────────────────────────────────
+// helpers
+
+func mustWrite(t *testing.T, dir, name, content string) {
+	t.Helper()
+	full := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(full), err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", full, err)
+	}
+}

--- a/src/Sky/Build/EmbeddedRuntime.hs
+++ b/src/Sky/Build/EmbeddedRuntime.hs
@@ -32,6 +32,7 @@
 -- re-embed marker: 2026-05-27 — Cycle 4 HS (rev7): JS comment </script> literal escaped + stream-loop session stamp
 -- re-embed marker: 2026-05-28 — Cycle 4 PT: Std.PubSub.publish (Task-shaped) + Std/PubSub.sky stdlib + live_pubsub_task.go runtime
 -- re-embed marker: 2026-05-28b — Sky.Http.Server withHeader Content-Type override fix (spike-discovered)
+-- re-embed marker: 2026-05-28c — fix(http-server): Server.static implementation via http.FileServer (was a stub returning literal "static:dir")
 module Sky.Build.EmbeddedRuntime
     ( embeddedRuntime
     , embeddedSkyStdlib


### PR DESCRIPTION
## Summary

`Sky.Http.Server.static` was a stub — any user calling `Server.static "/assets" "public"` got back the literal string `"static:public"` as the response body for every request under that prefix. Discovered today while building [examples/29-webview-threejs-spike](https://github.com/anzellai/sky/pull/109) (the Three.js spike for the upcoming Sky.Webview backend), which had to work around the bug with three hand-rolled `Server.get` + `File.readFile` handlers.

This PR replaces the stub with the real implementation.

## Implementation

- `Server_static` returns `SkyRoute{Method:"GET", Path:<normalised prefix>, StaticDir:<dir>, Handler:nil}`.
- URL prefix is normalised: missing leading `/` is added, trailing `/` is added so `ServeMux`'s longest-prefix-match catches every nested path under the prefix.
- `Server_listen` detects `StaticDir != ""` **before** the normal Sky-handler dispatch and registers `http.StripPrefix(<prefix>, http.FileServer(http.Dir(dir)))` directly on the mux.

What we get from `http.FileServer` + `http.Dir`:

- **Path-traversal protection** — `http.Dir` refuses `..` segments; `ServeMux` normalises traversal attempts via 30x redirects before they reach our file server.
- **MIME-type detection** — `mime.TypeByExtension` covers ~all common web formats (.js, .css, .html, .json, .svg, .png, .woff2, .wasm, etc).
- **Last-Modified** + **conditional GETs** (If-Modified-Since).
- **Range request** support (for partial-content / resumable downloads).

All security-hardened upstream.

## Tests

Three Go runtime tests under `server_static_test.go`:

1. `Test_ServerStatic_NormalisesPrefix` — pin the SkyRoute return shape (Method, Path, StaticDir, nil Handler) under various prefix inputs (`"/static"`, `"/static/"`, `"static"`, `"static/"`, `"/assets/v1"`).
2. `Test_ServerStatic_ServesFiles_WithCorrectContentType` — spins up an `httptest`-backed mux mirroring `Server_listen`'s wiring; asserts JS / CSS / SVG bodies serve with the right Content-Type and a missing file returns 404.
3. `Test_ServerStatic_RefusesPathTraversal` — `GET /static/../etc/passwd` MUST NOT return 200 (exact behaviour is "ServeMux redirects the normalised path", which never reaches our FileServer).

Adjacent regression sweep (`go test ./rt -run "Server|CSRF|HttpStream|live_test"`) clean.

## End-to-end verification

Wrote a fresh Sky app:

```elm
main =
    Server.listen 8766
        [ Server.get "/" rootHandler
        , Server.static "/static" "static"
        ]
```

Built + ran. `GET /static/hello.js` returns `Content-Type: text/javascript; charset=utf-8` + the JS body. `GET /static/style.css` returns `Content-Type: text/css; charset=utf-8`. `GET /static/missing.txt` returns 404. ✅

## Follow-up impact

When this merges, `examples/29-webview-threejs-spike` (PR #109) can drop its workaround:

```elm
[ Server.get "/" rootHandler
, Server.get "/healthz" healthzHandler
, Server.get "/static/three.min.js" (staticFile "static/three.min.js" "application/javascript")
, Server.get "/static/scene.js" (staticFile "static/scene.js" "application/javascript")
, Server.get "/static/style.css" (staticFile "static/style.css" "text/css; charset=utf-8")
]
```

Becomes:

```elm
[ Server.get "/" rootHandler
, Server.get "/healthz" healthzHandler
, Server.static "/static" "static"
]
```

Will update the spike PR after this merges.

## Cadence

DO NOT TAG. Accumulates with #105 D5 + #106 D3 + #107 PubSub.publish + #109 spike + Server.withHeader fix into a Cycle-4-follow-up batch tag once everything's on `main` and CI clears.