### PR TITLE
fix(canonicalise): cross-module alias-name collision + duplicate-module detection (Cycle 4 followup, #350 + #361)

### DIFF
--- a/sky-compiler.cabal
+++ b/sky-compiler.cabal
@@ -263,6 +263,7 @@ test-suite sky-tests
       Sky.Canonicalise.UnboundSpec
       Sky.Canonicalise.QualifiedTypeAliasSpec
       Sky.Canonicalise.DualImportCollisionSpec
+      Sky.Canonicalise.AliasNameCollisionSpec
       Sky.Type.ExhaustivenessSpec
       Sky.Type.AnyWildcardSpec
       Sky.Type.NumericBinopSpec

--- a/src/Sky/Build/EmbeddedRuntime.hs
+++ b/src/Sky/Build/EmbeddedRuntime.hs
@@ -35,6 +35,7 @@
 -- re-embed marker: 2026-05-28c — fix(http-server): Server.static implementation via http.FileServer (was a stub returning literal "static:dir")
 -- re-embed marker: 2026-05-28e — Cycle 4 #353: sky fmt next-anchor fallback so body comments above a reflowed expression round-trip losslessly
 -- re-embed marker: 2026-05-28f — revert(canonicalise): roll back #350 alias-name fix (regression in row-poly access on duplicate-named modules — #361)
+-- re-embed marker: 2026-05-28g — fix(canonicalise): cross-module alias-name collision v2 — (home, name) primary lookup + unique-body bare-name fallback (#350 + #361)
 module Sky.Build.EmbeddedRuntime
     ( embeddedRuntime
     , embeddedSkyStdlib

--- a/src/Sky/Canonicalise/Module.hs
+++ b/src/Sky/Canonicalise/Module.hs
@@ -1576,11 +1576,107 @@ canonicaliseAliases tmap aliasMap env aliases =
 -- expanded — applying them requires type-var substitution that we
 -- can add later. Treating them as nominal is correct, just
 -- pessimistic for inference.
-expandModuleAliases :: Map.Map String Can.Alias -> Can.Module -> Can.Module
+--
+-- ── Cycle 4 #350 + #361 v2 fix ───────────────────────────────
+--
+-- The alias map is keyed by `(home, name)`. Two dependency modules
+-- can each expose `type alias Model = ...` (e.g. `App.State.Model`
+-- AND `Lib.State.Model`); before this fix `collectDepAliases`
+-- flattened the map using `Map.unions` on the bare name key and ONE
+-- body silently won (#350). Downstream the HM solver then emitted
+-- the dishonest "Model vs Model" type error because both
+-- `Can.TType "App.State" "Model"` and `Can.TType "Lib.State" "Model"`
+-- resolved to the SAME body.
+--
+-- An earlier attempt (PR #111, reverted) keyed by `(home, name)`
+-- exclusively. That broke a legitimate consumer pattern (#361 —
+-- skydeploy/control-plane regression): a qualified type reference
+-- whose qualifier could NOT be resolved through the importer's
+-- own `import M as Q` list. This happens when the type transits
+-- through a re-exporting intermediate module (`import State
+-- exposing (..)`) and the consumer writes `Github.RepoInfo`
+-- without independently `import Github.Api as Github`. The
+-- qualifier resolver falls back to `Canonical "Github"` (literal
+-- short segment), the lookup misses, the alias body never
+-- unfolds, and a downstream `repo.fullName` access surfaces as
+-- the cryptic "RepoInfo vs { fullName : a | ... }" row-poly
+-- mismatch.
+--
+-- The v2 fix uses an `AliasMap` with two indices:
+--   (a) primary `(home, name) → Alias`, so two distinct
+--       same-named aliases coexist (closes #350)
+--   (b) derived bare-name fallback used when (a) misses AND
+--       there is a SINGLE unique body across all entries with
+--       that name (closes #361). The resulting `Can.TAlias`
+--       carries the RESOLVED home (from the fallback entry,
+--       not the typo'd qualifier).
+--
+-- If (a) misses AND (b) finds MULTIPLE distinct bodies under the
+-- same name, the lookup gives up and the type stays nominal — D5
+-- (PR #105) already guards against this shape at the qualifier
+-- collision level so we don't realistically reach this branch
+-- with conflicting bodies in well-formed code.
+data AliasMap = AliasMap
+    { _amByHome :: !(Map.Map (ModuleName.Canonical, String) Can.Alias)
+    , _amByName :: !(Map.Map String [(ModuleName.Canonical, Can.Alias)])
+    }
+
+
+-- | Build an `AliasMap` from a homed map. The bare-name fallback
+-- index dedupes by `Can.Alias` body — bodies that compare equal
+-- collapse into a single entry (same source-of-truth re-exported
+-- via multiple paths), keeping the "unique body" fallback honest.
+buildAliasMap
+    :: Map.Map (ModuleName.Canonical, String) Can.Alias
+    -> AliasMap
+buildAliasMap byHome =
+    let byName = Map.fromListWith (\new old -> dedupByBody (new ++ old))
+            [ (name, [(home, alias)])
+            | ((home, name), alias) <- Map.toList byHome
+            ]
+    in AliasMap byHome byName
+  where
+    -- O(n^2) over a single bare-name's bucket — fine since most
+    -- names map to ≤ 2 entries in practice. `Can.Alias` doesn't
+    -- derive `Eq` (would force a wider AST change) so compare
+    -- structurally via the inner `(vars, body)` pair which both
+    -- carry derived `Eq` instances through `Can.Type`.
+    aliasEq (Can.Alias vs1 b1) (Can.Alias vs2 b2) = vs1 == vs2 && b1 == b2
+    dedupByBody [] = []
+    dedupByBody ((h, a):rest) =
+        (h, a) : dedupByBody [ (h2, a2) | (h2, a2) <- rest, not (aliasEq a2 a) ]
+
+
+-- | Lookup an alias by `(home, name)`, falling back to bare-name
+-- when the home-keyed lookup misses AND the name maps to exactly
+-- ONE unique body. Returns `(resolvedHome, alias)` — the home
+-- carried by the resulting TAlias is the alias's TRUE home, not
+-- the caller's typo'd qualifier. That keeps later identity-based
+-- unification consistent.
+lookupAlias
+    :: AliasMap
+    -> ModuleName.Canonical
+    -> String
+    -> Maybe (ModuleName.Canonical, Can.Alias)
+lookupAlias (AliasMap byHome byName) home name =
+    case Map.lookup (home, name) byHome of
+        Just alias -> Just (home, alias)
+        Nothing -> case Map.lookup name byName of
+            Just [(h, alias)] -> Just (h, alias)
+            _ -> Nothing
+
+
+expandModuleAliases
+    :: Map.Map (ModuleName.Canonical, String) Can.Alias
+    -> Can.Module
+    -> Can.Module
 expandModuleAliases depAliases m =
-    let localAliases = Can._aliases m
-        -- Merge local and dep aliases; local wins on name collision (unlikely).
-        allAliases = Map.union localAliases depAliases
+    let home = Can._name m
+        localAliases = Map.mapKeys (\n -> (home, n)) (Can._aliases m)
+        -- Local entries win on a full-key collision (a dep keyed
+        -- under the current module's home — never happens in
+        -- practice but the left-bias keeps semantics predictable).
+        allAliases = buildAliasMap (Map.union localAliases depAliases)
         expand = expandTypeAliases allAliases Set.empty
     in m
         { Can._decls   = mapDeclsTypes expand (Can._decls m)
@@ -1590,8 +1686,10 @@ expandModuleAliases depAliases m =
 
 
 -- | Expand nominal type refs into TAlias nodes when they match an
--- alias in the alias map. Carries a visited-set so a recursive
--- alias (unusual but possible) can't loop.
+-- alias in the alias map. Carries a visited-set (also keyed by
+-- `(home, name)`) so a recursive alias from one home cannot
+-- accidentally short-circuit a same-named alias from a different
+-- home.
 --
 -- Parametric aliases (`type alias Cfg msg = { onSubmit : Form -> msg
 -- , ... }`) get the same treatment: the body's type vars are
@@ -1604,13 +1702,17 @@ expandModuleAliases depAliases m =
 -- unwrap arm (Unify.hs) never fires because the value isn't a
 -- T.Alias.  Expanding eagerly preserves alias identity (TAlias)
 -- AND unfolds for unification.
-expandTypeAliases :: Map.Map String Can.Alias -> Set.Set String -> Can.Type -> Can.Type
+expandTypeAliases
+    :: AliasMap
+    -> Set.Set (ModuleName.Canonical, String)
+    -> Can.Type
+    -> Can.Type
 expandTypeAliases aliasMap visited ty = case ty of
     Can.TType home name args
-        | not (Set.member name visited)
-        , Just (Can.Alias vars body) <- Map.lookup name aliasMap
+        | Just (resolvedHome, Can.Alias vars body) <- lookupAlias aliasMap home name
+        , not (Set.member (resolvedHome, name) visited)
         , length vars == length args ->
-            let visited' = Set.insert name visited
+            let visited' = Set.insert (resolvedHome, name) visited
                 -- Recur into args first so nested aliases also expand.
                 args' = map (expandTypeAliases aliasMap visited') args
                 -- Substitute vars → args' in the alias body, then
@@ -1618,7 +1720,7 @@ expandTypeAliases aliasMap visited ty = case ty of
                 subst = Map.fromList (zip vars args')
                 substituted = substTypeVars subst body
                 body' = expandTypeAliases aliasMap visited' substituted
-            in Can.TAlias home name (zip vars args') (Can.Filled body')
+            in Can.TAlias resolvedHome name (zip vars args') (Can.Filled body')
     Can.TType home name args ->
         Can.TType home name (map recur args)
     Can.TLambda a b ->
@@ -1770,11 +1872,24 @@ mapAliasBody f (Can.Alias vars body) = Can.Alias vars (f body)
 
 -- | Collect the canonicalised alias bodies from dep modules so a
 -- value annotation can refer to an imported record alias and still
--- have its body expanded for HM unification. Local aliases win on
--- collision (unlikely in practice).
-collectDepAliases :: Map.Map String DepInfo -> Map.Map String Can.Alias
+-- have its body expanded for HM unification.
+--
+-- Each entry is keyed by `(home, alias-name)`. Two deps can each
+-- expose `Model` (e.g. `App.State.Model` + `Lib.State.Model`) without
+-- collapsing — Cycle 4 #350 root cause was the prior `String`-keyed
+-- map silently dropping one body. Lookups in `expandTypeAliases` use
+-- the resolved `home` from `Can.TType` for the primary index, with
+-- a unique-body bare-name fallback for #361 (qualified type
+-- references that transit through a re-exporting intermediate
+-- module). See `AliasMap` / `lookupAlias` for the lookup contract.
+collectDepAliases
+    :: Map.Map String DepInfo
+    -> Map.Map (ModuleName.Canonical, String) Can.Alias
 collectDepAliases deps =
-    Map.unions [ _dep_aliasDefs d | d <- Map.elems deps ]
+    Map.unions
+        [ Map.mapKeys (\n -> (_dep_name d, n)) (_dep_aliasDefs d)
+        | d <- Map.elems deps
+        ]
 
 
 -- ═══════════════════════════════════════════════════════════

--- a/test/Sky/Canonicalise/AliasNameCollisionSpec.hs
+++ b/test/Sky/Canonicalise/AliasNameCollisionSpec.hs
@@ -1,0 +1,260 @@
+module Sky.Canonicalise.AliasNameCollisionSpec (spec) where
+
+-- Cycle 4 — task #350 / #361 regression fence (follow-up to D5 / PR #105).
+--
+-- This spec is the v2 follow-up to PR #111 (commit 5551053, reverted at
+-- 0f453bd). It pins TWO bug classes simultaneously:
+--
+-- 1. #350 — cross-module alias-NAME collision (the original Cycle 4
+--    follow-up gap). When TWO dependency modules each expose a type
+--    alias with the same NAME (e.g. `App.State.Model` and
+--    `Lib.State.Model`), the dep-alias map flattens to a single
+--    `String → Can.Alias` keyed on just the alias name. `Map.unions`
+--    is left-biased, so whichever dep comes first wins — the other
+--    dep's `Model` collapses into the same entry. At alias-expansion
+--    time, BOTH `Can.TType "App.State" "Model"` and
+--    `Can.TType "Lib.State" "Model"` look up the SAME body and the
+--    HM solver later prints the dishonest "Model vs Model" type
+--    error.
+--
+-- 2. #361 — the Dashboard-regression class (introduced by PR #111's
+--    pure (home, name) rekeying and the reason it was reverted).
+--    When a module references a qualified type WITHOUT a
+--    corresponding `import Mod as Q` (typically because the type
+--    transits through a re-exporting intermediate module), the
+--    canonicaliser's qualifier resolver falls back to
+--    `Canonical "<qualifier>"` (literal short segment). Under pure
+--    (home, name) keying that lookup misses and the alias body never
+--    unfolds — downstream the type checker reports "<Alias> vs
+--    { field : a | ... }" against any `target.field` access on a
+--    value typed by the alias. The skydeploy/control-plane case was
+--    `repo : Github.RepoInfo` used in `View/Dashboard.sky` where
+--    Dashboard does NOT directly `import Github.Api as Github`; the
+--    qualifier `Github` resolved to `Canonical "Github"` but the
+--    alias was registered as `(Canonical "Github.Api", "RepoInfo")`.
+--
+-- Fix shape (v2):
+--   * Primary lookup uses `(home, name)` — closes #350 by letting
+--     two distinct same-named aliases coexist.
+--   * Fallback by bare name when the primary misses AND there is a
+--     SINGLE unique body across all (home, name) entries with that
+--     name — closes #361 (the Dashboard regression). The resulting
+--     `Can.TAlias` carries the RESOLVED home (not the typo'd one),
+--     so downstream unification stays consistent.
+--   * Multiple distinct bodies under the same name with NO matching
+--     home is a true ambiguity — but in practice this is gated by
+--     D5 (PR #105) at the qualifier level so we don't reach this
+--     branch with conflicting bodies.
+
+import Test.Hspec
+import qualified System.Exit as Exit
+import System.Directory (getCurrentDirectory, doesFileExist,
+                         createDirectoryIfMissing)
+import System.FilePath ((</>))
+import System.Process (readCreateProcessWithExitCode, shell)
+import System.IO.Temp (withSystemTempDirectory)
+import Data.List (isInfixOf)
+
+
+findSky :: IO FilePath
+findSky = do
+    cwd <- getCurrentDirectory
+    let c = cwd </> "sky-out" </> "sky"
+    ok <- doesFileExist c
+    if ok then return c else fail ("missing: " ++ c)
+
+
+-- | Build a fixture with multiple source files keyed by relative path
+-- (always under `src/`) plus an empty sky.toml. Returns the build's
+-- exit code + combined stdout/stderr.
+buildFixture :: [(FilePath, String)] -> IO (Int, String)
+buildFixture files =
+    withSystemTempDirectory "sky-350" $ \tmp -> do
+        sky <- findSky
+        createDirectoryIfMissing True (tmp </> "src")
+        writeFile (tmp </> "sky.toml") "name = \"alias-name-test\"\n"
+        mapM_ (\(p, c) -> do
+            let dst = tmp </> p
+                dir = reverse (dropWhile (/= '/') (reverse dst))
+            createDirectoryIfMissing True dir
+            writeFile dst c) files
+        let cmd = "cd " ++ tmp ++ " && " ++ sky ++ " build src/Main.sky 2>&1"
+        (ec, sout, serr) <- readCreateProcessWithExitCode (shell cmd) ""
+        let combined = sout ++ serr
+            ecInt = case ec of
+                Exit.ExitSuccess -> 0
+                Exit.ExitFailure n -> n
+        return (ecInt, combined)
+
+
+-- An `App.State` module with its own Model alias + initial helper.
+appStateModule :: String
+appStateModule = unlines
+    [ "module App.State exposing (Model, initial)"
+    , ""
+    , "type alias Model = { count : Int }"
+    , ""
+    , "initial : Model"
+    , "initial = { count = 0 }"
+    ]
+
+
+-- A `Lib.State` module with a DIFFERENT Model alias + a settings
+-- helper. Last-segment matches App.State so it would have tripped D5,
+-- BUT users disambiguate with explicit `as` aliases — D5 lets it
+-- through. The deeper bug then surfaces inside the canonicaliser's
+-- depAliasMap, where the two `Model` entries collapse.
+libStateModule :: String
+libStateModule = unlines
+    [ "module Lib.State exposing (Model, settings)"
+    , ""
+    , "type alias Model = { name : String }"
+    , ""
+    , "settings : Model"
+    , "settings = { name = \"lib\" }"
+    ]
+
+
+-- A library module that exposes a record alias used in a typed sig.
+-- Mirrors `packages/sky-github/src/Github/Api.sky` from the
+-- skydeploy/control-plane regression.
+githubApiModule :: String
+githubApiModule = unlines
+    [ "module Github.Api exposing (RepoInfo, makeRepo)"
+    , ""
+    , "type alias RepoInfo = { fullName : String }"
+    , ""
+    , "makeRepo : String -> RepoInfo"
+    , "makeRepo name = { fullName = name }"
+    ]
+
+
+-- An intermediate module that imports Github.Api directly and
+-- re-exposes both the alias and a constructor that USES it.
+-- View modules (Dashboard) import State, not Github.Api.
+stateReexportModule :: String
+stateReexportModule = unlines
+    [ "module State exposing (..)"
+    , ""
+    , "import Github.Api as Github"
+    , ""
+    , "type alias Model = { repo : Github.RepoInfo }"
+    , ""
+    , "emptyModel : Model"
+    , "emptyModel = { repo = { fullName = \"\" } }"
+    ]
+
+
+spec :: Spec
+spec =
+    describe "Cycle 4 #350 / #361: cross-module type-alias name collision (v2)" $ do
+
+        it "lets two deps each expose `Model` under disambiguating `as` aliases (#350)" $ do
+            -- Pre-fix: build emitted `Foreign 'Lib.State.settings':
+            -- Model vs Model`. Post-fix: clean compile. The two
+            -- imports use explicit `as AppS` / `as LibS` so D5 does
+            -- not trip; the bug under test is the dep-alias map
+            -- collapsing on NAME.
+            let mainSrc = unlines
+                    [ "module Main exposing (main)"
+                    , ""
+                    , "import Sky.Core.Prelude exposing (..)"
+                    , "import Std.Log exposing (println)"
+                    , "import App.State as AppS"
+                    , "import Lib.State as LibS"
+                    , ""
+                    , "useApp : AppS.Model"
+                    , "useApp = AppS.initial"
+                    , ""
+                    , "useLib : LibS.Model"
+                    , "useLib = LibS.settings"
+                    , ""
+                    , "main = println (toString useApp.count ++ \"/\" ++ useLib.name)"
+                    ]
+            (ec, out) <- buildFixture
+                [ ("src/Main.sky",       mainSrc)
+                , ("src/App/State.sky",  appStateModule)
+                , ("src/Lib/State.sky",  libStateModule)
+                ]
+            -- The dishonest "Model vs Model" must not surface.
+            out `shouldNotSatisfy` ("Model vs Model" `isInfixOf`)
+            ec `shouldBe` 0
+            out `shouldSatisfy` ("Compilation successful" `isInfixOf`)
+
+
+        it "preserves alias-body identity per home module (#350)" $ do
+            -- Stronger: the two Model bodies have INCOMPATIBLE shapes
+            -- (App.State.Model has `count : Int`; Lib.State.Model has
+            -- `name : String`). If the dep-alias map still collapsed
+            -- (whichever order Map.unions visited), one site would see
+            -- the wrong body's fields and the program would either
+            -- fail to type-check OR mis-emit. Picking different fields
+            -- on each side ensures no accidental name overlap masks
+            -- the bug.
+            let mainSrc = unlines
+                    [ "module Main exposing (main)"
+                    , ""
+                    , "import Sky.Core.Prelude exposing (..)"
+                    , "import Std.Log exposing (println)"
+                    , "import App.State as AppS"
+                    , "import Lib.State as LibS"
+                    , ""
+                    , "-- field access on each side proves the body's"
+                    , "-- not been swapped for the OTHER home's alias"
+                    , "appCount : Int"
+                    , "appCount = AppS.initial.count"
+                    , ""
+                    , "libName : String"
+                    , "libName = LibS.settings.name"
+                    , ""
+                    , "main = println (toString appCount ++ \"|\" ++ libName)"
+                    ]
+            (ec, out) <- buildFixture
+                [ ("src/Main.sky",       mainSrc)
+                , ("src/App/State.sky",  appStateModule)
+                , ("src/Lib/State.sky",  libStateModule)
+                ]
+            ec `shouldBe` 0
+            out `shouldSatisfy` ("Compilation successful" `isInfixOf`)
+
+
+        it "qualified type referenced via a re-exporting transit module (#361)" $ do
+            -- The skydeploy/control-plane regression mirrored. The
+            -- consumer module (Main here, View/Dashboard.sky in the
+            -- real bug) writes `Github.RepoInfo` qualified but does
+            -- NOT directly `import Github.Api as Github` — the alias
+            -- transits through State (`exposing (..)`).
+            --
+            -- Under pure (home, name) keying the lookup uses the
+            -- typo'd `Canonical "Github"` and misses. Result: the
+            -- alias body never unfolds and a downstream `repo.fullName`
+            -- access surfaces as
+            --   `Variable 'repo' type mismatch: RepoInfo vs { fullName : a | ... }`
+            --
+            -- The v2 fix's bare-name fallback finds the unique
+            -- `RepoInfo` body and wraps the type with the correct
+            -- resolved home (`Canonical "Github.Api"`).
+            let mainSrc = unlines
+                    [ "module Main exposing (main)"
+                    , ""
+                    , "import Sky.Core.Prelude exposing (..)"
+                    , "import Std.Log exposing (println)"
+                    , "import State exposing (..)"
+                    , ""
+                    , "-- `Github` is NOT imported here. The qualifier"
+                    , "-- resolves only because State re-exposes everything"
+                    , "-- and the bare-name fallback finds the unique body."
+                    , "showRepo : Github.RepoInfo -> String"
+                    , "showRepo repo = repo.fullName"
+                    , ""
+                    , "main = println (showRepo emptyModel.repo)"
+                    ]
+            (ec, out) <- buildFixture
+                [ ("src/Main.sky",          mainSrc)
+                , ("src/State.sky",         stateReexportModule)
+                , ("src/Github/Api.sky",    githubApiModule)
+                ]
+            out `shouldNotSatisfy` ("RepoInfo vs {" `isInfixOf`)
+            out `shouldNotSatisfy` ("type mismatch" `isInfixOf`)
+            ec `shouldBe` 0
+            out `shouldSatisfy` ("Compilation successful" `isInfixOf`)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -17,6 +17,7 @@ import qualified Sky.Canonicalise.KernelFallbackSpec
 import qualified Sky.Canonicalise.UnboundSpec
 import qualified Sky.Canonicalise.QualifiedTypeAliasSpec
 import qualified Sky.Canonicalise.DualImportCollisionSpec
+import qualified Sky.Canonicalise.AliasNameCollisionSpec
 import qualified Sky.Type.ExhaustivenessSpec
 import qualified Sky.Type.AnyWildcardSpec
 import qualified Sky.Type.NumericBinopSpec
@@ -164,6 +165,15 @@ main = hspec $ do
     -- an explicit fix-it suggesting `as Alias`.
     describe "Sky.Canonicalise.DualImportCollision"
                                          Sky.Canonicalise.DualImportCollisionSpec.spec
+    -- Cycle 4 #350 / #361 v2: cross-module type-alias NAME collision.
+    -- Two deps each exposing `Model` under disambiguating `as Alias`
+    -- clauses (#350) — closes the dep-alias map collapsing on bare
+    -- name. AND qualified type reference through a re-exporting
+    -- transit module (#361) — the Dashboard regression that reverted
+    -- PR #111. Both close in one shot: (home, name) primary lookup +
+    -- bare-name fallback for unique bodies.
+    describe "Sky.Canonicalise.AliasNameCollision"
+                                         Sky.Canonicalise.AliasNameCollisionSpec.spec
     describe "Sky.Type.Exhaustiveness"   Sky.Type.ExhaustivenessSpec.spec
     -- Cross-branch HM `any` wildcard fix (compiler bug #3). Distinct
     -- occurrences of `any` in source types must NOT share a single


### PR DESCRIPTION
## Summary

Re-do of PR #111 (commit 5551053, reverted at 0f453bd) — closes BOTH the original #350 collision class AND the #361 row-poly regression that PR #111 introduced.

### Bug recap

**#350**: Two dep modules each expose `type alias Model = ...` with different bodies. Pre-fix `collectDepAliases` flattened the map via bare-name `Map.unions` — one body silently won, the HM solver emitted the dishonest "Model vs Model" error.

**#361** (regression introduced by PR #111): A consumer writes a qualified type reference (`Github.RepoInfo`) where the qualifier is NOT in the consumer's own `import M as Q` list — typically because the type transits through a re-exporting module (`import State exposing (..)`). Under pure (home, name) keying the qualifier resolver falls back to `Canonical "<qualifier>"`, the home-keyed lookup misses, the alias body never unfolds, and a downstream `repo.fullName` access surfaces as the cryptic row-poly mismatch:

```
Variable 'repo' type mismatch: RepoInfo vs { fullName : a | ... }
```

The real-world surface was `skydeploy/control-plane/src/View/Dashboard.sky:395:40` — `repo : Github.RepoInfo` from a State `exposing (..)` re-export.

### Fix shape

Combine (home, name) primary keying with a unique-body bare-name fallback:

- `collectDepAliases` rekeys per dep via `Map.mapKeys (\n -> (_dep_name d, n))` — same as PR #111.
- New `AliasMap` carries TWO indices:
  - `_amByHome :: Map (Canonical, String) Alias` — primary
  - `_amByName :: Map String [(Canonical, Alias)]` — fallback (deduped by structural body equality)
- `lookupAlias home name`:
  1. Try `(home, name)` first — closes #350.
  2. On miss, fall back to bare-name lookup. If exactly ONE unique body exists across all `(*, name)` entries, use it — closes #361. The resulting `Can.TAlias` carries the RESOLVED home (not the typo'd qualifier).
  3. Multiple distinct bodies under the same name with no matching home → return `Nothing`. D5 (PR #105) already gates this shape at the qualifier level so we don't realistically hit this branch with conflicting bodies in well-formed code.
- `expandTypeAliases` visited-set rekeyed to `(home, name)` so a recursive alias from one home cannot short-circuit a same-named alias from a different home.

`Can.Alias` has no derived `Eq`, so the bare-name bucket dedupes structurally via `(vars, body)` equality on `Can.Type` (which derives `Eq`).

### Why not duplicate-module detection (Approach C from the brief)?

Approach C was considered but ruled out as not load-bearing for the Dashboard regression: in the actual skydeploy case there are NO duplicate-named modules — `control-plane/src/Github` is a symlink into `packages/sky-github/src/Github`, so only ONE `Github.Api` is on disk. The Dashboard error came purely from the qualifier-resolution path, not from duplicate module discovery. Approach C would have left #361 unfixed.

The qualifier-resolution path's structural fix (bare-name fallback for unique bodies) is sufficient for both bug classes and stays narrowly scoped.

### Verification

- `cabal test sky-tests` focused groups:
  - Sky.Canonicalise.AliasNameCollision 3/3 PASS (new — 2 from #350, 1 new for #361 row-poly through a transit module).
  - All Canonicalise specs 13/13 PASS (was 10, +3 new).
  - Type specs 117/117 PASS (1 pending matches prior).
- `scripts/example-sweep.sh --build-only` — 20/20 PASS.
- `skydeploy/control-plane` builds clean (`sky install && sky build src/Main.sky`). Pre-fix would emit the dishonest row-poly mismatch on `View/Dashboard.sky:395:40`.
- `sky check examples/12-skyvote` — No errors found.
- TH re-embed marker bumped.

## Test plan
- [x] AliasNameCollisionSpec.hs (#350) — two deps each expose `Model` under `as AppS` / `as LibS` disambiguators, compiles clean, no "Model vs Model" leak.
- [x] AliasNameCollisionSpec.hs (#350) — distinct bodies (App.Model has `count:Int`, Lib.Model has `name:String`); field access on both sides proves bodies aren't swapped.
- [x] AliasNameCollisionSpec.hs (#361) — qualified type via a re-exporting transit module; consumer does NOT `import Github.Api as Github` directly; row-poly access works.
- [x] Existing D5 spec passes — qualifier collision detection untouched.
- [x] Existing QualifiedTypeAliasSpec passes — `import M as Alias` resolution untouched.
- [x] `cd /Users/anzel/works/playground/skydeploy/control-plane && sky build src/Main.sky` — clean (real-world regression test).

**DO NOT TAG.** Investigation revert from v0.15.27 — target v0.15.28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)