### PR TITLE
feat(stdlib): Cmd.publishNoEcho + Std.PubSub.publishNoEcho — opt-out echo for instant publisher feedback (#359)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -508,9 +508,9 @@ Each binding is either:
 | Module | Path | Key functions |
 |---|---|---|
 | `Task` | `Sky.Core.Task` | succeed, fail, map, andThen, perform, sequence, parallel, lazy, run, fromResult, andThenResult, mapError, onError |
-| `Cmd` | `Std.Cmd` | none, batch, perform, publish (pub/sub from update return) |
+| `Cmd` | `Std.Cmd` | none, batch, perform, publish (echo-by-default pub/sub from update return), publishNoEcho (opt-out echo — broker skips publisher's own subscription) |
 | `Sub` | `Std.Sub` | none, every, batch, subscribeTopic (pub/sub receive) |
-| `PubSub` | `Std.PubSub` | publish (Task-shaped — callable from raw `api` handlers / post-init / scheduled jobs; complements `Cmd.publish` which is bound to update-returns) |
+| `PubSub` | `Std.PubSub` | publish (Task-shaped — callable from raw `api` handlers / post-init / scheduled jobs; complements `Cmd.publish` which is bound to update-returns), publishNoEcho (Task-shaped no-echo — sets the broker's SkipOrigin bit for v0.16+ cross-process tier propagation) |
 | `Time` | `Sky.Core.Time` | now, sleep, every, unixMillis, format/formatISO8601/formatRFC3339/formatHTTP, addMillis, diffMillis, timeString |
 | `Std.Time` | `Std.Time` | 32 entries. IANA zones, addMonths/Years (month-end CLAMPED), dayOfWeek (ISO Mon=1..Sun=7), weekOfYear (ISO 8601), startOfDay/Week/Month/Year, diffDays/Hours/Minutes/Seconds. |
 | `Random` | `Sky.Core.Random` | int, float |

--- a/docs/skylive/pubsub.md
+++ b/docs/skylive/pubsub.md
@@ -54,15 +54,19 @@ doesn't deprecate polling for use cases that genuinely need it.
 ## API
 
 Three primitives — one per side of the TEA loop, plus a Task-shaped
-escape hatch for non-Live contexts:
+escape hatch for non-Live contexts, each with an echo-by-default form
+and a `publishNoEcho` variant that opts the publisher's own session
+out of delivery:
 
 ```elm
 -- Std.Cmd            (update-return tuple side)
-publish : String -> any -> Cmd msg
+publish       : String -> any -> Cmd msg
+publishNoEcho : String -> any -> Cmd msg
 -- Std.Sub            (subscriptions side)
 subscribeTopic : String -> (any -> msg) -> Sub msg
 -- Std.PubSub         (Task-shaped — any goroutine)
-publish : String -> any -> Task Error Int
+publish       : String -> any -> Task Error Int
+publishNoEcho : String -> any -> Task Error Int
 ```
 
 `Cmd.publish` and `Std.PubSub.publish` route to the same in-process
@@ -70,15 +74,16 @@ broker — a subscriber sees the same `SessionEvent` regardless of
 which side fired it. They differ only in where they can be CALLED
 from:
 
-- `Cmd.publish` lives inside an `update msg model -> (Model, Cmd Msg)`
-  return. Use it for "user clicked → broadcast" or "another Msg
-  triggered a broadcast".
-- `Std.PubSub.publish` returns a `Task Error Int` runnable from ANY
-  goroutine — raw `Sky.Http.Server` `api` handlers, post-init
-  bootstrap, scheduled jobs, callbacks from external systems
-  (webhooks). The `Int` is the broker's delivery count. Errors with
-  `Unavailable` when no `Live.app` is running in this process
-  (CLI tools, isolated unit tests, pure HTTP servers).
+- `Cmd.publish` / `Cmd.publishNoEcho` live inside an
+  `update msg model -> (Model, Cmd Msg)` return. Use them for "user
+  clicked → broadcast" or "another Msg triggered a broadcast".
+- `Std.PubSub.publish` / `Std.PubSub.publishNoEcho` return
+  `Task Error Int` runnable from ANY goroutine — raw
+  `Sky.Http.Server` `api` handlers, post-init bootstrap, scheduled
+  jobs, callbacks from external systems (webhooks). The `Int` is the
+  broker's delivery count. Errors with `Unavailable` when no
+  `Live.app` is running in this process (CLI tools, isolated unit
+  tests, pure HTTP servers).
 
 ### `Cmd.publish topic payload`
 
@@ -265,6 +270,73 @@ an `Origin` field on the wire that subscribers can match against their
 own sid. App-level suppression is the responsibility of the
 subscriber, not the publisher — this keeps the broker contract
 universal.
+
+### When to use echo vs no-echo
+
+`Cmd.publishNoEcho` (and `PubSub.publishNoEcho`) flips one bit:
+`SessionEvent.SkipOrigin = true`. The broker then skips delivery to
+any subscriber whose ownSid matches the publisher's sid — every other
+subscriber receives the event exactly as it would under the default
+`publish`.
+
+| Pattern | Use |
+|---|---|
+| Universal Msg handler — "A's tab and B's tab both apply the broadcast the same way through `MessageReceived`" | `publish` (echo-by-default) |
+| Instant feedback for publisher — "user clicked send, I've already appended the message to their model locally; just tell the OTHER tabs" | `publishNoEcho` |
+
+The savings:
+
+- **One broker round-trip per publish.** In v0.15.x in-process
+  broker, that's a channel push + a dispatch goroutine wakeup — sub-
+  microsecond, but eliminated entirely.
+- **Network latency in v0.16+ broker tiers.** Redis Pub/Sub, Cloud
+  Pub/Sub, NATS, and Postgres LISTEN/NOTIFY all route the publisher's
+  own echo back through the network. That's 10-100ms+ depending on
+  tier — visible UX latency on every keystroke / mouse click that
+  triggers a broadcast.
+
+The "instant feedback" pattern with `publishNoEcho`:
+
+```elm
+update msg model =
+    case msg of
+        SendChat text ->
+            let
+                chatMsg = { author = model.me, text = text, at = nowString () }
+                -- 1) Update the publisher's OWN model directly.
+                model_ =
+                    { model | history = model.history ++ [chatMsg], draft = "" }
+            in
+                ( model_
+                , Cmd.batch
+                    [ -- 2) Durable write — pattern from "write to DB first".
+                      Cmd.perform (persistMessage model.room chatMsg) PersistResult
+                    , -- 3) Broadcast to OTHER sessions only — broker suppresses
+                      --    delivery back to this session.
+                      Cmd.publishNoEcho
+                        ("chat:room-" ++ model.room)
+                        (chatMessageToDict chatMsg)
+                    ]
+                )
+
+        MessageReceived payload ->
+            -- Only fires for messages published by OTHER sessions —
+            -- the publisher's own message lands via the direct model
+            -- update above.
+            let
+                chatMsg = decodeChatMessage payload
+            in
+                ( { model | history = model.history ++ [chatMsg] }
+                , Cmd.none
+                )
+```
+
+`Cmd.publishNoEcho` is the right default for "I'm the source of
+truth for my own state" patterns. `Cmd.publish` remains the right
+default when the publisher's own dispatch path naturally consumes
+the broadcast — for example, a kanban board where every tab applies
+the same `CardMoved` Msg through `MessageReceived` whether they
+originated it or not.
 
 ## Cross-process delivery (v0.16+)
 

--- a/runtime-go/rt/live.go
+++ b/runtime-go/rt/live.go
@@ -840,16 +840,21 @@ func randID() string {
 
 type cmdT struct {
 	// kind values:
-	//   "none"      — Cmd.none — no-op
-	//   "batch"     — Cmd.batch — fan out a list of Cmds
-	//   "perform"   — Cmd.perform task toMsg — spawn task in goroutine
-	//   "publish"   — Cmd.publish topic payload (Cycle 3 P46 stub;
-	//                 P48 wires the dispatch path)
+	//   "none"          — Cmd.none — no-op
+	//   "batch"         — Cmd.batch — fan out a list of Cmds
+	//   "perform"       — Cmd.perform task toMsg — spawn task in goroutine
+	//   "publish"       — Cmd.publish topic payload (Cycle 3 P46/P48 —
+	//                     echo-by-default: publisher's own subscription
+	//                     receives the broadcast)
+	//   "publishNoEcho" — Cmd.publishNoEcho topic payload (Cycle 4 NE,
+	//                     issue #359 — broker skips delivery to
+	//                     subscribers whose ownerSid matches the
+	//                     publisher's sid)
 	kind  string
 	task  any
 	toMsg any
 	batch []any
-	// Pub/sub fields (kind = "publish"). Cycle 3 P46.
+	// Pub/sub fields (kind = "publish" or "publishNoEcho").
 	topic   string
 	payload any
 }
@@ -927,9 +932,34 @@ func Time_every(ms any, to any) SkySub { return Sub_every(ms, to) }
 // Fire-and-forget; no result feedback to the publisher (per design
 // doc §2.1). topic is the wire channel id (exact-match string;
 // pattern subs out of scope per design doc §1.2 non-goal 4).
+//
+// Echo-by-default: the publisher's own subscription on the same
+// topic receives the broadcast — matches Redis / NATS / MQTT
+// semantics. Use Cmd_publishNoEcho to opt out (issue #359).
 func Cmd_publish(topic, payload any) SkyCmd {
 	return cmdT{
 		kind:    "publish",
+		topic:   fmt.Sprintf("%v", topic),
+		payload: payload,
+	}
+}
+
+// Cmd_publishNoEcho builds a "publishNoEcho" Cmd. Sky-side surface:
+//
+//	Std.Cmd.publishNoEcho : String -> any -> Cmd msg
+//
+// Cycle 4 NE / issue #359 — opt out of echo-by-default. The broker
+// suppresses delivery to any subscriber whose ownerSid matches the
+// publisher's sid; every OTHER subscriber receives the broadcast
+// normally.
+//
+// Use this when the publisher updates its own model directly (in
+// `update`) and wants the broker to skip the round-trip back to
+// itself. In v0.16+ cross-process broker tiers (Redis / Cloud
+// Pub/Sub / NATS) the saved hop becomes 10-100ms+ of latency.
+func Cmd_publishNoEcho(topic, payload any) SkyCmd {
+	return cmdT{
+		kind:    "publishNoEcho",
 		topic:   fmt.Sprintf("%v", topic),
 		payload: payload,
 	}
@@ -3463,6 +3493,20 @@ func (app *liveApp) runCmd(sess *liveSession, cmd any) {
 			Payload: c.payload,
 			Origin:  sess.sid,
 		})
+	case "publishNoEcho":
+		// Cycle 4 NE / issue #359 — same dispatch as "publish" but
+		// the broker SKIPS delivery to subscribers whose ownerSid
+		// matches sess.sid (i.e. the publisher's own session). Pair
+		// with a direct model update for the "instant feedback for
+		// publisher" pattern without paying the broker round-trip.
+		if app.topics == nil {
+			return
+		}
+		app.Publish(c.topic, SessionEvent{
+			Payload:    c.payload,
+			Origin:     sess.sid,
+			SkipOrigin: true,
+		})
 	}
 }
 
@@ -3817,7 +3861,13 @@ func (app *liveApp) applyTopicSubsDiff(sess *liveSession, desired map[string]sub
 		}
 		for _, topic := range added {
 			leaf := desired[topic]
-			ch, brokerCancel := app.topics.Subscribe(topic)
+			// Register with the session sid as ownerSid so the broker
+			// can self-suppress on `Cmd.publishNoEcho` /
+			// `PubSub.publishNoEcho` (issue #359). Legacy callers
+			// who route through the bare Subscribe path are
+			// unaffected — empty ownerSid never matches a non-empty
+			// Origin.
+			ch, brokerCancel := app.topics.SubscribeWithOwner(topic, sess.sid)
 			// Wire the per-goroutine done channel HERE — before
 			// releasing the lock + spawning — so the cancel func
 			// stored in subRegistration is final + race-free

--- a/runtime-go/rt/live_pubsub_no_echo_test.go
+++ b/runtime-go/rt/live_pubsub_no_echo_test.go
@@ -1,0 +1,248 @@
+package rt
+
+// Cycle 4 NE — no-echo publish variants (Cmd.publishNoEcho /
+// PubSub.publishNoEcho).
+//
+// What this file pins:
+//
+//   - SessionEvent.SkipOrigin = true causes topicRegistry.Publish to
+//     skip delivery to subscribers whose ownSid matches event.Origin.
+//   - SkipOrigin = false (the default / existing behaviour) delivers
+//     to every subscriber — echo-by-default preserved.
+//   - PubSub_publishNoEcho with empty Origin behaves like a normal
+//     fan-out (no subscriber's ownSid is "", so nobody is "self").
+//   - Cmd_publishNoEcho builds a "publishNoEcho" cmdT whose runCmd
+//     arm routes through app.Publish with SkipOrigin=true.
+
+import (
+	"testing"
+	"time"
+)
+
+// ────────────────────────────────────────────────────────────────────
+// Registry-level SkipOrigin semantics
+// ────────────────────────────────────────────────────────────────────
+
+// TestTopicRegistry_SkipOriginSuppressesSelfDelivery pins the core
+// runtime contract: when event.SkipOrigin is true, a subscriber
+// registered with ownSid == event.Origin receives nothing while every
+// other subscriber receives the event normally.
+func TestTopicRegistry_SkipOriginSuppressesSelfDelivery(t *testing.T) {
+	r := newTopicRegistry(8)
+	defer r.Close()
+
+	pubCh, cancelPub := r.SubscribeWithOwner("room", "sid-publisher")
+	defer cancelPub()
+	otherCh, cancelOther := r.SubscribeWithOwner("room", "sid-other")
+	defer cancelOther()
+
+	delivered := r.Publish("room", SessionEvent{
+		Payload:    "hello",
+		Origin:     "sid-publisher",
+		SkipOrigin: true,
+	})
+	if delivered != 1 {
+		t.Fatalf("SkipOrigin Publish delivered=%d, want 1 (other only)", delivered)
+	}
+
+	// Publisher's own subscription must NOT receive.
+	expectNoRecvWithin(t, pubCh, 50*time.Millisecond)
+
+	// The foreign subscriber must receive.
+	ev, ok := recvWithin(t, otherCh, 100*time.Millisecond)
+	if !ok {
+		t.Fatalf("foreign subscriber did not receive event")
+	}
+	if ev.Payload != "hello" || ev.Origin != "sid-publisher" {
+		t.Fatalf("event mismatch: %+v", ev)
+	}
+}
+
+// TestTopicRegistry_SkipOriginNoSubscriptionForPublisher pins the
+// "publisher has no own subscription" case: SkipOrigin still delivers
+// to every other subscriber (nothing to skip — no-op).
+func TestTopicRegistry_SkipOriginNoSubscriptionForPublisher(t *testing.T) {
+	r := newTopicRegistry(8)
+	defer r.Close()
+
+	otherCh, cancelOther := r.SubscribeWithOwner("room", "sid-other")
+	defer cancelOther()
+
+	delivered := r.Publish("room", SessionEvent{
+		Payload:    "broadcast",
+		Origin:     "sid-publisher-no-sub",
+		SkipOrigin: true,
+	})
+	if delivered != 1 {
+		t.Fatalf("SkipOrigin Publish delivered=%d, want 1", delivered)
+	}
+	ev, ok := recvWithin(t, otherCh, 100*time.Millisecond)
+	if !ok {
+		t.Fatalf("foreign subscriber did not receive event")
+	}
+	if ev.Payload != "broadcast" {
+		t.Fatalf("event mismatch: %+v", ev)
+	}
+}
+
+// TestTopicRegistry_SkipOriginEmptyOriginDeliversAll pins the
+// server-side PubSub_publishNoEcho case: an empty Origin (server-side
+// publish, not tied to any session) delivers to every subscriber —
+// nobody's ownSid matches "".
+func TestTopicRegistry_SkipOriginEmptyOriginDeliversAll(t *testing.T) {
+	r := newTopicRegistry(8)
+	defer r.Close()
+
+	chA, cancelA := r.SubscribeWithOwner("room", "sid-a")
+	defer cancelA()
+	chB, cancelB := r.SubscribeWithOwner("room", "sid-b")
+	defer cancelB()
+
+	delivered := r.Publish("room", SessionEvent{
+		Payload:    "server-broadcast",
+		Origin:     "",
+		SkipOrigin: true,
+	})
+	if delivered != 2 {
+		t.Fatalf("empty-origin SkipOrigin Publish delivered=%d, want 2", delivered)
+	}
+	if _, ok := recvWithin(t, chA, 100*time.Millisecond); !ok {
+		t.Fatalf("sub A did not receive server-side publishNoEcho")
+	}
+	if _, ok := recvWithin(t, chB, 100*time.Millisecond); !ok {
+		t.Fatalf("sub B did not receive server-side publishNoEcho")
+	}
+}
+
+// TestTopicRegistry_SkipOriginFalsePreservesEcho pins the backward-
+// compat contract: the existing Cmd.publish / PubSub.publish path
+// leaves SkipOrigin=false (zero value) and MUST still echo to the
+// publisher's own subscription — the v0.15 default behaviour.
+func TestTopicRegistry_SkipOriginFalsePreservesEcho(t *testing.T) {
+	r := newTopicRegistry(8)
+	defer r.Close()
+
+	pubCh, cancelPub := r.SubscribeWithOwner("room", "sid-publisher")
+	defer cancelPub()
+
+	delivered := r.Publish("room", SessionEvent{
+		Payload: "echoed",
+		Origin:  "sid-publisher",
+		// SkipOrigin defaults to false — existing semantics.
+	})
+	if delivered != 1 {
+		t.Fatalf("echo-default Publish delivered=%d, want 1 (publisher echo)", delivered)
+	}
+	ev, ok := recvWithin(t, pubCh, 100*time.Millisecond)
+	if !ok {
+		t.Fatalf("publisher's own subscription did not receive echo")
+	}
+	if ev.Payload != "echoed" {
+		t.Fatalf("event mismatch: %+v", ev)
+	}
+}
+
+// TestTopicRegistry_SubscribeBackwardCompat — the old Subscribe entry
+// point (no ownSid arg) keeps working; such subscribers register with
+// ownSid == "" and therefore are NEVER skipped by SkipOrigin (because
+// publishers never have an empty Origin in the dispatch path — they
+// always carry their sess.sid, or are server-side which already keeps
+// Origin = "").
+func TestTopicRegistry_SubscribeBackwardCompat(t *testing.T) {
+	r := newTopicRegistry(8)
+	defer r.Close()
+
+	ch, cancel := r.Subscribe("legacy") // no ownSid — backward compat
+	defer cancel()
+	delivered := r.Publish("legacy", SessionEvent{
+		Payload:    "x",
+		Origin:     "sid-anybody",
+		SkipOrigin: true,
+	})
+	if delivered != 1 {
+		t.Fatalf("legacy subscriber w/ SkipOrigin Publish delivered=%d, want 1", delivered)
+	}
+	if _, ok := recvWithin(t, ch, 100*time.Millisecond); !ok {
+		t.Fatalf("legacy subscriber lost event")
+	}
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Cmd_publishNoEcho / PubSub_publishNoEcho kernel surfaces
+// ────────────────────────────────────────────────────────────────────
+
+// Test_CmdPublishNoEcho_BuildsCorrectCmd pins that Cmd_publishNoEcho
+// returns a cmdT whose kind = "publishNoEcho" and carries the topic
+// + payload. runCmd's matching arm is exercised in the dispatch test
+// below.
+func Test_CmdPublishNoEcho_BuildsCorrectCmd(t *testing.T) {
+	cmd := Cmd_publishNoEcho("topic-x", "payload-y")
+	if cmd.kind != "publishNoEcho" {
+		t.Fatalf("cmd.kind = %q, want %q", cmd.kind, "publishNoEcho")
+	}
+	if cmd.topic != "topic-x" {
+		t.Fatalf("cmd.topic = %q, want %q", cmd.topic, "topic-x")
+	}
+	if cmd.payload != "payload-y" {
+		t.Fatalf("cmd.payload = %v, want %v", cmd.payload, "payload-y")
+	}
+}
+
+// Test_PubSubPublishNoEcho_DeliversToOthersOnly — Task-shaped
+// publishNoEcho with an explicit Origin in the registered process
+// broker delivers to every subscriber except the one whose ownSid
+// matches Origin.
+//
+// The Task-shaped surface is normally called server-side (Origin =
+// ""), but a caller can pass an Origin via a future overload OR by
+// invoking the kernel directly from a context that has access to a
+// session sid. v0.15.x ships PubSub_publishNoEcho with Origin always
+// "" (server-side), so this test pins that the empty-origin call
+// behaves like a regular fan-out (no subscriber is "self").
+func Test_PubSubPublishNoEcho_ServerSideDeliversAll(t *testing.T) {
+	unregisterProcessBroker()
+	t.Cleanup(unregisterProcessBroker)
+
+	app := &liveApp{topics: newTopicRegistry(16)}
+	registerProcessBroker(app)
+
+	ch, cancel := app.topics.SubscribeWithOwner("noecho-topic", "sid-receiver")
+	defer cancel()
+
+	taskFn := PubSub_publishNoEcho("noecho-topic", "server-payload").(func() any)
+	result := taskFn()
+
+	if !isResultOk(result) {
+		t.Fatalf("expected Ok, got: %v", result)
+	}
+	delivered := resultOkValue(result).(int)
+	if delivered != 1 {
+		t.Fatalf("expected delivery count 1, got %d", delivered)
+	}
+
+	select {
+	case ev := <-ch:
+		if ev.Payload != "server-payload" {
+			t.Fatalf("payload mismatch: %v", ev.Payload)
+		}
+		if !ev.SkipOrigin {
+			t.Fatalf("expected SkipOrigin=true on delivered event")
+		}
+	default:
+		t.Fatal("subscriber did not receive the broadcast")
+	}
+}
+
+// Test_PubSubPublishNoEcho_NoLiveApp — same Err(Unavailable) path as
+// PubSub_publish when no Live.app is registered.
+func Test_PubSubPublishNoEcho_NoLiveApp(t *testing.T) {
+	unregisterProcessBroker()
+	t.Cleanup(unregisterProcessBroker)
+
+	taskFn := PubSub_publishNoEcho("any-topic", "payload").(func() any)
+	result := taskFn()
+
+	if !isResultErr(result) {
+		t.Fatalf("expected Err, got Ok with value: %v", result)
+	}
+}

--- a/runtime-go/rt/live_pubsub_task.go
+++ b/runtime-go/rt/live_pubsub_task.go
@@ -71,3 +71,41 @@ func PubSub_publish(topicArg, payloadArg any) any {
 		return Ok[any, any](delivered)
 	}
 }
+
+// PubSub_publishNoEcho — Task-shaped no-echo publish. Sky surface:
+//
+//	Std.PubSub.publishNoEcho : String -> any -> Task Error Int
+//
+// Cycle 4 NE / issue #359 — broker sets SkipOrigin = true on the
+// outgoing event. For the server-side path the Origin is always ""
+// (this function is called outside any Live session's update loop),
+// so SkipOrigin is effectively a no-op for the common case — no
+// subscriber's ownerSid will match an empty Origin.
+//
+// The Sky-side surface is still useful for forward-compat with v0.16+
+// cross-process broker tiers: a Redis/NATS/Cloud Pub/Sub backend may
+// need to advertise the "no-echo" bit on its own protocol level (so
+// the receiving node's broker can self-suppress without re-checking
+// the local registry). Shipping the surface now means user code that
+// migrates from PubSub.publish to PubSub.publishNoEcho doesn't need
+// a re-deploy at the v0.15 → v0.16 transition.
+func PubSub_publishNoEcho(topicArg, payloadArg any) any {
+	topic := AsString(topicArg)
+	return func() any {
+		app := processBroker.Load()
+		if app == nil {
+			return Err[any, any](ErrUnavailable(
+				"PubSub.publishNoEcho: no Sky.Live app registered in this process — Task-shaped publish needs Live.app running",
+			))
+		}
+		if app.topics == nil {
+			return Ok[any, any](0)
+		}
+		delivered := app.Publish(topic, SessionEvent{
+			Payload:    payloadArg,
+			Origin:     "",
+			SkipOrigin: true,
+		})
+		return Ok[any, any](delivered)
+	}
+}

--- a/runtime-go/rt/live_topics.go
+++ b/runtime-go/rt/live_topics.go
@@ -59,11 +59,18 @@ import (
 //   - Origin is the publisher sid; subscribers MAY self-skip on
 //     match to implement echo suppression at the app layer (echo-by-
 //     default is the locked behaviour per design doc Q2).
+//   - SkipOrigin (Cycle 4 NE — issue #359) requests broker-level
+//     self-suppression: when true, the registry skips delivery to
+//     any subscriber whose ownSid matches Origin. Set by
+//     `Cmd.publishNoEcho` / `PubSub.publishNoEcho`. Defaults to
+//     false → echo-by-default semantics preserved for existing
+//     `Cmd.publish` / `PubSub.publish` callers.
 type SessionEvent struct {
-	Topic     string
-	Payload   any
-	GlobalSeq int64
-	Origin    string
+	Topic      string
+	Payload    any
+	GlobalSeq  int64
+	Origin     string
+	SkipOrigin bool
 }
 
 // ═════════════════════════════════════════════════════════════════════
@@ -84,14 +91,23 @@ type SessionEvent struct {
 //     caller MUST call cancel when done; the registry uses cancel
 //     refcount transitions to drop the topic entry once it reaches 0.
 //
+//   - SubscribeWithOwner (Cycle 4 NE, issue #359) is Subscribe + an
+//     ownerSid argument the broker tracks alongside the channel. When
+//     a SkipOrigin publish arrives, the broker compares each
+//     subscriber's ownerSid to event.Origin and suppresses self-
+//     delivery. Legacy callers may keep using Subscribe (records ""
+//     as ownerSid; never matches a non-empty Origin).
+//
 //   - Publish returns the number of subscribers the event reached
 //     (useful for tracing / metrics + observability surfaces; the
-//     publisher's own subscription IS counted per echo-by-default).
+//     publisher's own subscription IS counted unless event.SkipOrigin
+//     suppresses it).
 //
 //   - Close releases any backend resources (no-op for the in-process
 //     impl; Redis / Cloud Pub/Sub close their network connections).
 type Broker interface {
 	Subscribe(topic string) (<-chan SessionEvent, func())
+	SubscribeWithOwner(topic, ownerSid string) (<-chan SessionEvent, func())
 	Publish(topic string, event SessionEvent) int
 	Close() error
 }
@@ -126,7 +142,18 @@ type topicEntry struct {
 	// subs holds every active subscriber's channel keyed by a
 	// per-subscribe unique id. Refcount = len(subs); when it reaches
 	// 0 the entry is removed from registry.entries.
-	subs map[uint64]chan SessionEvent
+	subs map[uint64]topicSub
+}
+
+// topicSub carries a single subscriber's delivery channel plus the
+// owning session sid (used by SkipOrigin self-suppression in
+// Cmd.publishNoEcho / PubSub.publishNoEcho — issue #359). ownerSid is
+// "" for legacy callers that registered via Subscribe (no-owner) —
+// such subscribers are never self-skipped because publishers never
+// dispatch with an empty Origin in the normal Live.app path.
+type topicSub struct {
+	ch       chan SessionEvent
+	ownerSid string
 }
 
 // subIDCounter — monotonic source of unique subscriber ids. atomic so
@@ -163,17 +190,38 @@ func newTopicRegistry(subBuf int) *topicRegistry {
 // When the cancel drops the refcount to zero, the topic entry is
 // removed from the registry — the contract that keeps the registry
 // bounded under churn (design doc §3.5).
+//
+// Subscribe registers with an empty ownerSid (legacy callers); to
+// participate in SkipOrigin self-suppression — `Cmd.publishNoEcho` /
+// `PubSub.publishNoEcho` (#359) — register via SubscribeWithOwner
+// instead.
 func (r *topicRegistry) Subscribe(topic string) (<-chan SessionEvent, func()) {
+	return r.SubscribeWithOwner(topic, "")
+}
+
+// SubscribeWithOwner is Subscribe + an `ownerSid` that the registry
+// records alongside the channel. When a SkipOrigin publish arrives,
+// the registry compares each subscriber's ownerSid to event.Origin
+// and skips delivery to matches. Legacy Subscribe is a thin wrapper
+// over this with ownerSid="" — empty ownerSid never matches a
+// non-empty Origin so legacy subscribers are not affected.
+//
+// Wired into Sky.Live's setupSubscriptions in P48 follow-up: the
+// session's sid IS the owner sid for every topic the session
+// subscribes to. The dispatch path passes session.sid as Origin on
+// every publish, so a session's own SkipOrigin publishes never echo
+// back to itself.
+func (r *topicRegistry) SubscribeWithOwner(topic, ownerSid string) (<-chan SessionEvent, func()) {
 	ch := make(chan SessionEvent, r.subBuf)
 	id := subIDCounter.Add(1)
 
 	r.mu.Lock()
 	entry, ok := r.entries[topic]
 	if !ok {
-		entry = &topicEntry{subs: map[uint64]chan SessionEvent{}}
+		entry = &topicEntry{subs: map[uint64]topicSub{}}
 		r.entries[topic] = entry
 	}
-	entry.subs[id] = ch
+	entry.subs[id] = topicSub{ch: ch, ownerSid: ownerSid}
 	r.mu.Unlock()
 
 	var cancelOnce sync.Once
@@ -204,10 +252,21 @@ func (r *topicRegistry) Subscribe(topic string) (<-chan SessionEvent, func()) {
 // arm. The publisher does not block; the next user dispatch (or
 // next broadcast) supersedes the missed event (per design doc §6.1).
 //
-// The publisher's OWN subscription is delivered to like any other —
-// echo-by-default is the locked behaviour (design doc Q2). App code
-// can self-skip on `event.Origin == sess.sid` if a particular
-// session shouldn't see its own message.
+// Echo behaviour:
+//
+//   - event.SkipOrigin == false (the default — `Cmd.publish` /
+//     `PubSub.publish`): every subscriber receives the event,
+//     including a subscriber whose ownerSid matches event.Origin.
+//     This is the echo-by-default behaviour from design doc Q2 and
+//     matches Redis / NATS / MQTT semantics.
+//
+//   - event.SkipOrigin == true (`Cmd.publishNoEcho` /
+//     `PubSub.publishNoEcho`, issue #359): every subscriber whose
+//     ownerSid matches event.Origin is skipped. Other subscribers
+//     receive normally. Pattern: publisher updates own model in
+//     `update`, calls publishNoEcho for the foreign fan-out — saves
+//     the broker round-trip + (in v0.16+ cross-process tiers) the
+//     network hop back.
 func (r *topicRegistry) Publish(topic string, event SessionEvent) int {
 	event.Topic = topic // canonicalise — caller might've left it blank
 	r.mu.Lock()
@@ -216,20 +275,33 @@ func (r *topicRegistry) Publish(topic string, event SessionEvent) int {
 		r.mu.Unlock()
 		return 0
 	}
-	// Snapshot the subscriber channel set under the lock, then
-	// release before the non-blocking pushes — keeps the critical
-	// section short so unrelated Subscribe / Cancel calls aren't
-	// stalled by a fan-out over many subscribers.
-	chans := make([]chan SessionEvent, 0, len(entry.subs))
-	for _, ch := range entry.subs {
-		chans = append(chans, ch)
+	// Snapshot the subscriber set under the lock, then release
+	// before the non-blocking pushes — keeps the critical section
+	// short so unrelated Subscribe / Cancel calls aren't stalled by
+	// a fan-out over many subscribers. We snapshot topicSub (not
+	// just the channel) so the SkipOrigin filter can compare
+	// ownerSid outside the lock.
+	subs := make([]topicSub, 0, len(entry.subs))
+	for _, sub := range entry.subs {
+		subs = append(subs, sub)
 	}
 	r.mu.Unlock()
 
 	delivered := 0
-	for _, ch := range chans {
+	for _, sub := range subs {
+		// SkipOrigin self-suppression — issue #359. The "" guard on
+		// ownerSid is load-bearing for the legacy Subscribe path
+		// (registered with empty ownerSid); without it, an empty
+		// Origin would silently skip every legacy subscriber. In
+		// practice publishers either carry sess.sid (Cmd.* dispatch
+		// arm) or "" (server-side PubSub.* path), and legacy
+		// subscribers register with "" — so the only intentional
+		// match is sess.sid → sess.sid.
+		if event.SkipOrigin && sub.ownerSid != "" && sub.ownerSid == event.Origin {
+			continue
+		}
 		select {
-		case ch <- event:
+		case sub.ch <- event:
 			delivered++
 		default:
 			// Slow / wedged subscriber — drop the event for THIS

--- a/runtime-go/rt/live_topics_test.go
+++ b/runtime-go/rt/live_topics_test.go
@@ -673,6 +673,10 @@ func newStubMemoryBroker() *stubMemoryBroker {
 }
 
 func (s *stubMemoryBroker) Subscribe(topic string) (<-chan SessionEvent, func()) {
+	return s.SubscribeWithOwner(topic, "")
+}
+
+func (s *stubMemoryBroker) SubscribeWithOwner(topic, _ownerSid string) (<-chan SessionEvent, func()) {
 	s.mu.Lock()
 	s.subscribed[topic]++
 	s.mu.Unlock()

--- a/sky-compiler.cabal
+++ b/sky-compiler.cabal
@@ -279,6 +279,7 @@ test-suite sky-tests
       Sky.Build.CaseSubjectNameShadowSpec
       Sky.Build.FfiKernelAliasSpec
       Sky.Build.PubSubPublishTaskSpec
+      Sky.Build.PubSubPublishNoEchoSpec
       Sky.Parse.MultiLineCaseSubjectSpec
       Sky.Parse.MultiLineCaseKeywordSpec
       Sky.Parse.MultiLineSignatureSpec

--- a/sky-stdlib/Std/Cmd.sky
+++ b/sky-stdlib/Std/Cmd.sky
@@ -7,7 +7,20 @@
 --
 -- `Cmd msg` is runtime-typed (empty home) — it shares its Go
 -- representation with the existing kernel-registered Cmd type.
-module Std.Cmd exposing (none, batch, perform, publish)
+--
+-- The pub/sub fan-out comes in two flavours:
+--   * `publish`        — echo-by-default; publisher's own
+--                        subscription on the same topic receives
+--                        the broadcast (matches Redis / NATS /
+--                        MQTT semantics).
+--   * `publishNoEcho`  — broker skips delivery to the publisher's
+--                        own subscription. Pair with a direct model
+--                        update for the "instant feedback for
+--                        publisher" pattern without paying the
+--                        broker round-trip (v0.16+ cross-process
+--                        broker tiers turn that hop into 10-100ms+
+--                        of network latency).
+module Std.Cmd exposing (none, batch, perform, publish, publishNoEcho)
 
 import Sky.Ffi as Ffi
 
@@ -38,7 +51,8 @@ perform =
 -- publisher. The publisher's own subscription (if any) ALSO
 -- receives the payload — echo-by-default matches Redis/NATS/MQTT
 -- semantics. App code can self-skip on `Origin == sess.sid` if
--- needed.
+-- needed, OR use `publishNoEcho` to push the suppression into the
+-- broker.
 --
 -- The payload is delivered as an opaque `any`; subscribers decode
 -- it via the `toMsg : any -> msg` function passed to
@@ -47,3 +61,23 @@ perform =
 publish : String -> any -> Cmd msg
 publish =
     Ffi.kernel "Cmd_publish"
+
+
+-- | `publishNoEcho topic payload` — broadcast `payload` to every
+-- subscriber EXCEPT the publisher's own session. Same shape as
+-- `publish` but the broker filters out the self-echo.
+--
+-- Use this when the publisher updates its own model directly in
+-- `update` (typical for "instant feedback" patterns — e.g. a chat
+-- message you've already appended locally, a vote you've already
+-- tallied) and only needs the broker for the foreign fan-out. Saves
+-- one broker round-trip per publish; in v0.16+ cross-process broker
+-- tiers (Redis / Cloud Pub/Sub / NATS) that's 10-100ms+ of
+-- user-visible latency.
+--
+-- The semantic difference is purely in delivery — the resulting
+-- `SessionEvent.Origin` is still the publisher's sid, and other
+-- subscribers see the broadcast identically to `publish`.
+publishNoEcho : String -> any -> Cmd msg
+publishNoEcho =
+    Ffi.kernel "Cmd_publishNoEcho"

--- a/sky-stdlib/Std/PubSub.sky
+++ b/sky-stdlib/Std/PubSub.sky
@@ -20,7 +20,20 @@
 --
 -- See `docs/skylive/pubsub.md` for the decision matrix and
 -- `examples/29-task-publish` for the canonical pattern.
-module Std.PubSub exposing (publish)
+--
+-- The pub/sub fan-out comes in two flavours:
+--   * `publish`        — echo-by-default. Server-side publishes
+--                        carry an empty `Origin`, so echo-by-
+--                        default has no visible effect for
+--                        Task-shaped callers (no subscriber's
+--                        ownSid matches "").
+--   * `publishNoEcho`  — sets the broker's SkipOrigin bit. In
+--                        v0.15.x in-process broker the difference
+--                        is cosmetic; in v0.16+ cross-process tiers
+--                        the no-echo bit propagates across the
+--                        protocol, saving the receiving node's
+--                        broker a local-registry roundtrip.
+module Std.PubSub exposing (publish, publishNoEcho)
 
 import Sky.Ffi as Ffi
 import Sky.Core.Error exposing (Error)
@@ -46,3 +59,20 @@ import Sky.Core.Task as Task
 publish : String -> any -> Task Error Int
 publish =
     Ffi.kernel "PubSub_publish"
+
+
+-- | `publishNoEcho topic payload` — Task-shaped publish that sets
+-- the broker's SkipOrigin bit on the outgoing event.
+--
+-- For the v0.15.x in-process broker the difference is cosmetic when
+-- called server-side (Origin is "", no subscriber's ownSid matches
+-- ""). For v0.16+ cross-process broker tiers — Redis Pub/Sub, Cloud
+-- Pub/Sub, NATS, Postgres LISTEN/NOTIFY — the no-echo bit is part
+-- of the wire protocol so the broker can self-suppress at the
+-- network edge, saving the receiving node a local-registry hop.
+--
+-- Same Err(Unavailable) semantics as `publish` when no `Live.app` is
+-- registered in this process.
+publishNoEcho : String -> any -> Task Error Int
+publishNoEcho =
+    Ffi.kernel "PubSub_publishNoEcho"

--- a/src/Sky/Build/EmbeddedRuntime.hs
+++ b/src/Sky/Build/EmbeddedRuntime.hs
@@ -36,6 +36,7 @@
 -- re-embed marker: 2026-05-28e — Cycle 4 #353: sky fmt next-anchor fallback so body comments above a reflowed expression round-trip losslessly
 -- re-embed marker: 2026-05-28f — revert(canonicalise): roll back #350 alias-name fix (regression in row-poly access on duplicate-named modules — #361)
 -- re-embed marker: 2026-05-28g — fix(canonicalise): cross-module alias-name collision v2 — (home, name) primary lookup + unique-body bare-name fallback (#350 + #361)
+-- re-embed marker: 2026-05-29 — Cycle 4 NE (#359): Cmd.publishNoEcho + PubSub.publishNoEcho — opt-out echo via SessionEvent.SkipOrigin + Broker.SubscribeWithOwner
 module Sky.Build.EmbeddedRuntime
     ( embeddedRuntime
     , embeddedSkyStdlib

--- a/src/Sky/Generate/Go/Kernel.hs
+++ b/src/Sky/Generate/Go/Kernel.hs
@@ -253,6 +253,7 @@ registry = Map.fromList
     , (("Cmd", "batch"),          KernelInfo "rt.Cmd_batch" 1 True)
     , (("Cmd", "perform"),        KernelInfo "rt.Cmd_perform" 2 True)
     , (("Cmd", "publish"),        KernelInfo "rt.Cmd_publish" 2 True)
+    , (("Cmd", "publishNoEcho"),  KernelInfo "rt.Cmd_publishNoEcho" 2 True)
 
     -- ═══════════════════════════════════════════════════════
     -- Time
@@ -496,6 +497,7 @@ registry = Map.fromList
     -- a Sky.Live update return).
     -- ═══════════════════════════════════════════════════════
     , (("PubSub", "publish"),     KernelInfo "rt.PubSub_publish" 2 True)
+    , (("PubSub", "publishNoEcho"), KernelInfo "rt.PubSub_publishNoEcho" 2 True)
 
     -- ═══════════════════════════════════════════════════════
     -- Set

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -1244,10 +1244,11 @@ Configure at runtime via env vars (or sky.toml `[log]` defaults):
 ```elm
 type Cmd msg = Cmd Foreign
 
-none    : Cmd msg
-perform : Task err a -> (Result err a -> msg) -> Cmd msg
-batch   : List (Cmd msg) -> Cmd msg
-publish : String -> any -> Cmd msg          -- pub/sub broadcast (Sky.Live only)
+none           : Cmd msg
+perform        : Task err a -> (Result err a -> msg) -> Cmd msg
+batch          : List (Cmd msg) -> Cmd msg
+publish        : String -> any -> Cmd msg   -- pub/sub broadcast, echo-by-default (Sky.Live only)
+publishNoEcho  : String -> any -> Cmd msg   -- pub/sub broadcast, broker skips publisher's own subscription
 ```
 
 `Cmd.perform` runs a Task in a background goroutine. When it completes, the result is dispatched as a Msg through the full update/view/diff/SSE cycle:
@@ -1291,10 +1292,13 @@ subscribeTopic : String -> (any -> msg) -> Sub msg     -- pub/sub receive (Sky.L
 Task-shaped publish for ANY context (raw `Sky.Http.Server` `api` handlers, post-init goroutines, scheduled jobs, webhook callbacks). Complements `Cmd.publish` which only fires from a Sky.Live `update` return — same broker, same subscribers, same in-process semantics.
 
 ```elm
-publish : String -> any -> Task Error Int    -- delivery count; Err Unavailable if no Live.app
+publish        : String -> any -> Task Error Int  -- delivery count; Err Unavailable if no Live.app
+publishNoEcho  : String -> any -> Task Error Int  -- sets broker's SkipOrigin bit (forward-compat with v0.16+ cross-process tiers)
 ```
 
 Both `Cmd.publish` and `Std.PubSub.publish` route to the same in-process topic registry — a subscriber's `Sub.subscribeTopic` receives them identically. Use `Cmd.publish` when you're inside an update return; use `Std.PubSub.publish` (with `Task.run` or `Cmd.perform`) from anywhere else.
+
+`publishNoEcho` is the "instant feedback for publisher" variant — the broker skips delivery to subscribers whose ownSid matches the publisher's sid (the publisher updates its own model directly in `update`, and only OTHER sessions receive the broadcast). Saves one broker round-trip per publish; in v0.16+ cross-process broker tiers that's 10-100ms+ of network latency.
 
 ### Std.Time
 

--- a/test/Sky/Build/PubSubPublishNoEchoSpec.hs
+++ b/test/Sky/Build/PubSubPublishNoEchoSpec.hs
@@ -1,0 +1,123 @@
+module Sky.Build.PubSubPublishNoEchoSpec (spec) where
+
+import Test.Hspec
+import System.Directory (getCurrentDirectory, doesFileExist,
+                         createDirectoryIfMissing)
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import System.Process (readCreateProcessWithExitCode, proc, CreateProcess(..))
+import System.Exit (ExitCode(..))
+import Data.List (isInfixOf)
+
+
+-- Cycle 4 NE / issue #359 — Cmd.publishNoEcho + Std.PubSub.publishNoEcho.
+--
+-- This spec pins:
+--
+--   1. Std.Cmd.publishNoEcho + Std.PubSub.publishNoEcho both
+--      type-check + build when imported by user code.
+--
+--   2. The PubSub.publishNoEcho call site routes to the
+--      rt.PubSub_publishNoEcho kernel (NOT to the panic-stub
+--      Ffi_kernel route) and reaches the runtime branch
+--      end-to-end — the Err(Unavailable) path fires when no
+--      Sky.Live app is registered.
+--
+--   3. The Cmd.publishNoEcho alias body lowers to its kernel
+--      stub — checked indirectly by the build succeeding with
+--      the import in scope (a missing kernel entry would surface
+--      as `undefined: rt.Cmd_publishNoEcho` at go build time,
+--      mirroring the Ffi-kernel-table validation that lights up
+--      missing entries).
+--
+-- The matching SkipOrigin runtime contract is exercised in
+-- runtime-go/rt/live_pubsub_no_echo_test.go.
+spec :: Spec
+spec = describe "Std.Cmd.publishNoEcho + Std.PubSub.publishNoEcho (Cycle 4 NE / #359)" $ do
+    it "type-checks + builds + routes PubSub kernel + runs the Err branch when no Live.app" $ do
+        sky <- findSky
+        withSystemTempDirectory "sky-pubsub-noecho" $ \tmp -> do
+            writeFixture tmp
+            (ec, out, errOut) <- runSky sky ["build", "src/Main.sky"] tmp
+            if ec /= ExitSuccess
+                then expectationFailure $
+                    "sky build failed.\n" ++ out ++ "\n" ++ errOut
+                else do
+                    built <- doesFileExist (tmp </> "sky-out" </> "app")
+                    built `shouldBe` True
+                    body <- readFile (tmp </> "sky-out" </> "main.go")
+                    -- PubSub.publishNoEcho lowers to its kernel
+                    -- symbol at the call site. Cmd.publishNoEcho's
+                    -- kernel-table entry is exercised by the build
+                    -- itself — Std.Cmd is in the import list, so
+                    -- the alias's rt.Ffi_kernel("Cmd_publishNoEcho")
+                    -- body must resolve; an unregistered name would
+                    -- surface as a build-time error in go build via
+                    -- `undefined: rt.Cmd_publishNoEcho` at any
+                    -- reachable call site.
+                    let pubSubRoutes = "rt.PubSub_publishNoEcho(" `isInfixOf` body
+                    pubSubRoutes `shouldBe` True
+                    -- Run with no Live.app — the PubSub Task fires
+                    -- its Err branch.
+                    (rc, runOut, _) <- runApp tmp
+                    rc `shouldBe` ExitSuccess
+                    ("no-live-app" `isInfixOf` runOut) `shouldBe` True
+
+  where
+    fixture :: String
+    fixture =
+        "module Main exposing (main)\n\n\
+        \import Sky.Core.Prelude exposing (..)\n\
+        \import Sky.Core.Task as Task\n\
+        \import Sky.Core.Dict as Dict\n\
+        \import Std.Cmd as Cmd\n\
+        \import Std.PubSub as PubSub\n\
+        \import Std.Log exposing (println)\n\n\n\
+        \-- Std.Cmd.publishNoEcho is in scope; an unregistered\n\
+        \-- kernel binding would surface as a build error when\n\
+        \-- the alias body's Ffi_kernel route fails to resolve\n\
+        \-- against the typed Cmd shape.\n\
+        \_cmdImported : String -> any -> Cmd ()\n\
+        \_cmdImported =\n\
+        \    Cmd.publishNoEcho\n\n\n\
+        \main =\n\
+        \    let\n\
+        \        payload = Dict.fromList [( \"k\", \"v\" )]\n\
+        \        result = Task.run (PubSub.publishNoEcho \"t\" payload)\n\
+        \    in\n\
+        \        case result of\n\
+        \            Ok n ->\n\
+        \                println (\"ok-\" ++ String.fromInt n)\n\
+        \            Err _ ->\n\
+        \                println \"no-live-app\"\n"
+
+    writeFixture :: FilePath -> IO ()
+    writeFixture tmp = do
+        createDirectoryIfMissing True (tmp </> "src")
+        writeFile (tmp </> "sky.toml")
+            ("name = \"pubsub-noecho\"\n"
+                ++ "version = \"0.0.0\"\n"
+                ++ "entry = \"src/Main.sky\"\n\n"
+                ++ "[source]\nroot = \"src\"\n")
+        writeFile (tmp </> "src" </> "Main.sky") fixture
+
+    findSky :: IO FilePath
+    findSky = do
+        cwd <- getCurrentDirectory
+        let candidate = cwd </> "sky-out" </> "sky"
+        ok <- doesFileExist candidate
+        if ok
+            then return candidate
+            else return "sky"
+
+    runSky :: FilePath -> [String] -> FilePath -> IO (ExitCode, String, String)
+    runSky sky args cwd =
+        readCreateProcessWithExitCode
+            ((proc sky args) { cwd = Just cwd })
+            ""
+
+    runApp :: FilePath -> IO (ExitCode, String, String)
+    runApp tmp =
+        readCreateProcessWithExitCode
+            ((proc (tmp </> "sky-out" </> "app") []) { cwd = Just tmp })
+            ""

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -33,6 +33,7 @@ import qualified Sky.Build.EntryLocalShadowsDepSpec
 import qualified Sky.Build.CaseSubjectNameShadowSpec
 import qualified Sky.Build.FfiKernelAliasSpec
 import qualified Sky.Build.PubSubPublishTaskSpec
+import qualified Sky.Build.PubSubPublishNoEchoSpec
 import qualified Sky.Parse.MultiLineCaseSubjectSpec
 import qualified Sky.Parse.MultiLineCaseKeywordSpec
 import qualified Sky.Parse.MultiLineSignatureSpec
@@ -221,6 +222,11 @@ main = hspec $ do
     -- / scheduled jobs), complements Cmd.publish which is bound to
     -- the Sky.Live update-return tuple.
     describe "Sky.Build.PubSubPublishTask" Sky.Build.PubSubPublishTaskSpec.spec
+    -- Cycle 4 NE / issue #359: Cmd.publishNoEcho + PubSub.publishNoEcho —
+    -- opt-out echo for "instant feedback for publisher" pattern. Saves
+    -- the broker round-trip; in v0.16+ cross-process broker tiers the
+    -- saved hop is 10-100ms+ of latency.
+    describe "Sky.Build.PubSubPublishNoEcho" Sky.Build.PubSubPublishNoEchoSpec.spec
     describe "Sky.Parse.MultiLineCaseSubject" Sky.Parse.MultiLineCaseSubjectSpec.spec
     describe "Sky.Parse.MultiLineCaseKeyword"
         Sky.Parse.MultiLineCaseKeywordSpec.spec


### PR DESCRIPTION
## Summary

Adds a no-echo variant of the pub/sub APIs so the publisher's own subscription is NOT delivered the broadcast — pair with a direct model update in `update` for "instant feedback for publisher" without paying the broker round-trip.

* `Std.Cmd.publishNoEcho : String -> any -> Cmd msg`
* `Std.PubSub.publishNoEcho : String -> any -> Task Error Int`

## Background

`Cmd.publish` and `Std.PubSub.publish` are echo-by-default (matches Redis / NATS / MQTT). For sky-language users building chat / collaborative-edit / kanban / live-dashboard apps, that echo is ergonomic friction — the publisher already updated its own model in `update` and now has to self-filter on `Origin == sess.sid` in `MessageReceived`. In v0.16+ cross-process broker tiers (Redis Pub/Sub, Cloud Pub/Sub, NATS, Postgres LISTEN/NOTIFY), the echo round-trip is 10-100ms+ of network latency — user-visible UX delay on every keystroke / click that triggers a broadcast.

Reported by the sky-language project owner.

## Design

One new bit on `SessionEvent`:

```go
type SessionEvent struct {
    Topic      string
    Payload    any
    GlobalSeq  int64
    Origin     string
    SkipOrigin bool   // NEW
}
```

The broker's `Publish` skips delivery to any subscriber whose `ownerSid` matches `event.Origin` when `SkipOrigin` is set. Existing `Cmd.publish` / `PubSub.publish` callers leave it false (zero value) — backward-compatible, no behavior change for `examples/27-multi-session-chat` or any other current pub/sub user.

The broker interface gains `SubscribeWithOwner(topic, ownerSid)`. The legacy `Subscribe(topic)` keeps working (records `""` as `ownerSid` — empty never matches a non-empty `Origin`, so legacy subscribers behave identically). Sky.Live's `setupSubscriptions` now uses `SubscribeWithOwner` with `sess.sid` so in-process Sky.Live sessions get real self-suppression for free.

`Cmd_publishNoEcho` / `PubSub_publishNoEcho` set `SkipOrigin = true` on the outgoing event. For `Cmd_publishNoEcho` the dispatch arm in `runCmd` carries `sess.sid` as `Origin` (publisher's session); for `PubSub_publishNoEcho` the server-side path keeps `Origin = ""` (no session to skip) but the bit propagates for forward-compat with cross-process broker tiers that may need it on their own protocol level.

No wire-format changes needed for v0.15.x — the bit lives entirely inside the in-process registry. v0.16+ cross-process tiers will encode it in their protocol envelopes (planned).

## Test plan

* [x] Runtime Go tests — `runtime-go/rt/live_pubsub_no_echo_test.go` covers SkipOrigin true/false, empty Origin (server-side), publisher-without-own-subscription, legacy Subscribe backward-compat, and the PubSub_publishNoEcho registered-app + no-app paths.
* [x] Race-clean — `go test ./rt -run "TopicRegistry|NoEcho|SkipOrigin" -race -count=3` green.
* [x] Cabal spec — `test/Sky/Build/PubSubPublishNoEchoSpec.hs` verifies the kernel routing + end-to-end Err(Unavailable) branch.
* [x] Cabal sweep — `unset SKY_RUNTIME_DIR && cabal test sky-tests` 413 examples / 0 failures / 1 pending (matches prior gate count + 1 new spec).
* [x] Smoke test — `Std.PubSub.publishNoEcho` + `Std.Cmd.publishNoEcho` compile + run via an isolated fixture; `rt.PubSub_publishNoEcho` shows up at the lowered call site.
* [x] `sky fmt` on `Std/Cmd.sky` + `Std/PubSub.sky` idempotent (4 successful runs).

## Docs

* `docs/skylive/pubsub.md` — new "When to use echo vs no-echo" subsection with the latency-tax explanation + the canonical "instant feedback for publisher" code pattern.
* `CLAUDE.md` + `templates/CLAUDE.md` — `Std.Cmd` and `Std.PubSub` stdlib table rows updated.

## Release

**DO NOT TAG** — batches with #114 for the next compiler-side patch tag.