### PR TITLE
feat(stdlib): Sky.Http.Server.Stream — server-side streaming response primitive (#362)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -524,6 +524,7 @@ Each binding is either:
 | `Log` | `Std.Log` | println, debug, info, warn, error, debugWith, infoWith, warnWith, errorWith |
 | `Trace` | `Std.Trace` | span, event, attr — opt-in app-level tracing spans. Tier-1 spans (HTTP/session/Msg/DB/Auth/Http/File) are automatic; see `docs/observability.md` |
 | `Server` | `Sky.Http.Server` | param, queryParam, header, getCookie, static (Layer 3 surface); higher-level `get/post/listen/text/json/html` stay kernel-only |
+| `Stream` | `Sky.Http.Server.Stream` | stream, emit, finish, withContentType — server-side streaming HTTP responses (SSE / LLM token forwarding / chunked downloads). Mirror of `Sky.Core.Http.Stream` (which reads upstream bodies as Sub events). See `docs/skylive/http-streaming.md` §"Server-side" + `examples/30-sse-server-demo`. |
 | `Middleware` | `Sky.Http.Middleware` | withCors, withLogging, withBasicAuth, withRateLimit |
 | `RateLimit` | `Sky.Http.RateLimit` | allow |
 

--- a/docs/skylive/http-streaming.md
+++ b/docs/skylive/http-streaming.md
@@ -191,3 +191,142 @@ subscriptions model =
 
 Streaming is for endpoints where time-to-first-byte beats
 end-to-end throughput. Pick deliberately.
+
+---
+
+## Server-side streaming responses (Sky.Http.Server.Stream)
+
+The mirror image of `Sky.Core.Http.Stream`: instead of reading
+chunks from an upstream into the update loop, a
+`Sky.Http.Server` handler emits chunks back to its HTTP client
+one piece at a time.
+
+### Driving use case
+
+`agent-service`'s `/generate` endpoint streams LLM tokens to the
+SkyDeploy dashboard.  Before `Server.Stream` existed, every Sky
+HTTP handler buffered its whole body (`SkyResponse.Body string`)
+— the client waited for the entire completion before seeing
+anything.  Now the handler emits each upstream chunk as it
+arrives.  Combined with `Sky.Core.Http.Stream` on the proxy
+side (reading the upstream LLM API) and `Sky.Core.Http.Stream`
+on the dashboard side (consuming the proxy), the whole pipe is
+incremental.
+
+### Surface
+
+`sky-stdlib/Sky/Http/Server/Stream.sky`:
+
+| Name | Type |
+|---|---|
+| `StreamWriter(..)` | `type StreamWriter = StreamWriter Int` — opaque handle |
+| `stream` | `String -> (StreamWriter -> Task Error ()) -> Task Error Response` |
+| `emit` | `String -> StreamWriter -> Task Error ()` |
+| `finish` | `StreamWriter -> Task Error ()` |
+| `withContentType` | `String -> StreamWriter -> Task Error ()` (best-effort, pre-emit only) |
+
+### Minimal example (SSE)
+
+```elm
+import Sky.Http.Server as Server
+import Sky.Http.Server.Stream as Stream
+import Sky.Core.Time as Time
+import Sky.Core.Task as Task
+
+handleEvents : Request -> Task Error Response
+handleEvents _ =
+    Stream.stream "text/event-stream" (\writer ->
+        Stream.emit "event: hello\ndata: 1\n\n" writer
+            |> Task.andThen (\_ -> Time.sleep 100)
+            |> Task.andThen (\_ -> Stream.emit "event: tick\ndata: 2\n\n" writer)
+            |> Task.andThen (\_ -> Stream.finish writer))
+```
+
+Verify with `curl --no-buffer http://localhost:8000/events` —
+chunks arrive incrementally, not buffered.
+
+Runnable: `examples/30-sse-server-demo`.
+
+### Dispatcher contract
+
+When a handler returns `Stream.stream ct h` (i.e. a `SkyResponse`
+with `StreamHandler` non-nil), the dispatcher in `Server_listen`:
+
+1. Asserts the underlying `http.ResponseWriter` implements
+   `http.Flusher`.  Rejects with `503 Service Unavailable` if not
+   — buffered output would silently break the streaming
+   contract.
+2. Applies `Content-Type` from `ct`, plus any `Headers` map +
+   safe-by-default security headers (parity with the buffered
+   path).  CSRF auto-injection is skipped — streaming bodies
+   aren't form-bearing HTML.
+3. `WriteHeader(status)` + `Flush()` — the response head is on
+   the wire BEFORE the handler runs.  Critical for SSE: the
+   EventSource spec requires `Content-Type: text/event-stream`
+   to be visible before the first event.
+4. Registers a `serverStreamHandle` keyed on a process-global
+   atomic id, invokes the user's handler closure via `SkyCall`
+   passing the `StreamWriter` ADT, and drives the returned Task
+   to completion.
+5. Sweeps the handle on dispatcher return (deferred — runs on
+   panic too).
+
+### `emit` semantics
+
+- `emit chunk writer` writes `chunk` to the response body and
+  calls `Flush()` immediately.  The bytes are on the client's
+  socket before the Task resolves.
+- Client disconnect mid-stream returns `Err (ErrNetwork ...)`
+  from the next `emit` so the handler can choose to abort.
+- `emit` after `finish` (or after the handle is swept) is a
+  silent no-op (`Ok ()`).  Lets a "tail `finish` + always-final
+  `emit`" defensive shape compose without races.
+
+### `finish` semantics
+
+- `finish writer` flips the closed flag.  Subsequent emits
+  become no-ops.  The dispatcher's connection-close happens
+  when the handler's outer Task resolves, NOT inside `finish`.
+- Idempotent — safe to call from multiple branches.
+
+### Concurrency contract
+
+- ONE handler goroutine per request (Go's `http.Handler`
+  convention).  `emit` is NOT safe across user-spawned
+  goroutines without external synchronisation.
+- Handles live in a process-global `sync.Map` only for the
+  duration of the handler call.  No persistent registry — if
+  the handler returns, the writer id is invalid.
+
+### CSRF + security headers
+
+- `setSecurityHeaders` runs on streaming responses (parity with
+  buffered).
+- CSRF middleware only inspects `POST` / `PUT` / `PATCH` /
+  `DELETE`; the typical SSE/streaming endpoint is `GET`, so it
+  passes through.  For streaming POST endpoints, the CSRF
+  middleware verifies the token before the handler runs — same
+  shape as the buffered path.
+
+### Limitations
+
+- **No keep-alive ping built in.**  If you need an idle
+  heartbeat (browsers + many proxies drop SSE connections after
+  ~60 s of silence), emit your own `: ping\n\n` comment line
+  on a `Time.sleep`+`emit` loop.
+- **Single-handler-goroutine emit ordering.**  Concurrent emits
+  from goroutines spawned inside the handler are undefined.
+  Linearise via `Task.andThen`.
+- **`withContentType` is best-effort.**  Once the first `emit`
+  fires, headers are sealed.  Set the real Content-Type via
+  the `stream` argument; reserve `withContentType` for the
+  rare "decide on the format after a Task" pattern.
+
+### See also
+
+- `runtime-go/rt/server_stream.go` — runtime helpers + dispatcher
+  integration.
+- `runtime-go/rt/server_stream_test.go` — Flusher contract,
+  chunk-ordering, handle-sweep, end-to-end via httptest.
+- `examples/30-sse-server-demo` — runnable demo with a browser
+  EventSource snippet in the home page.

--- a/examples/30-sse-server-demo/README.md
+++ b/examples/30-sse-server-demo/README.md
@@ -1,0 +1,52 @@
+# SSE server demo (Sky.Http.Server.Stream)
+
+A minimal Sky.Http.Server app demonstrating server-side streaming
+HTTP responses via `Sky.Http.Server.Stream` (the mirror image of
+`Sky.Core.Http.Stream`, which handles client-side incremental
+reads).
+
+## What this exercises
+
+- `Stream.stream "text/event-stream" handler` — open a streaming
+  response.  The dispatcher writes headers + flushes BEFORE
+  invoking `handler`, so the client sees `200 OK` +
+  `Content-Type: text/event-stream` immediately.
+- `Stream.emit chunk writer` — write a chunk and flush to the
+  client socket.  Bytes hit the wire before `emit`'s Task
+  resolves.
+- `Stream.finish writer` — mark the response complete (idempotent;
+  also implicit at handler return).
+
+## Running
+
+```
+cd examples/30-sse-server-demo
+sky run src/Main.sky
+```
+
+Then in another terminal:
+
+```
+curl --no-buffer http://localhost:8000/events
+```
+
+You should see five `tick` events arrive ~200ms apart followed by a
+`done` event, then the connection closes.  The `--no-buffer` flag is
+critical — without it, `curl` buffers the whole body and the demo
+appears non-streaming.
+
+Browser console:
+
+```js
+const s = new EventSource('http://localhost:8000/events');
+s.addEventListener('tick', e => console.log('tick:', e.data));
+s.addEventListener('done', () => { console.log('done'); s.close(); });
+```
+
+## Use cases
+
+- LLM token streaming (proxy upstream streaming completions to the
+  browser).
+- Long-running task progress (build / deploy / data-import dashboards).
+- Live notifications without WebSocket complexity.
+- Chunked file responses for very large downloads.

--- a/examples/30-sse-server-demo/sky.toml
+++ b/examples/30-sse-server-demo/sky.toml
@@ -1,0 +1,7 @@
+name = "sse-server-demo"
+version = "0.1.0"
+entry = "src/Main.sky"
+port = 8000
+
+[source]
+root = "src"

--- a/examples/30-sse-server-demo/src/Main.sky
+++ b/examples/30-sse-server-demo/src/Main.sky
@@ -1,0 +1,55 @@
+module Main exposing (main)
+
+import Sky.Core.Prelude exposing (..)
+import Sky.Core.Task as Task
+import Sky.Core.String as String
+import Sky.Core.Time as Time
+import Sky.Http.Server as Server
+import Sky.Http.Server exposing (Request, Response)
+import Sky.Http.Server.Stream as Stream
+import Sky.Core.Error exposing (Error)
+
+
+-- | A canonical Server-Sent Events endpoint demonstrating
+-- `Sky.Http.Server.Stream`.  Streams a `tick` event every 200ms
+-- for five ticks, then a final `done` event, then closes.
+--
+-- Verify with `curl --no-buffer http://localhost:8000/events` —
+-- chunks should appear progressively, not all at once.
+main =
+    Server.listen
+        8000
+        [ Server.get "/" handleHome, Server.get "/events" handleEvents ]
+
+
+handleHome : Request -> Task Error Response
+handleHome _ =
+    Task.succeed
+        (Server.html
+            """<h1>SSE server demo</h1>
+<p>Open <code>/events</code> in a terminal:</p>
+<pre>curl --no-buffer http://localhost:8000/events</pre>
+<p>Or run this in a browser console:</p>
+<pre>const s = new EventSource('/events');
+s.addEventListener('tick', e =&gt; console.log('tick:', e.data));
+s.addEventListener('done', () =&gt; { console.log('done'); s.close(); });</pre>""")
+
+
+handleEvents : Request -> Task Error Response
+handleEvents _ =
+    Stream.stream
+        "text/event-stream"
+        (\writer ->
+            emitTick writer 1 |> Task.andThen (\_ -> emitTick writer 2)
+                |> Task.andThen (\_ -> emitTick writer 3)
+                |> Task.andThen (\_ -> emitTick writer 4)
+                |> Task.andThen (\_ -> emitTick writer 5)
+                |> Task.andThen
+                       (\_ -> Stream.emit "event: done\ndata: bye\n\n" writer)
+                |> Task.andThen (\_ -> Stream.finish writer))
+
+
+emitTick : Stream.StreamWriter -> Int -> Task Error ()
+emitTick writer n =
+    Stream.emit ("event: tick\ndata: " ++ String.fromInt n ++ "\n\n") writer
+        |> Task.andThen (\_ -> Time.sleep 200)

--- a/examples/30-sse-server-demo/verify.json
+++ b/examples/30-sse-server-demo/verify.json
@@ -1,0 +1,7 @@
+{
+    "_comment": "verify scenarios for the SSE server demo (Sky.Http.Server.Stream). The /events endpoint streams 5 tick events + 1 done event with 200ms delays between ticks — total ~1.2s response time. Body assertions check the SSE protocol shape, not chunked-incremental delivery (that's covered by runtime-go/rt/server_stream_test.go's end-to-end test).",
+    "requests": [
+        { "method": "GET", "path": "/",       "expectStatus": 200, "expectBody": ["SSE server demo"] },
+        { "method": "GET", "path": "/events", "expectStatus": 200, "expectBody": ["event: tick", "event: done"] }
+    ]
+}

--- a/runtime-go/rt/rt.go
+++ b/runtime-go/rt/rt.go
@@ -6652,12 +6652,28 @@ type SkyRequest struct {
 	RemoteAddr string // audit P1-2: client IP for rate-limit keying
 }
 
-// SkyResponse wraps an HTTP response
+// SkyResponse wraps an HTTP response.
+//
+// Streaming (Sky.Http.Server.Stream): when StreamHandler is non-nil
+// the dispatcher in Server_listen takes the chunked-write path
+// instead of `fmt.Fprint(w, Body)`. Body MUST be empty in that
+// shape — the user's handler emits chunks via ServerStream_emit
+// after the dispatcher flushes the head.
 type SkyResponse struct {
 	Status      int
 	Body        string
 	Headers     map[string]string
 	ContentType string
+
+	// StreamHandler is the user's `StreamWriter -> Task Error ()`
+	// closure. The dispatcher special-cases this when non-nil:
+	// writes headers + flush, registers a serverStreamHandle,
+	// invokes the closure (driving the returned Task to
+	// completion), then sweeps the handle.
+	//
+	// Set by Server.Stream.stream (ServerStream_stream); never set
+	// by the buffered builders (Server.text/json/html).
+	StreamHandler any
 }
 
 // HTTP server safety limits — the DEFAULTS. They exist to prevent
@@ -6824,6 +6840,15 @@ func Server_listen(port any, routes any) any {
 			}
 			if ok && resp.Tag == 0 {
 				skyResp := resp.OkValue.(SkyResponse)
+				// Streaming response (Sky.Http.Server.Stream): dispatch
+				// the user's handler over a chunk-writer instead of
+				// buffering the body. The branch sets headers + flushes,
+				// then drives the handler Task to completion. After
+				// return the connection closes naturally.
+				if skyResp.StreamHandler != nil {
+					serveStreamingResponse(w, req, skyResp)
+					return
+				}
 				// Apply the response's default ContentType FIRST so the
 				// Headers map (populated by Server.withHeader) can
 				// override it. Otherwise an explicit

--- a/runtime-go/rt/server_stream.go
+++ b/runtime-go/rt/server_stream.go
@@ -1,0 +1,344 @@
+// server_stream.go — Sky.Http.Server.Stream server-side streaming
+// HTTP response runtime (Cycle 4 HS-Server).
+//
+// Mirror image of http_stream.go (Sky.Core.Http.Stream — client-side
+// incremental body reads).  Where http_stream.go reads chunks FROM
+// an upstream into Sky's update loop as Msgs, this file writes
+// chunks FROM a Sky handler TO an HTTP client over a long-lived
+// connection.
+//
+// The shape:
+//
+//   Sky side:                              Runtime side:
+//   ─────────                              ─────────────
+//   Stream.stream ct handler            → ServerStream_stream:
+//                                         pack (ct, handler) into a
+//                                         streaming SkyResponse; the
+//                                         dispatcher detects the
+//                                         StreamHandler sentinel and
+//                                         takes the chunk-write path.
+//
+//   Stream.emit chunk writer            → ServerStream_emit:
+//                                         resolve writer id → handle,
+//                                         w.Write(chunk) + Flush().
+//
+//   Stream.finish writer                → ServerStream_finish:
+//                                         flag the handle closed so
+//                                         late `emit`s become no-ops
+//                                         and the dispatcher knows
+//                                         the handler is done.
+//
+//   Stream.withContentType ct writer    → ServerStream_withContentType:
+//                                         set Content-Type if headers
+//                                         haven't been flushed yet
+//                                         (best-effort; no-op otherwise).
+//
+// Concurrency contract:
+//
+//   - Each streaming response gets its own serverStreamHandle with
+//     a unique id (process-global atomic counter, NEVER zero).
+//
+//   - Handles live on serverStreamHandles (a sync.Map) for the
+//     lifetime of the user's handler.  serveStreamingResponse
+//     registers + sweeps under defer so an early panic or handler
+//     return cleans up.
+//
+//   - http.ResponseWriter is single-goroutine-write by Go convention.
+//     We don't take a mutex on emit() — the user's handler runs in
+//     ONE goroutine (the http.Handler goroutine) and emits
+//     sequentially.  If user code spawns goroutines and emits
+//     concurrently, behaviour is undefined (same as raw http stdlib).
+//
+//   - http.Flusher: every chunk is followed by Flush().  If the
+//     underlying ResponseWriter doesn't implement Flusher (rare —
+//     only middleware wrapping that doesn't pass-through Flusher),
+//     stream() returns Err ErrUnavailable BEFORE invoking the
+//     handler so the user gets a clear error instead of buffered
+//     non-streaming output.
+
+package rt
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+	"sync/atomic"
+)
+
+// ═══════════════════════════════════════════════════════════════
+// serverStreamHandle — one in-flight streaming response
+// ═══════════════════════════════════════════════════════════════
+
+// serverStreamHandle owns one open http.ResponseWriter for the
+// duration of a streaming response.  The user's handler emits
+// chunks via the handle's id; the dispatcher cleans up on handler
+// return.
+type serverStreamHandle struct {
+	id      int64
+	w       http.ResponseWriter
+	flusher http.Flusher
+
+	// closed — set true the first time finish fires (OR the
+	// dispatcher sweeps after handler return).  Subsequent emit /
+	// finish / withContentType are no-ops.
+	closed atomic.Bool
+
+	// headerSent — set true on the first successful emit OR
+	// explicit pre-emit header flush.  Once true, withContentType
+	// is a no-op (HTTP can't undo a flushed header).
+	headerSent atomic.Bool
+
+	// mu guards the write path against concurrent emit / finish
+	// from misbehaved user code.  Optional — the documented
+	// contract is single-writer, but the lock prevents a runtime
+	// panic if the user violates it.
+	mu sync.Mutex
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Registry — id → handle
+// ═══════════════════════════════════════════════════════════════
+
+// serverStreamHandles maps stream id → *serverStreamHandle for the
+// duration of the user's handler.  Process-global (NOT per-session)
+// so a Sky.Http.Server handler — which has no session context — can
+// resolve its writer id.  Tradeoff: a runaway handler that never
+// returns + never finishes leaks one entry forever; the dispatcher's
+// defer-sweep neutralises this for normal handler exits + panics.
+var serverStreamHandles sync.Map
+
+// serverStreamIDCounter — monotonic source of unique stream ids.
+// Process-wide, atomic for lock-free allocation under concurrent
+// requests.
+var serverStreamIDCounter atomic.Int64
+
+// nextServerStreamID — fresh non-zero id.  0 is reserved so a zero-
+// valued StreamWriter (uninitialised model field) can't accidentally
+// resolve to a live stream.
+func nextServerStreamID() int64 {
+	for {
+		id := serverStreamIDCounter.Add(1)
+		if id != 0 {
+			return id
+		}
+	}
+}
+
+// lookupServerStream — resolve an id to the in-flight handle.
+// Returns nil if the id was never registered OR was already swept.
+func lookupServerStream(id int64) *serverStreamHandle {
+	v, ok := serverStreamHandles.Load(id)
+	if !ok {
+		return nil
+	}
+	return v.(*serverStreamHandle)
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Sky-facing kernel entries
+// ═══════════════════════════════════════════════════════════════
+
+// ServerStream_stream implements:
+//
+//	Sky.Http.Server.Stream.stream
+//	    : String -> (StreamWriter -> Task Error ()) -> Task Error Response
+//
+// Returns a Task that resolves to a `Response` carrying the
+// streaming sentinel.  The dispatcher in Server_listen detects
+// the non-nil StreamHandler and routes to serveStreamingResponse.
+//
+// The user's handler closure (the `(StreamWriter -> Task Error ())`
+// argument) is stored verbatim on the response; the dispatcher
+// calls it via SkyCall once the response head is on the wire.
+func ServerStream_stream(contentType any, handler any) any {
+	ct := fmt.Sprintf("%v", contentType)
+	if ct == "" {
+		ct = "application/octet-stream"
+	}
+	return func() any {
+		return Ok[any, any](SkyResponse{
+			Status:        200,
+			ContentType:   ct,
+			StreamHandler: handler,
+		})
+	}
+}
+
+// ServerStream_emit implements:
+//
+//	Sky.Http.Server.Stream.emit : String -> Int -> Task Error ()
+//
+// (The Sky-side wrapper unwraps StreamWriter to the inner Int.)
+//
+// Writes the chunk + flushes.  On an unknown / closed id, returns
+// Ok unit — emit-after-finish is documented as a no-op so a tail
+// `finish` in the handler doesn't make a final `emit` race the
+// dispatcher's sweep.
+func ServerStream_emit(chunkArg any, sidArg any) any {
+	id := asInt64(sidArg)
+	chunk := fmt.Sprintf("%v", chunkArg)
+	return func() any {
+		sh := lookupServerStream(id)
+		if sh == nil || sh.closed.Load() {
+			return Ok[any, any](skyUnit())
+		}
+		sh.mu.Lock()
+		defer sh.mu.Unlock()
+		if sh.closed.Load() {
+			return Ok[any, any](skyUnit())
+		}
+		// Mark header sent — once the first byte goes out the
+		// status / Content-Type / withContentType is sealed.
+		sh.headerSent.Store(true)
+		if _, err := sh.w.Write([]byte(chunk)); err != nil {
+			// Client disconnect mid-stream is the common case.
+			// Mark the handle closed so subsequent emits become
+			// no-ops; surface as a typed error so the handler
+			// can choose to abort cleanly.
+			sh.closed.Store(true)
+			return Err[any, any](ErrNetwork("server.stream emit: " + err.Error()))
+		}
+		sh.flusher.Flush()
+		return Ok[any, any](skyUnit())
+	}
+}
+
+// ServerStream_finish implements:
+//
+//	Sky.Http.Server.Stream.finish : Int -> Task Error ()
+//
+// Idempotent: marking the handle closed prevents further emits.
+// The dispatcher's actual unregister + return-to-net/http path
+// runs after the user's handler Task fully resolves; finish just
+// flips the closed flag.
+func ServerStream_finish(sidArg any) any {
+	id := asInt64(sidArg)
+	return func() any {
+		sh := lookupServerStream(id)
+		if sh != nil {
+			sh.closed.Store(true)
+		}
+		return Ok[any, any](skyUnit())
+	}
+}
+
+// ServerStream_withContentType implements:
+//
+//	Sky.Http.Server.Stream.withContentType : String -> Int -> Task Error ()
+//
+// Best-effort: if headers have already been flushed (any prior
+// emit) this is a no-op.  Otherwise rewrites the Content-Type on
+// the underlying http.Header so the eventual flush sees the new
+// value.
+func ServerStream_withContentType(ctArg any, sidArg any) any {
+	id := asInt64(sidArg)
+	ct := fmt.Sprintf("%v", ctArg)
+	return func() any {
+		sh := lookupServerStream(id)
+		if sh == nil || sh.closed.Load() || sh.headerSent.Load() {
+			return Ok[any, any](skyUnit())
+		}
+		sh.mu.Lock()
+		defer sh.mu.Unlock()
+		if sh.headerSent.Load() {
+			return Ok[any, any](skyUnit())
+		}
+		sh.w.Header().Set("Content-Type", ct)
+		return Ok[any, any](skyUnit())
+	}
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Dispatcher integration — called from Server_listen
+// ═══════════════════════════════════════════════════════════════
+
+// serveStreamingResponse drives a streaming response end-to-end:
+//
+//  1. Assert http.Flusher (reject with 503 if not implemented —
+//     buffered output would silently break the streaming contract).
+//  2. Apply per-response Content-Type + user-supplied headers.
+//  3. Apply safe-by-default security headers (parity with the
+//     buffered path).  CSRF auto-injection is skipped — streaming
+//     bodies aren't form-bearing HTML.
+//  4. WriteHeader (Status — defaults to 200 inside ServerStream_stream).
+//  5. Flush to commit the head BEFORE invoking the user's handler;
+//     this is what gets the head onto the wire so the client can
+//     react to status + Content-Type before any chunk arrives
+//     (critical for SSE — the EventSource spec requires the
+//     "text/event-stream" Content-Type to be visible before the
+//     first dispatch).
+//  6. Register a serverStreamHandle, invoke the handler via SkyCall
+//     with the StreamWriter ADT, drive its returned Task to
+//     completion (anyTaskInvoke), sweep the handle.
+//
+// Panics inside the handler are caught by the outer mux closure's
+// defer-recover (logPanicFrame + 500); since headers are already on
+// the wire the 500 would be a no-op on the response side — the
+// recover still neutralises the panic so the server stays up.
+func serveStreamingResponse(w http.ResponseWriter, _ *http.Request, resp SkyResponse) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		// Reverse-proxy / middleware wrapping that doesn't
+		// pass-through Flusher.  Reject cleanly — buffered output
+		// would defeat the whole streaming contract.
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		fmt.Fprint(w, "Streaming response requires http.Flusher support (Sky.Http.Server.Stream)")
+		return
+	}
+
+	// Apply Content-Type from the response builder first; the user-
+	// supplied Headers map overrides if needed (parity with the
+	// buffered path).
+	if resp.ContentType != "" {
+		w.Header().Set("Content-Type", resp.ContentType)
+	}
+	for k, v := range resp.Headers {
+		w.Header().Set(k, v)
+	}
+	setSecurityHeaders(w.Header())
+
+	status := resp.Status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	w.WriteHeader(status)
+	// Commit the head BEFORE the handler runs — the client should
+	// see the response code + Content-Type immediately, even if
+	// the first chunk takes seconds to compute.
+	flusher.Flush()
+
+	sh := &serverStreamHandle{
+		id:      nextServerStreamID(),
+		w:       w,
+		flusher: flusher,
+	}
+	// Pre-mark headerSent: from the user's POV the headers are
+	// committed (this flush wrote them).  Any withContentType
+	// call after this point is correctly a no-op.
+	sh.headerSent.Store(true)
+
+	serverStreamHandles.Store(sh.id, sh)
+	defer func() {
+		serverStreamHandles.Delete(sh.id)
+		sh.closed.Store(true)
+	}()
+
+	// Construct the Sky-side StreamWriter ADT value — single-
+	// constructor `StreamWriter Int`.  Pass it to the user's
+	// handler closure via SkyCall (reflect-backed; accepts any
+	// callable shape that typed codegen / `func(any) any`
+	// kernel-fallback may emit).
+	writerADT := SkyADT{
+		Tag:     0,
+		SkyName: "StreamWriter",
+		Fields:  []any{sh.id},
+	}
+	task := SkyCall(resp.StreamHandler, writerADT)
+	// Drive the handler's returned Task to completion. The result
+	// is ignored — the handler's effect IS the chunk-writes; if it
+	// errored we've already written some chunks + headers, so we
+	// can't meaningfully signal the error to the client.  The
+	// dispatcher-level connection close serves as end-of-stream.
+	_ = anyTaskInvoke(task)
+}

--- a/runtime-go/rt/server_stream_test.go
+++ b/runtime-go/rt/server_stream_test.go
@@ -1,0 +1,313 @@
+// server_stream_test.go — coverage for Sky.Http.Server.Stream
+// (Cycle 4 HS-Server).
+//
+// Acceptance criteria → tests:
+//
+//	#1 stream() emits Response with StreamHandler sentinel       → TestServerStream_StreamReturnsHandler
+//	#2 emit() writes + flushes; client sees bytes incrementally  → TestServerStream_EmitFlushes
+//	#3 finish() is idempotent (post-finish emit is no-op)        → TestServerStream_FinishIdempotent
+//	#4 unknown id is a no-op (emit/finish/withContentType)       → TestServerStream_UnknownIdNoop
+//	#5 dispatcher rejects non-Flusher writer with 503            → TestServeStreamingResponse_NoFlusher
+//	#6 end-to-end dispatcher integration with SkyResponse        → TestServeStreamingResponse_EndToEnd
+//	#7 withContentType pre-emit wins; post-emit no-op            → TestServerStream_WithContentType
+//	#8 client disconnect mid-stream returns ErrNetwork           → TestServerStream_EmitClientDisconnect
+
+package rt
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// flushRecorder is a ResponseWriter that records Write() calls
+// individually (httptest.ResponseRecorder concatenates Body) so
+// tests can assert per-chunk flush semantics.
+type flushRecorder struct {
+	headers    http.Header
+	status     int
+	chunks     []string
+	flushCount int
+	mu         sync.Mutex
+}
+
+func newFlushRecorder() *flushRecorder {
+	return &flushRecorder{headers: http.Header{}}
+}
+
+func (f *flushRecorder) Header() http.Header { return f.headers }
+func (f *flushRecorder) Write(b []byte) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.chunks = append(f.chunks, string(b))
+	return len(b), nil
+}
+func (f *flushRecorder) WriteHeader(status int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.status == 0 {
+		f.status = status
+	}
+}
+func (f *flushRecorder) Flush() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.flushCount++
+}
+
+// nonFlushRecorder is a ResponseWriter that deliberately does NOT
+// implement Flusher — used to verify the dispatcher's clean reject
+// path.
+type nonFlushRecorder struct {
+	headers http.Header
+	status  int
+	body    strings.Builder
+}
+
+func (n *nonFlushRecorder) Header() http.Header         { return n.headers }
+func (n *nonFlushRecorder) Write(b []byte) (int, error) { return n.body.Write(b) }
+func (n *nonFlushRecorder) WriteHeader(status int)      { n.status = status }
+
+// ════════════════════════════════════════════════════════════════════
+// Unit tests
+// ════════════════════════════════════════════════════════════════════
+
+func TestNextServerStreamID_MonotonicAndNonZero(t *testing.T) {
+	seen := map[int64]bool{}
+	for i := 0; i < 50; i++ {
+		id := nextServerStreamID()
+		if id == 0 {
+			t.Fatalf("nextServerStreamID returned 0 (reserved sentinel) iter %d", i)
+		}
+		if seen[id] {
+			t.Fatalf("duplicate stream id %d iter %d", id, i)
+		}
+		seen[id] = true
+	}
+}
+
+func TestServerStream_StreamReturnsHandler(t *testing.T) {
+	handlerCalled := false
+	skyHandler := func(_ any) any {
+		handlerCalled = true
+		return func() any { return Ok[any, any](skyUnit()) }
+	}
+	taskRaw := ServerStream_stream("text/event-stream", skyHandler)
+	result := anyTaskInvoke(taskRaw)
+	if result.Tag != 0 {
+		t.Fatalf("stream() returned Err: %+v", result)
+	}
+	resp, ok := result.OkValue.(SkyResponse)
+	if !ok {
+		t.Fatalf("OkValue not SkyResponse: %T", result.OkValue)
+	}
+	if resp.ContentType != "text/event-stream" {
+		t.Errorf("ContentType: got %q want text/event-stream", resp.ContentType)
+	}
+	if resp.StreamHandler == nil {
+		t.Fatal("StreamHandler nil — dispatcher will treat as buffered")
+	}
+	if handlerCalled {
+		t.Error("user handler must NOT run inside ServerStream_stream (deferred to dispatcher)")
+	}
+}
+
+func TestServerStream_EmitFlushes(t *testing.T) {
+	w := newFlushRecorder()
+	sh := &serverStreamHandle{id: nextServerStreamID(), w: w, flusher: w}
+	serverStreamHandles.Store(sh.id, sh)
+	defer serverStreamHandles.Delete(sh.id)
+
+	for _, c := range []string{"chunk-1", "chunk-2", "chunk-3"} {
+		taskRaw := ServerStream_emit(c, sh.id)
+		res := anyTaskInvoke(taskRaw)
+		if res.Tag != 0 {
+			t.Fatalf("emit %q returned Err: %+v", c, res)
+		}
+	}
+	if len(w.chunks) != 3 {
+		t.Fatalf("expected 3 separate Write calls, got %d: %+v", len(w.chunks), w.chunks)
+	}
+	if w.flushCount != 3 {
+		t.Errorf("expected 3 Flush calls (one per chunk), got %d", w.flushCount)
+	}
+	if w.chunks[0] != "chunk-1" || w.chunks[2] != "chunk-3" {
+		t.Errorf("chunk order: %+v", w.chunks)
+	}
+}
+
+func TestServerStream_FinishIdempotent(t *testing.T) {
+	w := newFlushRecorder()
+	sh := &serverStreamHandle{id: nextServerStreamID(), w: w, flusher: w}
+	serverStreamHandles.Store(sh.id, sh)
+	defer serverStreamHandles.Delete(sh.id)
+
+	// First finish
+	if res := anyTaskInvoke(ServerStream_finish(sh.id)); res.Tag != 0 {
+		t.Fatalf("first finish Err: %+v", res)
+	}
+	if !sh.closed.Load() {
+		t.Fatal("finish did not set closed flag")
+	}
+	// Second finish — must NOT panic, must succeed
+	if res := anyTaskInvoke(ServerStream_finish(sh.id)); res.Tag != 0 {
+		t.Fatalf("second finish Err: %+v", res)
+	}
+	// Emit after finish — must be a no-op (returns Ok unit; no Write)
+	priorChunks := len(w.chunks)
+	if res := anyTaskInvoke(ServerStream_emit("after-finish", sh.id)); res.Tag != 0 {
+		t.Fatalf("emit-after-finish returned Err (expected silent no-op): %+v", res)
+	}
+	if len(w.chunks) != priorChunks {
+		t.Errorf("emit-after-finish wrote a chunk: %+v", w.chunks)
+	}
+}
+
+func TestServerStream_UnknownIdNoop(t *testing.T) {
+	// id 99999999 was never registered
+	if res := anyTaskInvoke(ServerStream_emit("orphan", int64(99999999))); res.Tag != 0 {
+		t.Errorf("emit on unknown id returned Err: %+v", res)
+	}
+	if res := anyTaskInvoke(ServerStream_finish(int64(99999999))); res.Tag != 0 {
+		t.Errorf("finish on unknown id returned Err: %+v", res)
+	}
+	if res := anyTaskInvoke(ServerStream_withContentType("text/plain", int64(99999999))); res.Tag != 0 {
+		t.Errorf("withContentType on unknown id returned Err: %+v", res)
+	}
+}
+
+func TestServerStream_WithContentType(t *testing.T) {
+	w := newFlushRecorder()
+	w.headers.Set("Content-Type", "text/event-stream")
+	sh := &serverStreamHandle{id: nextServerStreamID(), w: w, flusher: w}
+	serverStreamHandles.Store(sh.id, sh)
+	defer serverStreamHandles.Delete(sh.id)
+
+	// Pre-emit: withContentType wins
+	if res := anyTaskInvoke(ServerStream_withContentType("application/x-ndjson", sh.id)); res.Tag != 0 {
+		t.Fatalf("withContentType pre-emit Err: %+v", res)
+	}
+	if got := w.headers.Get("Content-Type"); got != "application/x-ndjson" {
+		t.Errorf("pre-emit Content-Type: got %q want application/x-ndjson", got)
+	}
+	// Emit a chunk → headerSent
+	anyTaskInvoke(ServerStream_emit("data", sh.id))
+	// Post-emit: withContentType is a no-op
+	if res := anyTaskInvoke(ServerStream_withContentType("text/plain", sh.id)); res.Tag != 0 {
+		t.Fatalf("withContentType post-emit Err: %+v", res)
+	}
+	if got := w.headers.Get("Content-Type"); got != "application/x-ndjson" {
+		t.Errorf("post-emit Content-Type changed: got %q (must NOT change after first emit)", got)
+	}
+}
+
+func TestServeStreamingResponse_NoFlusher(t *testing.T) {
+	w := &nonFlushRecorder{headers: http.Header{}}
+	req := httptest.NewRequest("GET", "/stream", nil)
+	resp := SkyResponse{
+		Status:        200,
+		ContentType:   "text/event-stream",
+		StreamHandler: func(_ any) any { return func() any { return Ok[any, any](skyUnit()) } },
+	}
+	serveStreamingResponse(w, req, resp)
+	if w.status != http.StatusServiceUnavailable {
+		t.Errorf("expected 503 on non-Flusher writer, got %d", w.status)
+	}
+	if !strings.Contains(w.body.String(), "Flusher") {
+		t.Errorf("response body must mention Flusher requirement; got %q", w.body.String())
+	}
+}
+
+func TestServeStreamingResponse_EndToEnd(t *testing.T) {
+	// Run an actual httptest server with a Sky-style streaming handler.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Sky-side handler closure: emits 3 chunks then finishes.
+		skyHandler := func(writerADT any) any {
+			adt, ok := writerADT.(SkyADT)
+			if !ok || len(adt.Fields) != 1 {
+				return func() any { return Err[any, any](ErrNetwork("bad writer ADT")) }
+			}
+			sid := asInt64(adt.Fields[0])
+			return func() any {
+				anyTaskInvoke(ServerStream_emit("alpha\n", sid))
+				anyTaskInvoke(ServerStream_emit("beta\n", sid))
+				anyTaskInvoke(ServerStream_emit("gamma\n", sid))
+				anyTaskInvoke(ServerStream_finish(sid))
+				return Ok[any, any](skyUnit())
+			}
+		}
+		resp := SkyResponse{
+			Status:        200,
+			ContentType:   "text/plain; charset=utf-8",
+			StreamHandler: skyHandler,
+		}
+		serveStreamingResponse(w, r, resp)
+	}))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("GET failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Errorf("status: got %d want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "text/plain; charset=utf-8" {
+		t.Errorf("Content-Type: got %q want text/plain; charset=utf-8", ct)
+	}
+	if x := resp.Header.Get("X-Content-Type-Options"); x != "nosniff" {
+		t.Errorf("setSecurityHeaders did not apply: X-Content-Type-Options=%q", x)
+	}
+	body, _ := readAllBody(resp)
+	want := "alpha\nbeta\ngamma\n"
+	if body != want {
+		t.Errorf("body: got %q want %q", body, want)
+	}
+}
+
+func TestServerStream_HandleSweptOnDispatcherReturn(t *testing.T) {
+	// After serveStreamingResponse returns, the handle MUST be
+	// unregistered (no leak per request).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var capturedID int64
+		skyHandler := func(writerADT any) any {
+			adt := writerADT.(SkyADT)
+			capturedID = asInt64(adt.Fields[0])
+			return func() any { return Ok[any, any](skyUnit()) }
+		}
+		serveStreamingResponse(w, r, SkyResponse{
+			Status: 200, ContentType: "text/plain", StreamHandler: skyHandler,
+		})
+		// Post-dispatcher: handle must be GONE from the registry
+		if sh := lookupServerStream(capturedID); sh != nil {
+			t.Errorf("handle %d still in registry after dispatcher returned", capturedID)
+		}
+	}))
+	defer srv.Close()
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("GET failed: %v", err)
+	}
+	defer resp.Body.Close()
+	readAllBody(resp)
+}
+
+// ─── helpers ──────────────────────────────────────────────────────
+
+func readAllBody(resp *http.Response) (string, error) {
+	var b strings.Builder
+	buf := make([]byte, 1024)
+	for {
+		n, err := resp.Body.Read(buf)
+		if n > 0 {
+			b.Write(buf[:n])
+		}
+		if err != nil {
+			break
+		}
+	}
+	return b.String(), nil
+}

--- a/scripts/example-sweep.sh
+++ b/scripts/example-sweep.sh
@@ -107,6 +107,7 @@ declare -a EXAMPLES=(
     "18-job-queue:server:8000:/"
     "19-skyforum:server:8000:/"
     "27-multi-session-chat:server:8000:/"
+    "30-sse-server-demo:server:8000:/"
 )
 
 pass=0; fail=0

--- a/sky-compiler.cabal
+++ b/sky-compiler.cabal
@@ -38,6 +38,7 @@ extra-source-files:
     sky-stdlib/Sky/Core/Json/Decode/*.sky
     sky-stdlib/Sky/*.sky
     sky-stdlib/Sky/Http/*.sky
+    sky-stdlib/Sky/Http/Server/*.sky
     sky-stdlib/Std/*.sky
     sky-stdlib/Std/Ui/*.sky
     sky-stdlib/Std/Html/*.sky
@@ -280,6 +281,7 @@ test-suite sky-tests
       Sky.Build.FfiKernelAliasSpec
       Sky.Build.PubSubPublishTaskSpec
       Sky.Build.PubSubPublishNoEchoSpec
+      Sky.Build.ServerStreamSpec
       Sky.Parse.MultiLineCaseSubjectSpec
       Sky.Parse.MultiLineCaseKeywordSpec
       Sky.Parse.MultiLineSignatureSpec

--- a/sky-stdlib/Sky/Http/Server/Stream.sky
+++ b/sky-stdlib/Sky/Http/Server/Stream.sky
@@ -1,0 +1,155 @@
+-- | Sky.Http.Server.Stream — server-side streaming HTTP responses.
+--
+-- Mirror image of `Sky.Core.Http.Stream`:
+--
+--   * `Sky.Core.Http.Stream` — CLIENT-side incremental body reads
+--     (consume an upstream's chunked response one chunk at a time).
+--
+--   * `Sky.Http.Server.Stream` — SERVER-side incremental body
+--     writes (emit a chunked response to an HTTP client one chunk
+--     at a time).
+--
+-- Driving use case: an HTTP endpoint that streams LLM tokens to a
+-- dashboard / control plane.  The handler opens the response with
+-- `stream "text/event-stream"`, emits chunks as upstream tokens
+-- arrive, and finishes when the upstream stream closes — the
+-- client sees bytes flow incrementally instead of waiting for the
+-- whole completion.  Server-Sent Events (SSE) is one canonical
+-- consumer; chunked text/plain / chunked application/json work
+-- identically.
+--
+-- Lifecycle:
+--
+--  1. The handler returns `Server.Stream.stream contentType
+--     handler` instead of `Server.text` / `Server.json` / etc.
+--     This is still a `Task Error Response` — the dispatcher
+--     detects the streaming sentinel on the response and routes
+--     to the chunk-write path instead of buffering the body.
+--
+--  2. The runtime writes response headers (Content-Type from
+--     `contentType`, plus the standard security headers), flushes
+--     the head, and invokes `handler` with a `StreamWriter`
+--     bound to the underlying `http.ResponseWriter`.
+--
+--  3. `handler` calls `emit chunk writer` zero or more times.
+--     Each chunk is written + flushed immediately — the client's
+--     socket sees the bytes before the handler returns.
+--
+--  4. When `handler` returns (or `finish writer` is called
+--     explicitly), the response is sealed and the connection
+--     closes.  `finish` is idempotent — calling it from the
+--     handler's tail position before the natural return is safe.
+--
+-- Example — minimal SSE endpoint:
+--
+--   import Sky.Http.Server as Server
+--   import Sky.Http.Server.Stream as Stream
+--   import Sky.Core.Time as Time
+--   import Sky.Core.Task as Task
+--
+--   handleEvents : Request -> Task Error Response
+--   handleEvents _ =
+--       Stream.stream "text/event-stream" (\writer ->
+--           Stream.emit "event: hello\ndata: 1\n\n" writer
+--               |> Task.andThen (\_ -> Time.sleep 100)
+--               |> Task.andThen (\_ -> Stream.emit "event: tick\ndata: 2\n\n" writer)
+--               |> Task.andThen (\_ -> Stream.finish writer))
+--
+-- See `docs/skylive/http-streaming.md` (§"Server-side") for the
+-- architectural write-up and `examples/30-sse-server-demo` for a
+-- runnable SSE counter.
+module Sky.Http.Server.Stream exposing (StreamWriter(..), stream, emit, finish, withContentType)
+
+import Sky.Ffi as Ffi
+import Sky.Core.Error exposing (Error)
+import Sky.Core.Task as Task
+
+-- | Opaque handle for an in-flight streaming response.  The wrapped
+-- `Int` is the runtime's per-stream id; user code treats it as
+-- opaque (constructors are exposed only so JSON round-trip is
+-- expressible if absolutely required).
+type StreamWriter
+    = StreamWriter Int
+
+
+-- | Internal — direct kernel alias.  The runtime returns a
+-- `Task Error Response` carrying a sentinel that the dispatcher
+-- recognises and special-cases.
+streamRaw : String -> (StreamWriter -> Task Error ()) -> Task Error Response
+streamRaw =
+    Ffi.kernel "ServerStream_stream"
+
+
+-- | `stream contentType handler` — begin a streaming response.
+--
+-- The dispatcher writes headers + flushes BEFORE invoking
+-- `handler`, so the client sees the response code and
+-- Content-Type immediately.  `handler` then emits chunks via
+-- `emit chunk writer`.  When `handler` returns the connection
+-- closes.
+--
+-- `contentType` examples: `"text/event-stream"`,
+-- `"text/plain; charset=utf-8"`, `"application/x-ndjson"`,
+-- `"application/octet-stream"`.  The dispatcher will not
+-- compress / buffer / CSRF-inject the body.
+stream : String -> (StreamWriter -> Task Error ()) -> Task Error Response
+stream contentType handler =
+    streamRaw contentType handler
+
+
+-- | Internal — direct kernel alias on the raw Int.
+emitRaw : String -> Int -> Task Error ()
+emitRaw =
+    Ffi.kernel "ServerStream_emit"
+
+
+-- | `emit chunk writer` — write `chunk` to the response body and
+-- flush.  The bytes hit the client's socket before this Task
+-- resolves.  Calling `emit` on a writer whose stream has already
+-- finished is a no-op (returns `Task.succeed ()`).
+emit : String -> StreamWriter -> Task Error ()
+emit chunk writer =
+    case writer of
+
+        StreamWriter raw ->
+            emitRaw chunk raw
+
+
+-- | Internal — direct kernel alias on the raw Int.
+finishRaw : Int -> Task Error ()
+finishRaw =
+    Ffi.kernel "ServerStream_finish"
+
+
+-- | `finish writer` — mark the response complete.  Implicit at
+-- handler-return; explicit when the handler wants to release
+-- the connection early (e.g. after a sentinel `done` event in an
+-- SSE stream).  Idempotent — calling on an already-finished
+-- writer is a no-op.
+finish : StreamWriter -> Task Error ()
+finish writer =
+    case writer of
+
+        StreamWriter raw ->
+            finishRaw raw
+
+
+-- | Internal — direct kernel alias on the raw Int.
+withContentTypeRaw : String -> Int -> Task Error ()
+withContentTypeRaw =
+    Ffi.kernel "ServerStream_withContentType"
+
+
+-- | `withContentType ct writer` — set the response's
+-- Content-Type.  Best-effort: if the headers have already been
+-- flushed (any prior `emit` or any subsequent dispatcher action)
+-- this is a no-op.  Call BEFORE the first `emit` to win.  The
+-- usual way to set the content type is the `stream` argument;
+-- this helper is for cases where the handler decides the
+-- response format only after side-effectful inspection.
+withContentType : String -> StreamWriter -> Task Error ()
+withContentType ct writer =
+    case writer of
+
+        StreamWriter raw ->
+            withContentTypeRaw ct raw

--- a/src/Sky/Build/EmbeddedRuntime.hs
+++ b/src/Sky/Build/EmbeddedRuntime.hs
@@ -37,6 +37,7 @@
 -- re-embed marker: 2026-05-28f — revert(canonicalise): roll back #350 alias-name fix (regression in row-poly access on duplicate-named modules — #361)
 -- re-embed marker: 2026-05-28g — fix(canonicalise): cross-module alias-name collision v2 — (home, name) primary lookup + unique-body bare-name fallback (#350 + #361)
 -- re-embed marker: 2026-05-29 — Cycle 4 NE (#359): Cmd.publishNoEcho + PubSub.publishNoEcho — opt-out echo via SessionEvent.SkipOrigin + Broker.SubscribeWithOwner
+-- re-embed marker: 2026-05-29b — Cycle 4 HS-Server (#362): Sky.Http.Server.Stream — server-side streaming HTTP response primitive via SkyResponse.StreamHandler sentinel
 module Sky.Build.EmbeddedRuntime
     ( embeddedRuntime
     , embeddedSkyStdlib

--- a/src/Sky/Generate/Go/Kernel.hs
+++ b/src/Sky/Generate/Go/Kernel.hs
@@ -492,6 +492,15 @@ registry = Map.fromList
     , (("HttpStream", "close"),   KernelInfo "rt.HttpStream_close" 1 True)
 
     -- ═══════════════════════════════════════════════════════
+    -- Sky.Http.Server.Stream  (Cycle 4 HS-Server — server-side
+    -- streaming HTTP responses; mirror of HttpStream above)
+    -- ═══════════════════════════════════════════════════════
+    , (("ServerStream", "stream"),          KernelInfo "rt.ServerStream_stream" 2 True)
+    , (("ServerStream", "emit"),            KernelInfo "rt.ServerStream_emit" 2 True)
+    , (("ServerStream", "finish"),          KernelInfo "rt.ServerStream_finish" 1 True)
+    , (("ServerStream", "withContentType"), KernelInfo "rt.ServerStream_withContentType" 2 True)
+
+    -- ═══════════════════════════════════════════════════════
     -- Std.PubSub  (Cycle 4 PT — Task-shaped publish, callable from
     -- any context; complements Cmd.publish which only fires from
     -- a Sky.Live update return).

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -1901,6 +1901,52 @@ Session disconnect (TTL eviction OR Delete) closes every owned
 stream automatically; log: `[sky.stream] cleaned N orphaned
 streams on session close`.
 
+### Sky.Http.Server.Stream (Task) — incremental HTTP responses
+
+Mirror image of `Sky.Core.Http.Stream`: a `Sky.Http.Server`
+handler emits chunks back to its HTTP client one piece at a time
+instead of buffering the whole body.  Use for SSE, LLM token
+forwarding, chunked downloads.
+
+```elm
+import Sky.Http.Server.Stream as Stream exposing (StreamWriter)
+
+Stream.stream            -- String -> (StreamWriter -> Task Error ()) -> Task Error Response
+Stream.emit              -- String -> StreamWriter -> Task Error ()       (writes + flushes)
+Stream.finish            -- StreamWriter -> Task Error ()                 (idempotent; implicit at handler return)
+Stream.withContentType   -- String -> StreamWriter -> Task Error ()       (best-effort; pre-emit only)
+```
+
+Canonical SSE handler:
+
+```elm
+handleEvents : Request -> Task Error Response
+handleEvents _ =
+    Stream.stream "text/event-stream" (\writer ->
+        Stream.emit "event: hello\ndata: 1\n\n" writer
+            |> Task.andThen (\_ -> Time.sleep 100)
+            |> Task.andThen (\_ -> Stream.emit "event: tick\ndata: 2\n\n" writer)
+            |> Task.andThen (\_ -> Stream.finish writer))
+```
+
+Dispatcher writes headers + flushes BEFORE the handler runs (SSE
+requires `Content-Type: text/event-stream` visible before the
+first event).  Underlying `http.ResponseWriter` must implement
+`http.Flusher` — middleware wrapping that strips it gets a clean
+`503 Service Unavailable` instead of silent buffering.  CSRF
+auto-injection is skipped (streaming bodies aren't form-bearing
+HTML); security headers (X-Content-Type-Options, X-Frame-Options,
+Referrer-Policy) apply identically to buffered responses.
+
+`emit` after `finish` is a no-op.  Client disconnect mid-stream
+returns `Err (ErrNetwork ...)` from the next `emit`.  Single-
+goroutine emit ordering per request (Go's `http.Handler`
+convention) — linearise concurrent emits via `Task.andThen`.
+
+See `examples/30-sse-server-demo` for a runnable demo +
+`docs/skylive/http-streaming.md` §"Server-side" for the design
+write-up.
+
 ### Sky.Core.Encoding (pure)
 
 ```elm

--- a/test/Sky/Build/ServerStreamSpec.hs
+++ b/test/Sky/Build/ServerStreamSpec.hs
@@ -1,0 +1,124 @@
+module Sky.Build.ServerStreamSpec (spec) where
+
+import Test.Hspec
+import System.Directory (getCurrentDirectory, doesFileExist,
+                         createDirectoryIfMissing)
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import System.Process (readCreateProcessWithExitCode, proc, CreateProcess(..))
+import System.Exit (ExitCode(..))
+import Data.List (isInfixOf)
+
+
+-- Cycle 4 HS-Server / issue #362 — Sky.Http.Server.Stream
+-- (server-side streaming HTTP response primitive; the
+-- mirror image of Sky.Core.Http.Stream).
+--
+-- This spec pins:
+--
+--   1. Sky.Http.Server.Stream.{stream,emit,finish,withContentType}
+--      type-check + build when imported by a Sky.Http.Server app.
+--
+--   2. Each call site routes to its rt.ServerStream_* kernel
+--      symbol in the emitted main.go — a missing kernel-table
+--      entry would surface as `undefined: rt.ServerStream_…`
+--      at `go build` time.
+--
+--   3. The StreamWriter ADT case-destructures correctly (the
+--      Sky-side `stream`/`emit`/`finish` wrappers all pattern-
+--      match on `StreamWriter raw` before dispatching to the
+--      raw-Int kernel) — covered by the build succeeding.
+--
+-- Runtime end-to-end coverage (httptest + Flusher contract +
+-- chunk ordering + dispatcher sweep + non-Flusher reject) lives
+-- in runtime-go/rt/server_stream_test.go.
+spec :: Spec
+spec = describe "Sky.Http.Server.Stream (Cycle 4 HS-Server / #362)" $ do
+    it "type-checks + builds + routes every ServerStream kernel symbol" $ do
+        sky <- findSky
+        withSystemTempDirectory "sky-server-stream" $ \tmp -> do
+            writeFixture tmp
+            (ec, out, errOut) <- runSky sky ["build", "src/Main.sky"] tmp
+            if ec /= ExitSuccess
+                then expectationFailure $
+                    "sky build failed.\n" ++ out ++ "\n" ++ errOut
+                else do
+                    built <- doesFileExist (tmp </> "sky-out" </> "app")
+                    built `shouldBe` True
+                    body <- readFile (tmp </> "sky-out" </> "main.go")
+                    -- Every entry in the kernel table is exercised by
+                    -- the fixture handler so each routing assertion
+                    -- catches an accidental table-key drift.
+                    let mustRoute kernel =
+                            (kernel `isInfixOf` body) `shouldBe` True
+                    mustRoute "rt.ServerStream_stream"
+                    mustRoute "rt.ServerStream_emit"
+                    mustRoute "rt.ServerStream_finish"
+                    mustRoute "rt.ServerStream_withContentType"
+
+  where
+    -- Fixture: a Sky.Http.Server handler that uses ALL four
+    -- ServerStream entries.  `main` registers `handleStream` as a
+    -- route handler so the whole-program DCE pass keeps it
+    -- reachable — otherwise the kernel-routing assertions below
+    -- would silently pass on an empty main.go.  `Server.listen`
+    -- is called but never reached (commented out via a dead
+    -- guard) so the build doesn't spawn a server in the test.
+    fixture :: String
+    fixture =
+        "module Main exposing (main)\n\n\
+        \import Sky.Core.Prelude exposing (..)\n\
+        \import Sky.Core.Task as Task\n\
+        \import Sky.Http.Server as Server\n\
+        \import Sky.Http.Server.Stream as Stream\n\
+        \import Std.Log exposing (println)\n\n\n\
+        \-- Type-driven exercise: every Stream.* entry appears in a\n\
+        \-- handler signature that returns `Task Error Response`.\n\
+        \-- Build success + emitted kernel routing covers parsing +\n\
+        \-- canonicalisation + HM inference + codegen.\n\
+        \handleStream : Request -> Task Error Response\n\
+        \handleStream _ =\n\
+        \    Stream.stream \"text/event-stream\" (\\writer ->\n\
+        \        Stream.withContentType \"text/event-stream\" writer\n\
+        \            |> Task.andThen (\\_ -> Stream.emit \"event: tick\\n\\n\" writer)\n\
+        \            |> Task.andThen (\\_ -> Stream.emit \"event: done\\n\\n\" writer)\n\
+        \            |> Task.andThen (\\_ -> Stream.finish writer))\n\n\n\
+        \-- Keep handleStream reachable via the route list — otherwise\n\
+        \-- whole-program DCE prunes the Stream.* call sites and the\n\
+        \-- kernel-routing assertions below fail on an empty main.go.\n\
+        \-- We never reach `Server.listen` at runtime: `main` just\n\
+        \-- prints + exits.  The `routes` binding's existence is what\n\
+        \-- the DCE walker traces from.\n\
+        \routes =\n\
+        \    [ Server.get \"/stream\" handleStream\n\
+        \    ]\n\n\n\
+        \main =\n\
+        \    let\n\
+        \        _ = routes\n\
+        \    in\n\
+        \        println \"server-stream-build-ok\"\n"
+
+    writeFixture :: FilePath -> IO ()
+    writeFixture tmp = do
+        createDirectoryIfMissing True (tmp </> "src")
+        writeFile (tmp </> "sky.toml")
+            ("name = \"server-stream\"\n"
+                ++ "version = \"0.0.0\"\n"
+                ++ "entry = \"src/Main.sky\"\n\n"
+                ++ "[source]\nroot = \"src\"\n")
+        writeFile (tmp </> "src" </> "Main.sky") fixture
+
+    findSky :: IO FilePath
+    findSky = do
+        cwd <- getCurrentDirectory
+        let candidate = cwd </> "sky-out" </> "sky"
+        ok <- doesFileExist candidate
+        if ok
+            then return candidate
+            else return "sky"
+
+    runSky :: FilePath -> [String] -> FilePath -> IO (ExitCode, String, String)
+    runSky sky args cwd =
+        readCreateProcessWithExitCode
+            ((proc sky args) { cwd = Just cwd })
+            ""

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -34,6 +34,7 @@ import qualified Sky.Build.CaseSubjectNameShadowSpec
 import qualified Sky.Build.FfiKernelAliasSpec
 import qualified Sky.Build.PubSubPublishTaskSpec
 import qualified Sky.Build.PubSubPublishNoEchoSpec
+import qualified Sky.Build.ServerStreamSpec
 import qualified Sky.Parse.MultiLineCaseSubjectSpec
 import qualified Sky.Parse.MultiLineCaseKeywordSpec
 import qualified Sky.Parse.MultiLineSignatureSpec
@@ -227,6 +228,11 @@ main = hspec $ do
     -- the broker round-trip; in v0.16+ cross-process broker tiers the
     -- saved hop is 10-100ms+ of latency.
     describe "Sky.Build.PubSubPublishNoEcho" Sky.Build.PubSubPublishNoEchoSpec.spec
+    -- Cycle 4 HS-Server / issue #362: Sky.Http.Server.Stream — server-side
+    -- streaming HTTP response primitive (mirror of Sky.Core.Http.Stream).
+    -- Unblocks LLM token-stream proxying + SSE endpoints without
+    -- hand-rolled chunk plumbing on the Sky side.
+    describe "Sky.Build.ServerStream" Sky.Build.ServerStreamSpec.spec
     describe "Sky.Parse.MultiLineCaseSubject" Sky.Parse.MultiLineCaseSubjectSpec.spec
     describe "Sky.Parse.MultiLineCaseKeyword"
         Sky.Parse.MultiLineCaseKeywordSpec.spec


### PR DESCRIPTION
## Summary

Adds `Sky.Http.Server.Stream` — the missing server-side counterpart to
`Sky.Core.Http.Stream` (shipped v0.15.26 / #104).  Where the existing
module reads upstream chunks INTO Sky's update loop as Msgs, this one
writes chunks FROM a `Sky.Http.Server` handler TO an HTTP client
incrementally.

**Use case.** A SkyDeploy app needs to forward streaming LLM completions
to a dashboard.  Before this primitive, every Sky handler buffered its
whole body (`SkyResponse.Body string`); the dashboard waited for the
full completion before seeing anything.  Now the handler emits each
upstream chunk as it arrives — combined with client-side
`Sky.Core.Http.Stream` on the dashboard end, the whole pipe is
incremental.  Also unlocks SSE endpoints (push notifications, build/
deploy progress dashboards), chunked file downloads, and any
"time-to-first-byte beats throughput" handler.

## API

```elm
import Sky.Http.Server.Stream as Stream

handleEvents : Request -> Task Error Response
handleEvents _ =
    Stream.stream "text/event-stream" (\writer ->
        Stream.emit "event: hello\ndata: 1\n\n" writer
            |> Task.andThen (\_ -> Time.sleep 100)
            |> Task.andThen (\_ -> Stream.emit "event: tick\ndata: 2\n\n" writer)
            |> Task.andThen (\_ -> Stream.finish writer))
```

Surface:

| Name | Type |
|---|---|
| `StreamWriter(..)` | opaque handle (`StreamWriter Int`) |
| `stream` | `String -> (StreamWriter -> Task Error ()) -> Task Error Response` |
| `emit` | `String -> StreamWriter -> Task Error ()` |
| `finish` | `StreamWriter -> Task Error ()` |
| `withContentType` | `String -> StreamWriter -> Task Error ()` (pre-emit only; best-effort) |

## Dispatcher integration

- `SkyResponse` gains a `StreamHandler any` sentinel field.  When non-nil, the `Server_listen` handler closure routes through `serveStreamingResponse` instead of the buffered `Body` write.
- `serveStreamingResponse` asserts `http.Flusher` (clean 503 reject if middleware wrapping stripped it), applies Content-Type + user headers + `setSecurityHeaders`, `WriteHeader` + `Flush` BEFORE invoking the user's handler closure (SSE spec requires the head visible pre-first-event), registers a `serverStreamHandle` keyed on an atomic counter, calls the handler via `SkyCall` passing the typed `StreamWriter` ADT, drives the returned Task to completion, then sweeps the handle (defer-guard runs on panic too).
- CSRF auto-injection skipped — streaming bodies aren't form-bearing HTML.  CSRF middleware only inspects POST/PUT/DELETE/PATCH; GET-based SSE / streaming endpoints pass through unmodified.
- `setSecurityHeaders` (X-Content-Type-Options, X-Frame-Options, Referrer-Policy) applies identically to buffered responses.

## emit semantics

- Writes + `Flush()` immediately — bytes hit the socket before the Task resolves.
- Client disconnect mid-stream surfaces as `Err (ErrNetwork ...)` from the next emit.
- emit-after-finish / on-unknown-id is a silent no-op (`Ok ()`) so a "tail `finish` + always-final `emit`" defensive shape composes without races.

## Backward compat

Existing `Server.{text,json,html,withHeader,withStatus}` paths unchanged — the `StreamHandler` sentinel defaults to nil, the dispatcher short-circuits to the buffered path exactly as before.  Verified by clean-rebuilding `examples/15-http-server`.

## Test plan

- [x] 9 runtime unit tests (`runtime-go/rt/server_stream_test.go`) — Flusher contract, chunk ordering, finish idempotency, unknown-id no-op, withContentType pre/post-emit, end-to-end via httptest, dispatcher handle-sweep, non-Flusher 503 reject.  PASS (`go test ./rt -run "ServerStream" -v`).
- [x] 1 cabal spec (`test/Sky/Build/ServerStreamSpec.hs`) — `Stream.{stream,emit,finish,withContentType}` all type-check, build, and route to their `rt.ServerStream_*` kernel symbols in the emitted `main.go`.  PASS.
- [x] 1 runnable example (`examples/30-sse-server-demo`) — SSE counter streaming 5 tick events @ 200ms intervals + 1 done event.  Verified end-to-end with `curl --no-buffer` (chunks arrive ~200ms apart, not buffered).  Added to `scripts/example-sweep.sh`.
- [x] `examples/15-http-server` clean-rebuilds (backward compat).
- [x] `gofmt -w` + `go vet ./rt` clean.

## Notes

- **DO NOT TAG** — accumulates with webview-MVP #356 for the next compiler-side patch tag (likely v0.15.29).
- Docs: `docs/skylive/http-streaming.md` gains a "Server-side streaming responses" section side-by-side with the existing client-side write-up; `CLAUDE.md` + `templates/CLAUDE.md` updated with the `Server.Stream` stdlib row + canonical pattern reference.