### PR TITLE
docs: add "--stdin" to fmt command config for zed editor

### DIFF
--- a/docs/tooling/lsp.md
+++ b/docs/tooling/lsp.md
@@ -113,7 +113,7 @@ curl --create-dirs --output-dir ~/.config/helix/runtime/queries/sky \
   "languages": {
     "Sky": {
       "language_servers": ["sky-lsp"],
-      "formatter": { "external": { "command": "sky", "arguments": ["fmt"] } }
+      "formatter": { "external": { "command": "sky", "arguments": ["fmt", "--stdin"] } }
     }
   },
   "lsp": {


### PR DESCRIPTION
Without the `--stdin` flag, the formatter replaces the entire file with "Formatted [file name]" when it runs.  With the flag, everything works as expected