### PR TITLE
fix(runtime): strip inline `# comment` suffix from .env values

### DIFF
--- a/runtime-go/rt/dotenv.go
+++ b/runtime-go/rt/dotenv.go
@@ -96,8 +96,7 @@ func loadDotEnvFile(path string, override bool) error {
 			continue
 		}
 		key := strings.TrimSpace(line[:eq])
-		val := strings.TrimSpace(line[eq+1:])
-		val = stripMatchingQuotes(val)
+		val := stripDotEnvValue(line[eq+1:])
 		if _, set := os.LookupEnv(key); set && !override {
 			continue
 		}
@@ -106,12 +105,61 @@ func loadDotEnvFile(path string, override bool) error {
 	return sc.Err()
 }
 
-func stripMatchingQuotes(s string) string {
-	if len(s) >= 2 {
-		first, last := s[0], s[len(s)-1]
-		if (first == '"' && last == '"') || (first == '\'' && last == '\'') {
-			return s[1 : len(s)-1]
+// stripDotEnvValue normalises a raw `KEY=…` RHS into its actual value,
+// matching godotenv / python-dotenv / Foreman semantics:
+//   * unquoted `value` — trim surrounding whitespace
+//   * unquoted `value  # comment` — strip the trailing comment when
+//     `#` is preceded by whitespace (so `tag#1` stays intact and only
+//     `tag #1` becomes `tag`)
+//   * quoted `"value"` / `'value'` — strip the matching outer quotes and
+//     preserve the inner content verbatim (a `#` inside quotes is part
+//     of the value)
+//
+// This is the canonical .env contract every other ecosystem honours; Sky
+// previously kept the trailing `# comment` as part of the value, which
+// silently broke any deploy whose `.env` had a trailing comment on a
+// load-bearing setting (real-world hit on sky-lang.org's OAuth callback,
+// 2026-06-02).
+func stripDotEnvValue(raw string) string {
+	// Drop only leading whitespace first so the quote check sees the
+	// real opening character. Trailing whitespace handled per-branch.
+	s := strings.TrimLeft(raw, " \t")
+	if s == "" {
+		return ""
+	}
+	if first := s[0]; first == '"' || first == '\'' {
+		// Quoted value — content runs to the matching closing quote;
+		// anything after it is treated as comment / ignored.
+		if end := strings.IndexByte(s[1:], first); end >= 0 {
+			return s[1 : 1+end]
+		}
+		// Unterminated quote — fall through and treat the whole thing
+		// as an unquoted value (the closing quote, if any, sits in
+		// trailing space and would be lost regardless).
+	}
+	// Leading `#` on an unquoted value means the whole RHS is a
+	// comment and the value is empty (matches godotenv / python-dotenv:
+	// `KEY=# stuff` → "" and `KEY= # stuff` → "" after the TrimLeft above).
+	if s[0] == '#' {
+		return ""
+	}
+	// Unquoted: strip a trailing ` # …` (or `\t#…`) comment. A `#`
+	// without preceding whitespace is part of the value (hash tags,
+	// fragment identifiers, comment markers inside URLs).
+	if i := indexInlineCommentStart(s); i >= 0 {
+		s = s[:i]
+	}
+	return strings.TrimRight(s, " \t")
+}
+
+// indexInlineCommentStart returns the byte index of the inline comment
+// `#` (preceded by ASCII whitespace) in an unquoted value, or -1 if
+// the value carries no inline comment.
+func indexInlineCommentStart(s string) int {
+	for i := 1; i < len(s); i++ {
+		if s[i] == '#' && (s[i-1] == ' ' || s[i-1] == '\t') {
+			return i
 		}
 	}
-	return s
+	return -1
 }

--- a/runtime-go/rt/dotenv_test.go
+++ b/runtime-go/rt/dotenv_test.go
@@ -1,0 +1,159 @@
+package rt
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestStripDotEnvValue covers the canonical .env semantics that
+// dotenv.go's loader must honour. The regression that motivated this
+// suite: sky-lang.org's .env had
+//
+//	SKYLANG_BASE_URL=https://sky-lang.org    # used for redirect_uri
+//
+// which Sky previously read as the full literal "https://sky-lang.org
+// (whitespace) # used for redirect_uri", silently breaking the OAuth
+// redirect_uri check at GitHub. Every other dotenv parser
+// (godotenv / python-dotenv / Foreman / dotenv-cli) strips the trailing
+// ` # comment` from an unquoted value.
+func TestStripDotEnvValue(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// Plain unquoted
+		{"plain", "value", "value"},
+		{"leading-ws", "  value", "value"},
+		{"trailing-ws", "value  ", "value"},
+		{"both-ws", "  value  ", "value"},
+		{"empty", "", ""},
+		{"only-ws", "   ", ""},
+
+		// Inline comments — STRIPPED when preceded by whitespace
+		{"comment-after-space", "value # comment", "value"},
+		{"comment-after-tab", "value\t# comment", "value"},
+		{"comment-many-spaces", "value     # boom", "value"},
+		{"comment-with-hash-inside", "value # has #2 inside", "value"},
+		{"comment-no-space-after-hash", "value #x", "value"},
+
+		// `#` WITHOUT preceding whitespace stays in the value
+		{"hash-tag", "tag#1", "tag#1"},
+		{"hash-fragment", "https://x.io/page#section", "https://x.io/page#section"},
+		{"hash-many", "a#b#c", "a#b#c"},
+
+		// Quoted values — strip outer quotes, preserve inner content
+		{"double-quoted", `"value"`, "value"},
+		{"single-quoted", `'value'`, "value"},
+		{"quoted-with-hash", `"value # not a comment"`, "value # not a comment"},
+		{"quoted-with-spaces", `"  spaced  "`, "  spaced  "},
+		{"single-quoted-hash", `'has#tag'`, "has#tag"},
+		{"quoted-then-junk-dropped", `"value" # trailing comment`, "value"},
+
+		// Edge cases
+		{"unterminated-double-quote", `"unterminated`, `"unterminated`},
+		{"unterminated-single-quote", `'unterminated`, `'unterminated`},
+		// Leading `#` (post-trim) means the whole RHS is a comment per
+		// godotenv / python-dotenv conventions.
+		{"only-hash", "#", ""},
+		{"hash-then-space", "# x", ""},
+		{"space-then-hash", " # comment", ""},
+		{"tab-then-hash", "\t# comment", ""},
+
+		// The real-world hit
+		{
+			"sky-lang.org-base-url",
+			"https://sky-lang.org    # used to construct OAuth redirect_uri",
+			"https://sky-lang.org",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := stripDotEnvValue(c.in)
+			if got != c.want {
+				t.Fatalf("stripDotEnvValue(%q) = %q; want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// TestLoadDotEnvFile_InlineComments end-to-end-loads a fixture .env
+// file and asserts the resulting os.Getenv values are comment-stripped.
+// This is the customer-visible contract — TestStripDotEnvValue covers
+// the helper in isolation; this covers the integration through
+// bufio.Scanner + os.Setenv.
+func TestLoadDotEnvFile_InlineComments(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".env")
+	body := `# leading comment line
+PLAIN=value
+WITH_COMMENT=hello # trailing comment
+WITH_TAB_COMMENT=tab-val	# tab before hash
+URL_WITH_FRAGMENT=https://x.io/page#section
+QUOTED="value # inside quotes"
+QUOTED_THEN_COMMENT="kept" # dropped
+EMPTY=
+COMMENT_ONLY_LINE=actual    # comment
+
+# blank line above
+`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Isolate side effects on the process env.
+	keys := []string{
+		"PLAIN", "WITH_COMMENT", "WITH_TAB_COMMENT",
+		"URL_WITH_FRAGMENT", "QUOTED", "QUOTED_THEN_COMMENT",
+		"EMPTY", "COMMENT_ONLY_LINE",
+	}
+	for _, k := range keys {
+		_ = os.Unsetenv(k)
+		t.Cleanup(func() { _ = os.Unsetenv(k) })
+	}
+
+	if err := loadDotEnvFile(path, false); err != nil {
+		t.Fatal(err)
+	}
+
+	want := map[string]string{
+		"PLAIN":               "value",
+		"WITH_COMMENT":        "hello",
+		"WITH_TAB_COMMENT":    "tab-val",
+		"URL_WITH_FRAGMENT":   "https://x.io/page#section",
+		"QUOTED":              "value # inside quotes",
+		"QUOTED_THEN_COMMENT": "kept",
+		"EMPTY":               "",
+		"COMMENT_ONLY_LINE":   "actual",
+	}
+	for k, w := range want {
+		got := os.Getenv(k)
+		if got != w {
+			t.Errorf("%s: got %q; want %q", k, got, w)
+		}
+	}
+}
+
+// TestLoadDotEnvFile_NoOverride confirms the 12-factor precedence:
+// values already set in the process env are NEVER overwritten by
+// the .env file when override=false.
+func TestLoadDotEnvFile_NoOverride(t *testing.T) {
+	const k = "SKY_TEST_NO_OVERRIDE_PRECEDENCE"
+	const shellValue = "from-shell"
+
+	t.Setenv(k, shellValue)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".env")
+	if err := os.WriteFile(path, []byte(k+"=from-dotenv\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := loadDotEnvFile(path, false); err != nil {
+		t.Fatal(err)
+	}
+	if got := os.Getenv(k); got != shellValue {
+		t.Fatalf("override leaked: got %q, want %q (process env should win)", got, shellValue)
+	}
+}


### PR DESCRIPTION
## What

Sky's dotenv loader (`runtime-go/rt/dotenv.go`) now strips godotenv-style
inline `# comment` suffixes from .env values.

## Why

Hit in production on `sky-lang.org`'s `.env.production`:

```
SKYLANG_BASE_URL=https://sky-lang.org    # used for redirect_uri
```

The Sky app read the full literal `"https://sky-lang.org    # used for redirect_uri"` and silently broke GitHub's OAuth `redirect_uri` check.

Every other dotenv parser (`godotenv` / `python-dotenv` / `Foreman` / `dotenv-cli`) strips the trailing ` # comment` from an unquoted value when `#` is preceded by whitespace.

## Contract

`stripDotEnvValue` implements the canonical contract:

| Input | Output | Note |
|---|---|---|
| `value` | `value` | plain |
| `value  # comment` | `value` | whitespace before `#` = comment |
| `value#tag` | `value#tag` | no whitespace = part of value |
| `"value # x"` | `value # x` | `#` inside quotes is preserved |
| `''` | `''` | empty |
| `#comment` | `''` | leading `#` = whole RHS is comment |

## Tests

`dotenv_test.go` (NEW) covers:
- `TestStripDotEnvValue` — 24 unit cases over the helper
- `TestLoadDotEnvFile_InlineComments` — 8 cases end-to-end through `bufio.Scanner` + `os.Setenv` (including the real-world hit)
- `TestLoadDotEnvFile_NoOverride` — confirms 12-factor precedence (shell env wins) unchanged

`go test ./runtime-go/rt/` — green.

## Backward compatibility

Every existing `.env` value whose RHS doesn't contain `#` is byte-identical to the prior behaviour. Values with `#` inside that previously appeared to "work" (no parser ever stripped them) get the canonical interpretation now — anyone relying on a literal trailing comment as part of the value can quote the value (`KEY="value # actual"`) to preserve it.