### PR TITLE
fix(types): expand head type-alias before def param/return split (+ Handler alias)

### DIFF
--- a/runtime-go/rt/rt.go
+++ b/runtime-go/rt/rt.go
@@ -8108,8 +8108,12 @@ func Middleware_withBasicAuth(expectedUser any, expectedPass any, handler any) a
 			if !(userOk && passOk) {
 				return Ok[any, any](SkyResponse{Status: 401, Body: "bad credentials"})
 			}
+			// Run the wrapped handler's task. Use anyTaskInvoke (as CORS /
+			// logging do) rather than a bare `func() any` assertion: a Sky
+			// handler returns a typed SkyTask[E, A], not a thunk, so the old
+			// assertion panicked at runtime.
 			task := SkyCall(handler, req)
-			return task.(func() any)()
+			return anyTaskInvoke(task)
 		}
 	}
 }
@@ -8146,8 +8150,10 @@ func Middleware_withRateLimit(name any, capacity any, refillPerSec any, handler 
 					Headers: map[string]string{"Retry-After": "1"},
 				})
 			}
+			// See withBasicAuth: anyTaskInvoke handles the typed SkyTask the
+			// wrapped handler returns (the old `func() any` assertion panicked).
 			task := SkyCall(handler, req)
-			return task.(func() any)()
+			return anyTaskInvoke(task)
 		}
 	}
 }

--- a/sky-stdlib/Sky/Http/Middleware.sky
+++ b/sky-stdlib/Sky/Http/Middleware.sky
@@ -9,6 +9,7 @@ module Sky.Http.Middleware exposing
 
 
 import Sky.Ffi as Ffi
+import Sky.Http.Server exposing (Handler)
 
 
 -- | `withCors allowedOrigins handler` — add CORS headers for the

--- a/sky-stdlib/Sky/Http/Server.sky
+++ b/sky-stdlib/Sky/Http/Server.sky
@@ -9,7 +9,7 @@
 -- hover surfaces `String -> (Request -> Task Error Response) ->
 -- Route`, and consumers can annotate their handlers exactly.
 module Sky.Http.Server exposing
-    ( Request, Response, Route, Server, Cookie
+    ( Request, Response, Route, Server, Cookie, Handler
     , get, post, put, delete, any, api
     , listen
     , text, json, html, withStatus, redirect
@@ -53,6 +53,16 @@ type alias Response =
     , headers : Dict String String
     , contentType : String
     }
+
+
+-- | The shape of every Sky HTTP handler: a function from an inbound
+-- `Request` to a `Task` yielding a `Response`.  A transparent alias for
+-- `(Request -> Task Error Response)`, so a value annotated `Handler`
+-- unifies with the parameter of `get` / `post` / … and the
+-- `Sky.Http.Middleware` composers decorate handlers without an opaque
+-- wrapper type.
+type alias Handler =
+    Request -> Task Error Response
 
 
 -- | A registered route.  Opaque — produced by `get` / `post` /

--- a/src/Sky/Canonicalise/Module.hs
+++ b/src/Sky/Canonicalise/Module.hs
@@ -212,14 +212,22 @@ canonicaliseWithDeps deps srcMod =
         -- Register type aliases
         env4 = registerAliases tmap aliasMap env3 (Src._aliases srcMod)
 
+        -- Canonicalise aliases
+        aliases = canonicaliseAliases tmap aliasMap env4 (Src._aliases srcMod)
+
+        -- Local ∪ dependency alias bodies, keyed by (home, name).  Used to
+        -- expand an alias-typed annotation into its function shape BEFORE the
+        -- param/return split in `canonicaliseValue` (see the comment there).
+        bodyAliases = buildAliasMap
+            (Map.union
+                (Map.mapKeys (\n -> (modName, n)) aliases)
+                depAliasMap)
+
         -- Canonicalise declarations
-        decls = canonicaliseDecls tmap aliasMap env4 (Src._values srcMod)
+        decls = canonicaliseDecls bodyAliases tmap aliasMap env4 (Src._values srcMod)
 
         -- Canonicalise unions
         unions = canonicaliseUnions tmap aliasMap env4 (Src._unions srcMod)
-
-        -- Canonicalise aliases
-        aliases = canonicaliseAliases tmap aliasMap env4 (Src._aliases srcMod)
 
         -- Exports
         exports = canonicaliseExports (Src._exports srcMod)
@@ -1640,19 +1648,21 @@ registerAliases tmap aliasMap env aliases =
 
 -- | Canonicalise all value declarations
 canonicaliseDecls
-    :: Map.Map String ModuleName.Canonical
+    :: AliasMap
+    -> Map.Map String ModuleName.Canonical
     -> Map.Map String ModuleName.Canonical
     -> Env.Env -> [A.Located Src.Value] -> Can.Decls
-canonicaliseDecls tmap aliasMap env values =
-    foldr (\v rest -> Can.Declare (canonicaliseValue tmap aliasMap env v) rest) Can.SaveTheEnvironment values
+canonicaliseDecls bodyAliases tmap aliasMap env values =
+    foldr (\v rest -> Can.Declare (canonicaliseValue bodyAliases tmap aliasMap env v) rest) Can.SaveTheEnvironment values
 
 
 -- | Canonicalise a single value declaration
 canonicaliseValue
-    :: Map.Map String ModuleName.Canonical
+    :: AliasMap
+    -> Map.Map String ModuleName.Canonical
     -> Map.Map String ModuleName.Canonical
     -> Env.Env -> A.Located Src.Value -> Can.Def
-canonicaliseValue tmap aliasMap env (A.At _ val) =
+canonicaliseValue bodyAliases tmap aliasMap env (A.At _ val) =
     let
         name = Src._valueName val
         params = Src._valuePatterns val
@@ -1674,7 +1684,20 @@ canonicaliseValue tmap aliasMap env (A.At _ val) =
         Just (A.At _ srcType) ->
             let
                 home = Env._home env
-                canType = CanType.canonicaliseTypeAnnotationWithAliases tmap aliasMap home srcType
+                canTypeRaw = CanType.canonicaliseTypeAnnotationWithAliases tmap aliasMap home srcType
+                -- Unfold an alias at the HEAD of the annotation before
+                -- splitting params from the return type.  When the whole
+                -- annotation is a type alias whose body is a function
+                -- (`f : Handler` where `type alias Handler = Request ->
+                -- Task Error Response`), the raw canonical form is a nominal
+                -- `TType` that `arrowArgs` cannot peel — so without this the
+                -- def's parameters would be dropped and the body checked
+                -- against the unpeeled alias.  Only the head is unfolded:
+                -- argument / return leaf types keep their nominal form (the
+                -- later module-level alias-expansion pass handles those), so
+                -- the typed lowering of ordinary `f : Rec -> String`
+                -- signatures is byte-for-byte unchanged.
+                canType = unfoldHeadAlias bodyAliases canTypeRaw
                 freeVars = CanType.freeTypeVars srcType
                 nPats = length canPatterns
                 typedPatterns = zip canPatterns (take nPats (arrowArgs canType))
@@ -1691,10 +1714,37 @@ canonicaliseValue tmap aliasMap env (A.At _ val) =
             Can.TypedDef name freeVars typedPatterns canBody resultType
 
 
--- | Extract argument types from a function type
+-- | Extract argument types from a function type.  Unwraps a `TAlias`
+-- head so an alias whose body is a function (`type alias Handler =
+-- Request -> Task Error Response`) contributes its parameters.
 arrowArgs :: Can.Type -> [Can.Type]
 arrowArgs (Can.TLambda from to) = from : arrowArgs to
+arrowArgs (Can.TAlias _ _ _ aliasInner) = arrowArgs (aliasBodyType aliasInner)
 arrowArgs _ = []
+
+
+-- | The underlying type carried by a `TAlias`'s filled/hoisted body.
+aliasBodyType :: Can.AliasType -> Can.Type
+aliasBodyType (Can.Filled t)  = t
+aliasBodyType (Can.Hoisted t) = t
+
+
+-- | Replace a type alias that appears AT THE HEAD of an annotation with
+-- its (substituted) body, so a function-typed alias contributes its
+-- parameters when the def is split.  Only the head is touched —
+-- argument and return leaf types are left as-is.  The visited set keys
+-- on `(home, name)` so a mutually-recursive alias chain can't loop.
+unfoldHeadAlias :: AliasMap -> Can.Type -> Can.Type
+unfoldHeadAlias amap = go Set.empty
+  where
+    go visited ty = case ty of
+        Can.TType home name args
+            | Just (rHome, Can.Alias vars body) <- lookupAlias amap home name
+            , not (Set.member (rHome, name) visited)
+            , length vars == length args ->
+                let subst = Map.fromList (zip vars args)
+                in go (Set.insert (rHome, name) visited) (substTypeVars subst body)
+        _ -> ty
 
 
 -- | Extract the result type from a function type, stripping exactly N
@@ -1703,6 +1753,7 @@ arrowArgs _ = []
 arrowResultN :: Int -> Can.Type -> Can.Type
 arrowResultN n t | n <= 0 = t
 arrowResultN n (Can.TLambda _ to) = arrowResultN (n - 1) to
+arrowResultN n (Can.TAlias _ _ _ aliasInner) = arrowResultN n (aliasBodyType aliasInner)
 arrowResultN _ t = t
 
 


### PR DESCRIPTION
@anzellai, I didn't give up on the development of the Rust backend due to learning reasons. 

During the development of the project, I stumbled upon some blocking points. As I don't grasp Sky's compiler whole picture, ignore if the following change doesn't properly apply. 

(I have enforced AI to not use Rust's `Box<dyn Any>` under any circumstances - and it complains at some points)

--------------

## Problem

A definition whose **entire signature is a type alias that expands to a function** drops all of its parameters at canonicalisation. Minimal repro:

```elm
-- Lib.sky
type alias Fn = Int -> Int

-- Main.sky
myInc : Lib.Fn
myInc n = n + 1     -- TYPE ERROR: expected: Fn, actual: Int
```

The param/return split in `canonicaliseValue` (`arrowArgs` / `arrowResultN`) only peels `TLambda`. But an alias reference is a nominal `TType` at split time — the alias → `TAlias` expansion pass runs *later* — so the parameters are never extracted and the body is checked against the unpeeled alias.

This also blocked the documented `Sky.Http.Middleware` composition: `Server.get "/" (handler |> Mw.withCors ["*"])` was a type error on both backends, because `Sky.Http.Middleware`'s `withCors : ... -> Handler -> Handler` referenced a `Handler` type that didn't exist (it fell through to an opaque, non-unifying `TType ""  "Handler"`).

## Fix

1. **`src/Sky/Canonicalise/Module.hs`** — unfold an alias at the **head** of an annotation before the param/return split. Head-only: argument and return leaf types keep their nominal form, so ordinary `f : Rec -> String` signatures lower byte-for-byte unchanged. The split helpers also learn to unwrap a `TAlias` head.
2. **`sky-stdlib/Sky/Http/Server.sky`** — add the public, transparent `type alias Handler = Request -> Task Error Response` (and export it). Handlers can now be annotated `Handler`.
3. **`sky-stdlib/Sky/Http/Middleware.sky`** — `import Sky.Http.Server exposing (Handler)`.
4. **`runtime-go/rt/rt.go`** — a separate latent runtime bug this unblocks: `Middleware_withBasicAuth` / `withRateLimit` asserted the wrapped handler's task was a `func() any` thunk and panicked on the typed `SkyTask` a real handler returns. Both now use `anyTaskInvoke` (as CORS / logging already do). No example exercised middleware, so this shipped latent.

## Verification

- Three repros (`Lib.Fn`, `Server.Handler`, full middleware composition) type-check and build.
- Middleware runs end-to-end on Go: CORS `Access-Control-Allow-Origin: *`; basic-auth → 401 (no creds) / 200 (good creds); zero panics.
- No regression: `07-todo-cli`, `05-mux-server`, `15-http-server`, `30-sse-server-demo` build clean.
- Targeted `cabal test` (Canonicalise / Alias / Kernel / FfiGen) green.

### Pre-existing, unrelated
`Sky.Build.CrossModuleLambdaCollisionC` (#365) fails identically on a clean checkout (confirmed by reverting every change in this PR and rebuilding). It is a separate cross-module-lambda codegen regression, not introduced here.