### PR TITLE
fix(codegen): type cross-module let-lambda params by region, not render-order IORef (#365)

### DIFF
--- a/src/Sky/Build/Compile.hs
+++ b/src/Sky/Build/Compile.hs
@@ -11106,7 +11106,22 @@ defToStmts def = case def of
         -- module's version survived the flat _stEnv ambiguity
         -- collapse).
         let solved = Rec._cg_solvedTypes getCgEnv
-            curMod = unsafePerformIO (readIORef globalCurrentDepModule)
+            iorefMod = unsafePerformIO (readIORef globalCurrentDepModule)
+            -- v0.15.6 #365 — derive the defining module from the def's own
+            -- body region instead of trusting the render-order IORef hint.
+            -- The hint is set by sentinel decls in pkg-decls order, but the
+            -- lazily-forced `defToStmts` thunks don't force in that order —
+            -- it stuck on the FIRST dep, so a later dep's `let encodeOne
+            -- x = …` read the first dep's *ambiguous* per-module entry and
+            -- degraded to `func(x any)`.  Regions are file-unique, so the
+            -- per-module region ledger gives the module deterministically.
+            -- Only override inside dep-rendering context (iorefMod set);
+            -- entry-module decls keep the flat-lookup (`Nothing`) path.
+            curMod = case iorefMod of
+                Just im -> case Solve.moduleForRegion (A.toRegion body) solved of
+                    Just rm -> Just rm
+                    Nothing -> Just im
+                Nothing -> Nothing
             scopedSolved = Solve.withCurrentModule curMod solved
             inferredTy = Solve.lookupSolvedVarScoped name scopedSolved
             (paramTys, retTy) = case inferredTy of

--- a/src/Sky/Type/Solve.hs
+++ b/src/Sky/Type/Solve.hs
@@ -19,6 +19,7 @@ module Sky.Type.Solve
     , emptySolvedTypes               -- v0.15.x P37a
     , lookupSolvedVar                -- v0.15.x P37a
     , lookupSolvedVarScoped          -- v0.15.6 #365 — per-module env lookup
+    , moduleForRegion                -- v0.15.6 #365 — region -> defining module
     , lookupSolvedRegion             -- v0.15.x P37a
     , lookupSolvedRegionScoped       -- v0.15.6 #365 — per-module region lookup
     , insertSolvedVar                -- v0.15.x P37a
@@ -186,6 +187,25 @@ lookupSolvedVarScoped name solvedTypes =
                         Nothing -> Map.lookup name (_stEnv solvedTypes)
                 Nothing -> Map.lookup name (_stEnv solvedTypes)
         Nothing -> Map.lookup name (_stEnv solvedTypes)
+
+
+-- | v0.15.6 #365 — determine the module that *defines* a region by
+-- which per-module region map contains it.  Regions are file-unique,
+-- so a hit is unambiguous; returns `Just` only on a single match.
+--
+-- This is the deterministic counterpart to the render-order
+-- `globalCurrentDepModule` IORef hint in `Compile.hs`: that hint can
+-- lag behind a lazily-forced decl thunk (it stuck on the FIRST dep,
+-- so a later dep's `let encodeOne x = …` read the first dep's
+-- ambiguous per-module entry and degraded to `any`).  Deriving the
+-- module from the def's own region instead is stable regardless of
+-- thunk-forcing order.
+moduleForRegion :: A.Region -> SolvedTypes -> Maybe String
+moduleForRegion r solvedTypes =
+    case [ m | (m, rm) <- Map.toList (_stPerModuleRegions solvedTypes)
+             , Map.member r rm ] of
+        [m] -> Just m
+        _   -> Nothing
 
 
 -- | Look up the HM type recorded at a given source region.


### PR DESCRIPTION
@anzellai, following the same principle, of avoiding lowering to `any` when a concrete type is available. 

--------------------------

## Problem

When several modules each define a same-named `let`-bound lambda — e.g. `let encodeOne x = …` inside `Lib.A.asJson`, `Lib.A.otherAsJson`, AND `Lib.B.asJson`, where `x` is `ItemA` / `OtherA` / `ItemB` respectively — the lambda's parameter is emitted as `func(x any)` even for a module whose `encodeOne` is *unambiguous*, instead of the concrete record type (`func(x Lib_B_ItemB_R)`).

It stays sound at runtime (a `rt.Coerce[…]` bridge at the call site fixes the slot), but loses the typed-codegen optimization and trips the standing `CrossModuleLambdaCollisionC` spec.

## Root cause

The per-module type ledger is correct (`Lib.B.encodeOne → ItemB -> String`; `Lib.A.encodeOne → _ambig`). The lambda-param lowering picks *which* module it is in by reading `globalCurrentDepModule`, an `IORef` set by sentinel decls in pkg-decls render order. But the lazily-forced `defToStmts` thunks don't force in that order — the hint sticks on the **first** dep, so a later dep's lambda reads the first dep's ambiguous entry and falls back to `any`.

## Fix

Derive the defining module **deterministically from the def's own body region** (regions are file-unique) via the per-module region ledger, instead of the render-order IORef. This mirrors the call-site `Coerce` path, which already typed correctly because it keys off the region. Scoped to dep-rendering context (IORef set), so entry-module decls keep their existing flat-lookup path; falls back to the IORef when a region has no ledger entry (synthetic / monomorphised regions).

- `src/Sky/Type/Solve.hs`: add `moduleForRegion :: Region -> SolvedTypes -> Maybe String`.
- `src/Sky/Build/Compile.hs` (`defToStmts`, `Can.Def` arm): pick `curMod` from `moduleForRegion (toRegion body)`.

## Verification

- `CrossModuleLambdaCollisionC` passes (was the documented standing-lock failure); codegen is now `Lib.A → func(x any)×2`, `Lib.B → func(x Lib_B_ItemB_R)`.
- `examples/13-skyshop` (76k-FFI standing-lock) builds clean.
- FFI / Toml / Kernel byte-identity: 32 examples, 0 failures.
- Builds on current `main` (v0.16.4-dev).