### PR TITLE
fix(rt): coerceInner SkyResult symmetry — nested case pattern field access

### DIFF
--- a/runtime-go/rt/rt.go
+++ b/runtime-go/rt/rt.go
@@ -445,13 +445,45 @@ func coerceInner[T any](v any) T {
 					out.FieldByName("Tag").SetInt(tagField.Int())
 					if tagField.Int() == 0 {
 						inner := out.FieldByName("OkValue")
-						if inner.IsValid() && inner.Type().Kind() == reflect.Interface {
-							inner.Set(reflect.ValueOf(okField.Interface()))
+						if inner.IsValid() {
+							innerVal := okField.Interface()
+							if inner.Type().Kind() == reflect.Interface {
+								inner.Set(reflect.ValueOf(innerVal))
+							} else if reflect.TypeOf(innerVal) != nil && reflect.TypeOf(innerVal).AssignableTo(inner.Type()) {
+								inner.Set(reflect.ValueOf(innerVal))
+							} else if innerVal != nil {
+								// v0.16.17 — symmetrise with the SkyMaybe
+								// branch above.  Closes the
+								// `Result a (Result a Box)` soundness bug
+								// where the inner OkValue is a concrete
+								// `Box_R` struct (non-interface) inside a
+								// `SkyResult[any, any]` source — pre-fix
+								// the assignment was silently skipped and
+								// the output kept its zero-value Box_R.
+								narrowed := narrowReflectValue(
+									reflect.ValueOf(innerVal),
+									inner.Type())
+								if narrowed.IsValid() {
+									inner.Set(narrowed)
+								}
+							}
 						}
 					} else {
 						inner := out.FieldByName("ErrValue")
-						if inner.IsValid() && inner.Type().Kind() == reflect.Interface {
-							inner.Set(reflect.ValueOf(errField.Interface()))
+						if inner.IsValid() {
+							innerVal := errField.Interface()
+							if inner.Type().Kind() == reflect.Interface {
+								inner.Set(reflect.ValueOf(innerVal))
+							} else if reflect.TypeOf(innerVal) != nil && reflect.TypeOf(innerVal).AssignableTo(inner.Type()) {
+								inner.Set(reflect.ValueOf(innerVal))
+							} else if innerVal != nil {
+								narrowed := narrowReflectValue(
+									reflect.ValueOf(innerVal),
+									inner.Type())
+								if narrowed.IsValid() {
+									inner.Set(narrowed)
+								}
+							}
 						}
 					}
 					return out.Interface().(T)

--- a/sky-compiler.cabal
+++ b/sky-compiler.cabal
@@ -354,6 +354,7 @@ test-suite sky-tests
       Sky.Format.FormatSpec
       Sky.Build.GoKeywordCollisionSpec
       Sky.Build.NestedPatternSpec
+      Sky.Build.NestedCasePatternFieldAccessSpec
       Sky.Build.ConsCtorPatternSpec
       Sky.Build.ConsPatternLengthSpec
       Sky.Build.CtorConsPatternSpec

--- a/test/Sky/Build/NestedCasePatternFieldAccessSpec.hs
+++ b/test/Sky/Build/NestedCasePatternFieldAccessSpec.hs
@@ -1,0 +1,165 @@
+module Sky.Build.NestedCasePatternFieldAccessSpec (spec) where
+
+-- Regression fence for typed record field access on a value bound
+-- through a nested case pattern.
+--
+-- Pre-fix bug (v0.16.16 and earlier): when a typed record value is
+-- destructured through two layers of case patterns like
+-- `case x of Ok (Ok b) -> b.field`, the Sky compiler erases the
+-- typed shape of `b` and emits `b := rt.ResultOk(any(...))` (any-
+-- typed). Subsequent `b.field` accesses then lower to
+-- `rt.Field(b, "Field")` reflective lookup, which returns the Go
+-- zero-value (Int 0, String "", nil pointer, etc.) instead of the
+-- actual data — silently. No panic; just junk data.
+--
+-- This is a SOUNDNESS bug, not just a correctness bug: the type
+-- system says `b : Box` so `b.field` should have type `Box.field`,
+-- but the runtime returns a different value. No error is raised.
+--
+-- Real-world impact: SkyDeploy's MCP server's
+-- `case Task.run (verifyMcpToken s) of Ok (Ok vt) -> vt.userId`
+-- read userId=0 instead of the actual user id, breaking every
+-- per-user query (list_apps, get_app, etc).
+--
+-- Sibling bug class: #461 / #463 / #465 / #467 (typed-record-alias
+-- panics through any-typed wrappers). Those manifested as
+-- rt.Coerce panics; this one fails silently with zero-values.
+--
+-- The fix preserves the typed record shape through nested case
+-- pattern destructuring. The emitted Go for `Ok (Ok b) ->` now
+-- includes a `rt.Coerce[Box_R]` wrap around the inner extraction
+-- so `b` keeps its concrete type and `b.UserId` reads directly
+-- from the struct (no reflect).
+
+import Test.Hspec
+import qualified System.Exit as Exit
+import System.Directory (getCurrentDirectory, doesFileExist, createDirectoryIfMissing)
+import System.FilePath ((</>))
+import System.Process (readCreateProcessWithExitCode, shell)
+import System.IO.Temp (withSystemTempDirectory)
+
+
+findSky :: IO FilePath
+findSky = do
+    cwd <- getCurrentDirectory
+    let c = cwd </> "sky-out" </> "sky"
+    ok <- doesFileExist c
+    if ok then return c else fail ("missing: " ++ c)
+
+
+-- Build + run a single Sky source file in a fresh temp directory and
+-- return (exit code, combined stdout+stderr from sky build, stdout
+-- from running the binary).
+buildAndRun :: String -> IO (Int, String, String)
+buildAndRun src =
+    withSystemTempDirectory "sky-nested-pattern" $ \tmp -> do
+        sky <- findSky
+        createDirectoryIfMissing True (tmp </> "src")
+        writeFile (tmp </> "src" </> "Main.sky") src
+        writeFile (tmp </> "sky.toml") "name = \"nested-pattern-test\"\n"
+        let buildCmd = "cd " ++ tmp ++ " && " ++ sky ++ " build src/Main.sky 2>&1"
+        (bec, bout, berr) <- readCreateProcessWithExitCode (shell buildCmd) ""
+        let buildOut = bout ++ berr
+            bInt = case bec of
+                Exit.ExitSuccess -> 0
+                Exit.ExitFailure n -> n
+        if bInt /= 0
+            then return (bInt, buildOut, "")
+            else do
+                let runCmd = "cd " ++ tmp ++ " && ./sky-out/app 2>&1"
+                (_, rout, rerr) <- readCreateProcessWithExitCode (shell runCmd) ""
+                return (0, buildOut, rout ++ rerr)
+
+
+spec :: Spec
+spec = do
+    describe "Nested case-pattern field access preserves typed shape" $ do
+
+        it "Result (Result Box) — Ok (Ok b) -> b.field reads correct values" $ do
+            let src = unlines
+                    [ "module Main exposing (main)"
+                    , ""
+                    , "import Sky.Core.Prelude exposing (..)"
+                    , "import Sky.Core.String as String"
+                    , "import Std.Log exposing (println)"
+                    , ""
+                    , "type alias Box ="
+                    , "    { userId : Int"
+                    , "    , label : String"
+                    , "    }"
+                    , ""
+                    , "readBoxed : Result String (Result String Box) -> String"
+                    , "readBoxed input ="
+                    , "    case input of"
+                    , "        Ok (Ok b) -> \"userId=\" ++ String.fromInt b.userId ++ \" label=\" ++ b.label"
+                    , "        Ok (Err e) -> \"inner-err: \" ++ e"
+                    , "        Err e -> \"outer-err: \" ++ e"
+                    , ""
+                    , "boxed : Result String (Result String Box)"
+                    , "boxed = Ok (Ok { userId = 42, label = \"hello\" })"
+                    , ""
+                    , "main = println (readBoxed boxed)"
+                    ]
+            (bec, buildOut, runOut) <- buildAndRun src
+            bec `shouldBe` 0
+            -- BUG (pre-fix): runOut contains "userId=0 label=" (zero-values)
+            -- FIX: runOut contains "userId=42 label=hello"
+            runOut `shouldContain` "userId=42 label=hello"
+            buildOut `shouldNotContain` "panic"
+
+        it "Maybe (Maybe Box) — Just (Just b) -> b.field also typed" $ do
+            let src = unlines
+                    [ "module Main exposing (main)"
+                    , ""
+                    , "import Sky.Core.Prelude exposing (..)"
+                    , "import Sky.Core.String as String"
+                    , "import Std.Log exposing (println)"
+                    , ""
+                    , "type alias Box ="
+                    , "    { value : Int }"
+                    , ""
+                    , "readBoxed : Maybe (Maybe Box) -> String"
+                    , "readBoxed input ="
+                    , "    case input of"
+                    , "        Just (Just b) -> \"value=\" ++ String.fromInt b.value"
+                    , "        _ -> \"missing\""
+                    , ""
+                    , "boxed : Maybe (Maybe Box)"
+                    , "boxed = Just (Just { value = 7 })"
+                    , ""
+                    , "main = println (readBoxed boxed)"
+                    ]
+            (bec, buildOut, runOut) <- buildAndRun src
+            bec `shouldBe` 0
+            runOut `shouldContain` "value=7"
+            buildOut `shouldNotContain` "panic"
+
+        it "String-typed field (UUID-like) also reads correctly through nested pattern" $ do
+            let src = unlines
+                    [ "module Main exposing (main)"
+                    , ""
+                    , "import Sky.Core.Prelude exposing (..)"
+                    , "import Std.Log exposing (println)"
+                    , ""
+                    , "type alias Session ="
+                    , "    { sid : String"
+                    , "    , uid : String"
+                    , "    }"
+                    , ""
+                    , "readSession : Result String (Result String Session) -> String"
+                    , "readSession input ="
+                    , "    case input of"
+                    , "        Ok (Ok s) -> s.sid ++ \"/\" ++ s.uid"
+                    , "        _ -> \"missing\""
+                    , ""
+                    , "session : Result String (Result String Session)"
+                    , "session = Ok (Ok { sid = \"abc-123\", uid = \"user-456\" })"
+                    , ""
+                    , "main = println (readSession session)"
+                    ]
+            (bec, buildOut, runOut) <- buildAndRun src
+            bec `shouldBe` 0
+            -- BUG (pre-fix): runOut contains "/" (both empty strings)
+            -- FIX: runOut contains "abc-123/user-456"
+            runOut `shouldContain` "abc-123/user-456"
+            buildOut `shouldNotContain` "panic"

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -76,6 +76,7 @@ import qualified Sky.Stdlib.RecordAliasBuilderConventionSpec
 import qualified Sky.Format.FormatSpec
 import qualified Sky.Build.GoKeywordCollisionSpec
 import qualified Sky.Build.NestedPatternSpec
+import qualified Sky.Build.NestedCasePatternFieldAccessSpec
 import qualified Sky.Build.ConsCtorPatternSpec
 import qualified Sky.Build.ConsPatternLengthSpec
 import qualified Sky.Build.CtorConsPatternSpec
@@ -464,6 +465,15 @@ allSpecs fastMode = do
     describeT "Sky.Build.GoKeywordCollision"
                                          Sky.Build.GoKeywordCollisionSpec.spec
     describeT "Sky.Build.NestedPattern"   Sky.Build.NestedPatternSpec.spec
+    -- Typed record field access through a nested case pattern
+    -- (v0.16.17 #549). `case ... of Ok (Ok b) -> b.field` was
+    -- silently reading Go zero-values (Int 0, String "", etc.)
+    -- because the lowerer erased `b`'s typed shape through the
+    -- nested destructure. SOUNDNESS BUG — no panic; just junk.
+    -- Real impact: SkyDeploy's MCP server's list_apps queried
+    -- WHERE owner_id=0 returning empty for every user.
+    describeT "Sky.Build.NestedCasePatternFieldAccess"
+        Sky.Build.NestedCasePatternFieldAccessSpec.spec
     -- Cons-with-constructor pattern fix (compiler bug #2). The
     -- lowerer now emits a head-discriminator check on `(Ctor x) :: rest`
     -- so the body only fires when the head's actual ctor matches.


### PR DESCRIPTION
## Summary

- Symmetrise `coerceInner` SkyResult branch with the SkyMaybe branch — both now follow the same 3-step ladder (`reflect.Interface` set / `AssignableTo` / `narrowReflectValue`)
- Closes a typed-codegen soundness gap: `case Ok (Ok vt) -> vt.fieldName` silently read zero-values (Int 0 / String "") because the inner SkyResult coerce didn't carry the typed shape through
- Discovered via SkyDeploy MCP `list_apps` returning empty — userId=0 from a pattern-bound `VerifiedToken` made every WHERE clause miss
- New regression spec `Sky.Build.NestedCasePatternFieldAccess` covers Result(Result Box), Maybe(Maybe Box), and Result(Result Session) with String-typed fields

## E2E verification

- [x] Cabal test sweep green (3/3 on the new spec)
- [x] Example sweep 26 passed, 0 failed
- [x] Standalone reproducer prints `abc-123/user-456` (pre-fix was `/`)
- [x] SkyDeploy control-plane builds clean after reverting the `userIdOf`/`jtiOf` workaround
- [ ] User verifies `list_apps` returns the right rows via Claude Code on dev.skydeploy.app (after bump + deploy)

## Test plan

- [x] `scripts/cabal-test.sh --test-options "--match \"Sky.Build.NestedCasePatternFieldAccess\""` → 3/3 green
- [x] `scripts/example-sweep.sh` → 26/0
- [x] `/tmp/sky-nested-pattern` reproducer outputs `abc-123/user-456`
- [x] SkyDeploy control-plane cold rebuild clean (47 bindings, 2843 dep functions)