### PR TITLE
fix(v0.16.23): idempotent setAttribute in __skyApplyPatches (#568)

### DIFF
--- a/runtime-go/rt/live.go
+++ b/runtime-go/rt/live.go
@@ -6283,6 +6283,43 @@ function __skyReplaceHTMLPreservingFocus(container, newHTML) {
     if (isFocused) preservedFocus = live;
   }
 
+  // Splice IFRAMES across the swap (#568 second loop).  Without
+  // this, an HTML-replace patch that touches the iframe's parent
+  // subtree (sibling sky-id reorder, structural reorganisation)
+  // destroys the live iframe via removeChild and creates a fresh
+  // one from the placeholder markup.  The fresh iframe's src
+  // triggers a navigation regardless of whether the value matches
+  // the live one — every reload re-fires the embedded console's
+  // handshake form, opens a new SSE, and pegs the tenant Cloud
+  // Run instance.
+  //
+  // Same splice pattern as inputs.  The iframe's src is treated
+  // as USER STATE AUTHORITY (the live document, internal SSE,
+  // navigation history, scroll position are owned by the iframe).
+  // Placeholder contributes non-authority attrs only — class,
+  // style, sandbox, referrerpolicy — via the existing helper
+  // (whose authority filter covers value/checked/selected; src
+  // isn't in that list, so we strip it from the placeholder
+  // before mirroring to avoid the same setAttribute-triggered
+  // navigation the patch path's guard prevents).
+  var liveFrames = container.querySelectorAll("iframe");
+  for (var fi = 0; fi < liveFrames.length; fi++) {
+    var liveFr = liveFrames[fi];
+    var phFr = __skyFindPlaceholder(tmp, liveFr);
+    if (!phFr) continue;
+    // Strip src from placeholder so __skyCopyAttrsExceptAuthority
+    // doesn't write it onto the live iframe (which would navigate
+    // it, same problem we are solving).  If the server WANTS to
+    // change the iframe URL it can do so by changing the live
+    // iframe's sky-id — that produces an HTML-replace whose
+    // placeholder has no live match, falling through to the
+    // default innerHTML path and creating a fresh iframe at the
+    // new URL.
+    if (phFr.hasAttribute("src")) phFr.removeAttribute("src");
+    __skyCopyAttrsExceptAuthority(phFr, liveFr);
+    phFr.parentNode.replaceChild(liveFr, phFr);
+  }
+
   // Commit: throw away container's current children (those we didn't
   // splice are stale; spliced ones already moved into tmp), then
   // attach tmp's children. Done.

--- a/runtime-go/rt/live.go
+++ b/runtime-go/rt/live.go
@@ -6866,7 +6866,20 @@ function __skyApplyPatches(patches) {
         }
         if (v === "") { el.removeAttribute(k); }
         else {
-          el.setAttribute(k, v);
+          // Idempotent setAttribute (#568): some elements re-fetch or
+          // re-navigate on ANY assignment to certain attributes, even
+          // when the new value is identical to the existing one. The
+          // poster child is the iframe src attribute — calling
+          // setAttribute with the same value causes the browser to
+          // re-navigate the iframe, dropping any SSE / cookie /
+          // scroll state inside. Same class: img src refetches,
+          // link href rebuilds the stylesheet, script src re-executes
+          // (browsers vary). Skipping the no-op write costs one
+          // getAttribute compare per attr and rules out a whole bug
+          // class. Mirrors the guard in __skyCopyAttrsExceptAuthority.
+          if (el.getAttribute(k) !== v) {
+            el.setAttribute(k, v);
+          }
           // Sync DOM properties that don't reflect from attrs.
           if (k === "value" && ("value" in el)) {
             el.value = v;

--- a/runtime-go/rt/live.go
+++ b/runtime-go/rt/live.go
@@ -6307,14 +6307,23 @@ function __skyReplaceHTMLPreservingFocus(container, newHTML) {
     var liveFr = liveFrames[fi];
     var phFr = __skyFindPlaceholder(tmp, liveFr);
     if (!phFr) continue;
+    // SRC-EQUALITY GATE.  sky-id is purely structural (tag +
+    // position + form-name) and does NOT encode src.  So two
+    // renders that emit <iframe src=A> then <iframe src=B> at
+    // the same structural position share a sky-id, and naive
+    // splicing would freeze the iframe at src=A forever — every
+    // legitimate URL change would silently no-op.  Only splice
+    // (preserve the live iframe) when the SERVER's intended src
+    // matches the live src.  When they differ, fall through to
+    // the default innerHTML path so the live iframe gets
+    // destroyed and a fresh one navigates to the new URL.
+    var liveSrc = liveFr.getAttribute("src") || "";
+    var phSrc = phFr.getAttribute("src") || "";
+    if (liveSrc !== phSrc) continue;
     // Strip src from placeholder so __skyCopyAttrsExceptAuthority
     // doesn't write it onto the live iframe (which would navigate
-    // it, same problem we are solving).  If the server WANTS to
-    // change the iframe URL it can do so by changing the live
-    // iframe's sky-id — that produces an HTML-replace whose
-    // placeholder has no live match, falling through to the
-    // default innerHTML path and creating a fresh iframe at the
-    // new URL.
+    // it even when the strings already match — assigning src
+    // unconditionally re-fetches in some browsers).
     if (phFr.hasAttribute("src")) phFr.removeAttribute("src");
     __skyCopyAttrsExceptAuthority(phFr, liveFr);
     phFr.parentNode.replaceChild(liveFr, phFr);

--- a/runtime-go/rt/live_sse_patches_client_test.go
+++ b/runtime-go/rt/live_sse_patches_client_test.go
@@ -291,6 +291,25 @@ func TestLiveJS_IframePreservedAcrossHTMLReplace(t *testing.T) {
 			"embedded console / multi-tab dashboards / preview iframes.",
 			wantIframeQuery)
 	}
+	// SRC-EQUALITY GATE — without this, the splice would freeze the
+	// iframe at its first-loaded URL forever. Sky.Live's sky-id is
+	// purely structural (path + position + tag, plus form-name for
+	// inputs); it does NOT encode src. So two renders that emit
+	// <iframe src=A> then <iframe src=B> at the same structural
+	// position share a sky-id, and naive splicing matches the
+	// placeholder by sky-id and preserves the live iframe, dropping
+	// the new src on the floor. The gate compares liveSrc vs phSrc
+	// and skips the splice when they differ — fall-through to the
+	// default innerHTML path destroys the live iframe and creates a
+	// fresh one at the new URL. Caught in adversarial review of #568.
+	wantSrcGate := "if (liveSrc !== phSrc) continue;"
+	if !strings.Contains(js, wantSrcGate) {
+		t.Fatalf("iframe splice must guard with src-equality (%q); "+
+			"not found in liveJS — without it, the iframe is FROZEN at "+
+			"its first URL forever because sky-id doesn't encode src. "+
+			"See runtime-go/rt/live.go and #568 adversarial review.",
+			wantSrcGate)
+	}
 	// The splice must strip src from the placeholder so the
 	// follow-on __skyCopyAttrsExceptAuthority call doesn't write
 	// src onto the live iframe (which would trigger the same

--- a/runtime-go/rt/live_sse_patches_client_test.go
+++ b/runtime-go/rt/live_sse_patches_client_test.go
@@ -256,3 +256,51 @@ func TestLiveJS_IdempotentSetAttributeGuard(t *testing.T) {
 			"image-heavy apps under any Tick subscription.", wantGuard)
 	}
 }
+
+// TestLiveJS_IframePreservedAcrossHTMLReplace pins the SECOND iframe-
+// reload path closed by #568. The attribute-patch guard
+// (TestLiveJS_IdempotentSetAttributeGuard) handles the case where the
+// diff emits an attrs patch for an unchanged iframe.src. But the
+// diff also emits *HTML-replace* patches when a parent subtree's
+// structure changes (sibling sky-id reorder, child-count change,
+// etc.). The HTML-replace path goes through
+// __skyReplaceHTMLPreservingFocus, which historically only spliced
+// inputs/textareas/selects — iframes inside the swapped subtree got
+// removeChild'd and recreated from the new HTML, triggering a fresh
+// navigation regardless of whether the URL changed.
+//
+// Production manifestation: the 438ms back-to-back POSTs to
+// /_sky/console/_login that confirmed the loop was not just a 4s
+// Tick. Each parent-tree diff round that touched any sibling of the
+// iframe destroyed and re-created the iframe, re-firing the
+// handshake form-submit.
+//
+// The fix splices iframes alongside inputs/textareas/selects with
+// the live iframe's src treated as user-state authority — the live
+// document, internal SSE, navigation history, scroll position
+// belong to the iframe. Placeholder contributes only non-src attrs.
+func TestLiveJS_IframePreservedAcrossHTMLReplace(t *testing.T) {
+	js := liveJS("test-sid")
+	wantIframeQuery := `container.querySelectorAll("iframe")`
+	if !strings.Contains(js, wantIframeQuery) {
+		t.Fatalf("__skyReplaceHTMLPreservingFocus must walk iframes via %q; "+
+			"not found in liveJS — see runtime-go/rt/live.go and #568. "+
+			"Without this, any HTML-replace patch on a subtree containing "+
+			"an iframe destroys and re-creates the iframe, triggering a "+
+			"fresh navigation even when the src is unchanged. Breaks "+
+			"embedded console / multi-tab dashboards / preview iframes.",
+			wantIframeQuery)
+	}
+	// The splice must strip src from the placeholder so the
+	// follow-on __skyCopyAttrsExceptAuthority call doesn't write
+	// src onto the live iframe (which would trigger the same
+	// navigation we're solving). A precise substring matches the
+	// guard.
+	wantStripSrc := `phFr.removeAttribute("src")`
+	if !strings.Contains(js, wantStripSrc) {
+		t.Fatalf("iframe splice must strip src from placeholder via %q "+
+			"so __skyCopyAttrsExceptAuthority doesn't navigate the live "+
+			"iframe; not found in liveJS — see runtime-go/rt/live.go.",
+			wantStripSrc)
+	}
+}

--- a/runtime-go/rt/live_sse_patches_client_test.go
+++ b/runtime-go/rt/live_sse_patches_client_test.go
@@ -217,3 +217,42 @@ func TestHandleSSE_EmitsEventPatchForPatchFrame(t *testing.T) {
 		t.Fatalf("handleSSE didn't emit our queued event:patch frame (seq=7)")
 	}
 }
+
+// ─── (e) Idempotent setAttribute guard (#568) ───────────────────
+//
+// __skyApplyPatches must guard setAttribute(k, v) with a getAttribute
+// equality check. Without the guard, an SSE patch carrying an
+// unchanged attribute value still calls setAttribute, which browsers
+// treat as a "navigate / refetch" event for src/href-bearing elements
+// (most painfully: <iframe src="…"> reloads on ANY assignment, even
+// to the same string).
+//
+// Production regression: dev.skydeploy.app/_sky/console rendered
+// inside the dashboard via <iframe src=…>. The dashboard Tick (4s)
+// re-rendered, sent SSE attribute patches that touched iframe.src
+// with the unchanged value, the iframe reloaded every 4s, every
+// reload re-fired the cross-origin handshake form-POST to
+// <slug>.<host>/_sky/console/_login, and each handshake opened a
+// fresh long-lived SSE on the tenant Cloud Run instance. With
+// max_instances=1 and containerConcurrency=80, the tenant saturated
+// in minutes and Cloud Run's GFE responded "Rate exceeded." to
+// every subsequent request.
+//
+// The runtime fix is a one-line guard in the JS patch loop. This
+// regression pins the guard string-contents so a future rewrite of
+// __skyApplyPatches can't silently drop it.
+func TestLiveJS_IdempotentSetAttributeGuard(t *testing.T) {
+	js := liveJS("test-sid")
+	// The guarded pattern is "if (el.getAttribute(k) !== v) {" — a
+	// substring search is robust against whitespace tweaks but tight
+	// enough to catch a logic flip (e.g. someone "simplifying" the
+	// guard back to unconditional setAttribute).
+	wantGuard := "if (el.getAttribute(k) !== v) {"
+	if !strings.Contains(js, wantGuard) {
+		t.Fatalf("__skyApplyPatches must guard setAttribute with %q; not found in liveJS — "+
+			"see runtime-go/rt/live.go and docs for issue #568. Without this guard, "+
+			"every Sky.Live SSE patch that re-emits an unchanged iframe/img/link/script "+
+			"src or href triggers a browser refetch, breaking embedded console / "+
+			"image-heavy apps under any Tick subscription.", wantGuard)
+	}
+}


### PR DESCRIPTION
## Summary

Closes the iframe-reload loop class that pegged tenant Cloud Run instances at "Rate exceeded.". Two commits close two distinct paths through `runtime-go/rt/live.go`'s embedded JS:

**Commit 1 — idempotent `setAttribute` in `__skyApplyPatches`**
Guards `el.setAttribute(k, v)` with a `getAttribute(k) !== v` check. Without it, every SSE attribute-patch that re-emits an unchanged iframe `src` triggers a browser-side navigation. Mirrors the same guard already present in `__skyCopyAttrsExceptAuthority` (the splice path).

**Commit 2 — preserve iframes across `__skyReplaceHTMLPreservingFocus`**
Splices live iframes alongside inputs / textareas / selects so HTML-replace patches don't destroy + recreate the iframe. The live `src` is treated as user-state authority; placeholder contributes non-`src` attrs only.

## Why both

Production logs from `dev.skydeploy.app/_sky/console` (tenant: `sky-diagram`) showed two distinct symptoms:
1. Login POSTs ~4s apart → the attribute-patch path firing on Tick re-renders. Closed by commit 1.
2. Login POSTs **438ms apart** (sub-Tick) → an HTML-replace patch destroying and recreating the iframe. Closed by commit 2.

Together they hit the bug from both sides. With both shipped, no Sky.Live diff round — whether attrs-only or full-subtree HTML — can cause an iframe to navigate to its existing URL.

## Same class also closes
- `<img src>` spurious refetches under Tick re-renders
- `<link href>` stylesheet rebuilds
- `<script src>` re-executes (browser-dependent)
- Embedded console / app-preview iframes losing scroll, SSE, cookies on Tick

## Test plan
- [x] `TestLiveJS_IdempotentSetAttributeGuard` — pins the attribute-patch guard
- [x] `TestLiveJS_IframePreservedAcrossHTMLReplace` — pins the iframe splice + src-strip
- [x] `go test ./rt/` Sky.Live suite — green
- [ ] CI: full `cabal test` + example sweep + Playwright via `verify-all-web.sh`
- [ ] Post-merge manual on `dev.skydeploy.app/_sky/console`: open Console tab, leave for 2 minutes → confirm tenant Cloud Run logs show **zero** repeat `/_sky/console/_login` POSTs after the initial handshake (pre-fix: one every 4-5s + occasional sub-second bursts).

Pairs with [anzellai/skydeploy#5](https://github.com/anzellai/skydeploy/pull/5) (Tick suppressed on Console tab — belt-and-braces).