### PR TITLE
stdlib: annotate Std.Ui.dispatchTag with its inferred signature

### DIFF
--- a/sky-stdlib/Std/Ui.sky
+++ b/sky-stdlib/Std/Ui.sky
@@ -2223,6 +2223,7 @@ locationCss loc =
 -- Dispatch to the right Std.Html constructor by tag name. <img>
 -- is void (no children); other tags take children unchanged.
 -- Unknown tags fall back to <div>.
+dispatchTag : String -> List (Attr.Attribute msg) -> List (Html.Html msg) -> Html.Html msg
 dispatchTag tag attrs children =
     if tag == "a" then
         Html.a attrs children


### PR DESCRIPTION
Adds an explicit type signature to `Std.Ui.dispatchTag` (the tag-string → `Std.Html` constructor dispatcher):

```elm
dispatchTag : String -> List (Attr.Attribute msg) -> List (Html.Html msg) -> Html.Html msg
```

**Motivation** — `dispatchTag` was the only unannotated top-level binding in `Std.Ui`.

**Backend-neutral and Go-safe.** The annotation is exactly the type HM already infers — it matches the shape of every `Std.Html` builder `dispatchTag` forwards to (`a : List (Attribute msg) -> List (Html msg) -> Html msg`). Writing down a type the checker already agrees with does not change Go codegen or any runtime behavior; it's pure stdlib documentation that also happens to unblock the experimental backend.

Thanks, @anzellai 
