### PR TITLE
stdlib: annotate Sky.Core.{List,Maybe,Result,Basics} + Sky.Test top-level bindings

### DIFF
--- a/sky-stdlib/Sky/Core/Basics.sky
+++ b/sky-stdlib/Sky/Core/Basics.sky
@@ -16,30 +16,36 @@ module Sky.Core.Basics exposing
     )
 
 
+identity : a -> a
 identity x =
     x
 
 
+always : a -> b -> a
 always x _ =
     x
 
 
+not : Bool -> Bool
 not b =
     case b of
         True -> False
         False -> True
 
 
+fst : ( a, b ) -> a
 fst t =
     case t of
         (a, _) -> a
 
 
+snd : ( a, b ) -> b
 snd t =
     case t of
         (_, b) -> b
 
 
+clamp : Int -> Int -> Int -> Int
 clamp lo hi x =
     if x < lo then
         lo

--- a/sky-stdlib/Sky/Core/List.sky
+++ b/sky-stdlib/Sky/Core/List.sky
@@ -41,12 +41,14 @@ module Sky.Core.List exposing
     )
 
 
+map : (a -> b) -> List a -> List b
 map fn list =
     case list of
         [] -> []
         (x :: rest) -> fn x :: map fn rest
 
 
+filter : (a -> Bool) -> List a -> List a
 filter pred list =
     case list of
         [] -> []
@@ -57,6 +59,7 @@ filter pred list =
                 filter pred rest
 
 
+any : (a -> Bool) -> List a -> Bool
 any pred list =
     case list of
         [] -> False
@@ -67,6 +70,7 @@ any pred list =
                 any pred rest
 
 
+all : (a -> Bool) -> List a -> Bool
 all pred list =
     case list of
         [] -> True
@@ -77,6 +81,7 @@ all pred list =
                 False
 
 
+find : (a -> Bool) -> List a -> Maybe a
 find pred list =
     case list of
         [] -> Nothing
@@ -87,72 +92,85 @@ find pred list =
                 find pred rest
 
 
+foldl : (a -> b -> b) -> b -> List a -> b
 foldl fn acc list =
     case list of
         [] -> acc
         (x :: rest) -> foldl fn (fn x acc) rest
 
 
+foldr : (a -> b -> b) -> b -> List a -> b
 foldr fn acc list =
     case list of
         [] -> acc
         (x :: rest) -> fn x (foldr fn acc rest)
 
 
+concatMap : (a -> List b) -> List a -> List b
 concatMap fn list =
     case list of
         [] -> []
         (x :: rest) -> append (fn x) (concatMap fn rest)
 
 
+indexedMap : (Int -> a -> b) -> List a -> List b
 indexedMap fn list =
     indexedMapHelp fn 0 list
 
 
+indexedMapHelp : (Int -> a -> b) -> Int -> List a -> List b
 indexedMapHelp fn i list =
     case list of
         [] -> []
         (x :: rest) -> fn i x :: indexedMapHelp fn (i + 1) rest
 
 
+isEmpty : List a -> Bool
 isEmpty list =
     case list of
         [] -> True
         _ -> False
 
 
+length : List a -> Int
 length list =
     case list of
         [] -> 0
         (_ :: rest) -> 1 + length rest
 
 
+head : List a -> Maybe a
 head list =
     case list of
         [] -> Nothing
         (x :: _) -> Just x
 
 
+tail : List a -> Maybe (List a)
 tail list =
     case list of
         [] -> Nothing
         (_ :: rest) -> Just rest
 
 
+cons : a -> List a -> List a
 cons x list =
     x :: list
 
 
+reverse : List a -> List a
 reverse list =
     reverseHelp list []
 
 
+reverseHelp : List a -> List a -> List a
 reverseHelp list acc =
     case list of
         [] -> acc
         (x :: rest) -> reverseHelp rest (x :: acc)
 
 
+take : Int -> List a -> List a
 take n list =
     if n <= 0 then
         []
@@ -162,6 +180,7 @@ take n list =
             (x :: rest) -> x :: take (n - 1) rest
 
 
+drop : Int -> List a -> List a
 drop n list =
     if n <= 0 then
         list
@@ -171,18 +190,21 @@ drop n list =
             (_ :: rest) -> drop (n - 1) rest
 
 
+append : List a -> List a -> List a
 append xs ys =
     case xs of
         [] -> ys
         (x :: rest) -> x :: append rest ys
 
 
+concat : List (List a) -> List a
 concat lists =
     case lists of
         [] -> []
         (xs :: rest) -> append xs (concat rest)
 
 
+member : a -> List a -> Bool
 member x list =
     case list of
         [] -> False
@@ -193,6 +215,7 @@ member x list =
                 member x rest
 
 
+range : Int -> Int -> List Int
 range lo hi =
     if lo > hi then
         []
@@ -200,6 +223,7 @@ range lo hi =
         lo :: range (lo + 1) hi
 
 
+zip : List a -> List b -> List ( a, b )
 zip xs ys =
     case xs of
         [] -> []

--- a/sky-stdlib/Sky/Core/Maybe.sky
+++ b/sky-stdlib/Sky/Core/Maybe.sky
@@ -21,24 +21,28 @@ module Sky.Core.Maybe exposing
     )
 
 
+withDefault : a -> Maybe a -> a
 withDefault def m =
     case m of
         Just x -> x
         Nothing -> def
 
 
+map : (a -> b) -> Maybe a -> Maybe b
 map fn m =
     case m of
         Just x -> Just (fn x)
         Nothing -> Nothing
 
 
+andThen : (a -> Maybe b) -> Maybe a -> Maybe b
 andThen fn m =
     case m of
         Just x -> fn x
         Nothing -> Nothing
 
 
+map2 : (a -> b -> c) -> Maybe a -> Maybe b -> Maybe c
 map2 fn ma mb =
     case ma of
         Just a ->
@@ -48,6 +52,7 @@ map2 fn ma mb =
         Nothing -> Nothing
 
 
+map3 : (a -> b -> c -> d) -> Maybe a -> Maybe b -> Maybe c -> Maybe d
 map3 fn ma mb mc =
     case ma of
         Just a ->
@@ -60,6 +65,7 @@ map3 fn ma mb mc =
         Nothing -> Nothing
 
 
+map4 : (a -> b -> c -> d -> e) -> Maybe a -> Maybe b -> Maybe c -> Maybe d -> Maybe e
 map4 fn ma mb mc md =
     case ma of
         Just a ->
@@ -75,6 +81,7 @@ map4 fn ma mb mc md =
         Nothing -> Nothing
 
 
+map5 : (a -> b -> c -> d -> e -> f) -> Maybe a -> Maybe b -> Maybe c -> Maybe d -> Maybe e -> Maybe f
 map5 fn ma mb mc md me =
     case ma of
         Just a ->
@@ -93,6 +100,7 @@ map5 fn ma mb mc md me =
         Nothing -> Nothing
 
 
+andMap : Maybe a -> Maybe (a -> b) -> Maybe b
 andMap ma mfn =
     case mfn of
         Just fn ->
@@ -102,6 +110,7 @@ andMap ma mfn =
         Nothing -> Nothing
 
 
+combine : List (Maybe a) -> Maybe (List a)
 combine maybes =
     case maybes of
         [] -> Just []
@@ -114,12 +123,14 @@ combine maybes =
                 Nothing -> Nothing
 
 
+isJust : Maybe a -> Bool
 isJust m =
     case m of
         Just _ -> True
         Nothing -> False
 
 
+isNothing : Maybe a -> Bool
 isNothing m =
     case m of
         Just _ -> False

--- a/sky-stdlib/Sky/Core/Result.sky
+++ b/sky-stdlib/Sky/Core/Result.sky
@@ -21,30 +21,35 @@ module Sky.Core.Result exposing
     )
 
 
+withDefault : a -> Result e a -> a
 withDefault def r =
     case r of
         Ok x -> x
         Err _ -> def
 
 
+map : (a -> b) -> Result e a -> Result e b
 map fn r =
     case r of
         Ok x -> Ok (fn x)
         Err e -> Err e
 
 
+andThen : (a -> Result e b) -> Result e a -> Result e b
 andThen fn r =
     case r of
         Ok x -> fn x
         Err e -> Err e
 
 
+mapError : (e1 -> e2) -> Result e1 a -> Result e2 a
 mapError fn r =
     case r of
         Ok x -> Ok x
         Err e -> Err (fn e)
 
 
+map2 : (a -> b -> c) -> Result e a -> Result e b -> Result e c
 map2 fn ra rb =
     case ra of
         Ok a ->
@@ -54,6 +59,7 @@ map2 fn ra rb =
         Err e -> Err e
 
 
+map3 : (a -> b -> c -> d) -> Result e a -> Result e b -> Result e c -> Result e d
 map3 fn ra rb rc =
     case ra of
         Ok a ->
@@ -66,6 +72,7 @@ map3 fn ra rb rc =
         Err e -> Err e
 
 
+map4 : (a -> b -> c -> d -> f) -> Result e a -> Result e b -> Result e c -> Result e d -> Result e f
 map4 fn ra rb rc rd =
     case ra of
         Ok a ->
@@ -81,6 +88,7 @@ map4 fn ra rb rc rd =
         Err e -> Err e
 
 
+map5 : (a -> b -> c -> d -> f -> g) -> Result e a -> Result e b -> Result e c -> Result e d -> Result e f -> Result e g
 map5 fn ra rb rc rd re =
     case ra of
         Ok a ->
@@ -99,6 +107,7 @@ map5 fn ra rb rc rd re =
         Err err -> Err err
 
 
+andMap : Result e a -> Result e (a -> b) -> Result e b
 andMap ra rfn =
     case rfn of
         Ok fn ->
@@ -108,6 +117,7 @@ andMap ra rfn =
         Err e -> Err e
 
 
+combine : List (Result e a) -> Result e (List a)
 combine results =
     case results of
         [] -> Ok []

--- a/sky-stdlib/Sky/Test.sky
+++ b/sky-stdlib/Sky/Test.sky
@@ -300,6 +300,7 @@ debugShow v =
 -- and be built with `sky build` or `sky run`. Exits with status 0
 -- when every test passes, 1 when any test fails. `sky test` does
 -- the equivalent via a synthesised wrapper module.
+runMain : List Test -> a
 runMain tests =
     let
         results = run tests


### PR DESCRIPTION
## Summary
- Follow-up to PR #129 (Std.Ui.dispatchTag annotation)
- Audit found Std.Ui + every Std.Ui.* sub-module already fully annotated; gap is in the foundational Sky.Core modules
- Adds HM-inferred type signatures to 52 top-level bindings across 5 modules

## Motivation
These are the most widely-imported stdlib modules. Annotating them helps LSP hover surface real types without re-running the solver, and unblocks experimental backends (Arthur's Rust port) that walk surface signatures rather than re-running inference.

## Coverage
| Module | Added | Bindings |
|---|---|---|
| Sky.Core.List | 24 | map / filter / any / all / find / foldl / foldr / concatMap / indexedMap / indexedMapHelp / isEmpty / length / head / tail / cons / reverse / reverseHelp / take / drop / append / concat / member / range / zip |
| Sky.Core.Maybe | 11 | withDefault / map / andThen / map2..5 / andMap / combine / isJust / isNothing |
| Sky.Core.Result | 10 | withDefault / map / andThen / mapError / map2..5 / andMap / combine |
| Sky.Core.Basics | 6 | identity / always / not / fst / snd / clamp |
| Sky.Test | 1 | runMain |

## Test plan
- [x] Each annotation matches what the HM solver was inferring (verified via `sky build` typechecks clean)
- [x] Byte-identical Go codegen verified on examples/26-ui-showcase (Std.Ui-heavy, List/Maybe/Result HOFs) and examples/06-json (Maybe/Result/Basics-heavy)
- [x] Full example sweep — 26/26 build clean
- [x] No signature changed in polymorphism or runtime shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)