### PR TITLE
feat(codegen): Stage C curried-shape lambda lowering (#590)

### DIFF
--- a/runtime-go/rt/console_app/main.go
+++ b/runtime-go/rt/console_app/main.go
@@ -3430,7 +3430,15 @@ func HubStore_hubStore(dbPath string) State_Store_R {
 		return rt.TaskCoerceT[Sky_Core_Error_Error, []State_ErrorRow_R](rt.Hub_readErrors(dbPath))
 	}, ReadFilteredErrors: func(svc string) rt.SkyTask[Sky_Core_Error_Error, []State_ErrorRow_R] {
 		return rt.TaskCoerceT[Sky_Core_Error_Error, []State_ErrorRow_R](rt.Hub_readFilteredErrors(dbPath, svc))
-	}, ReadFilteredLogs: rt.Coerce[func(string) func(State_LogFilter_R) rt.SkyTask[Sky_Core_Error_Error, []State_LogEntry_R]](func(svc any) any { return func(filter any) any { return rt.Hub_readFilteredLogs(dbPath, svc, filter) } }), ReadFilteredMetrics: func(svc string) rt.SkyTask[Sky_Core_Error_Error, []State_MetricRow_R] {
+	}, ReadFilteredLogs: func(_lp_svc string) func(State_LogFilter_R) rt.SkyTask[Sky_Core_Error_Error, []State_LogEntry_R] {
+		svc := _lp_svc
+		_ = svc
+		return func(_lp_filter State_LogFilter_R) rt.SkyTask[Sky_Core_Error_Error, []State_LogEntry_R] {
+			filter := _lp_filter
+			_ = filter
+			return rt.TaskCoerceT[Sky_Core_Error_Error, []State_LogEntry_R](rt.Hub_readFilteredLogs(dbPath, svc, filter))
+		}
+	}, ReadFilteredMetrics: func(svc string) rt.SkyTask[Sky_Core_Error_Error, []State_MetricRow_R] {
 		return rt.TaskCoerceT[Sky_Core_Error_Error, []State_MetricRow_R](rt.Hub_readFilteredMetrics(dbPath, svc))
 	}, ReadFilteredTraces: func(svc string) rt.SkyTask[Sky_Core_Error_Error, []State_TraceRow_R] {
 		return rt.TaskCoerceT[Sky_Core_Error_Error, []State_TraceRow_R](rt.Hub_readFilteredTraces(dbPath, svc))
@@ -6827,9 +6835,15 @@ func httpStore(parent string) State_Store_R {
 		return rt.TaskCoerceT[Sky_Core_Error_Error, []State_ErrorRow_R](fetchErrors(rt.CoerceString(parent)))
 	}, ReadFilteredErrors: func(_svc string) rt.SkyTask[Sky_Core_Error_Error, []State_ErrorRow_R] {
 		return rt.TaskCoerceT[Sky_Core_Error_Error, []State_ErrorRow_R](fetchErrors(rt.CoerceString(parent)))
-	}, ReadFilteredLogs: rt.Coerce[func(string) func(State_LogFilter_R) rt.SkyTask[Sky_Core_Error_Error, []State_LogEntry_R]](func(_svc any) any {
-		return func(filter any) any { return fetchLogs(parent, rt.Coerce[State_LogFilter_R](filter)) }
-	}), ReadFilteredMetrics: func(_svc string) rt.SkyTask[Sky_Core_Error_Error, []State_MetricRow_R] {
+	}, ReadFilteredLogs: func(_lp__svc string) func(State_LogFilter_R) rt.SkyTask[Sky_Core_Error_Error, []State_LogEntry_R] {
+		_svc := _lp__svc
+		_ = _svc
+		return func(_lp_filter State_LogFilter_R) rt.SkyTask[Sky_Core_Error_Error, []State_LogEntry_R] {
+			filter := _lp_filter
+			_ = filter
+			return rt.TaskCoerceT[Sky_Core_Error_Error, []State_LogEntry_R](fetchLogs(parent, rt.Coerce[State_LogFilter_R](filter)))
+		}
+	}, ReadFilteredMetrics: func(_svc string) rt.SkyTask[Sky_Core_Error_Error, []State_MetricRow_R] {
 		return rt.TaskCoerceT[Sky_Core_Error_Error, []State_MetricRow_R](fetchMetrics(rt.CoerceString(parent)))
 	}, ReadFilteredTraces: func(_svc string) rt.SkyTask[Sky_Core_Error_Error, []State_TraceRow_R] {
 		return rt.TaskCoerceT[Sky_Core_Error_Error, []State_TraceRow_R](fetchTraces(rt.CoerceString(parent)))

--- a/sky-compiler.cabal
+++ b/sky-compiler.cabal
@@ -373,6 +373,7 @@ test-suite sky-tests
       Sky.Build.PartialKernelAppSpec
       Sky.Build.PartialUserHofSpec
       Sky.Build.HofTypedMsgSpec
+      Sky.Build.CurriedLambdaStageCSpec
       Sky.Build.CoerceArgParametricSpec
       Sky.Build.UnannotatedParametricCfgViewSpec
       Sky.Build.UnannotatedParametricCfgUserHelperSpec

--- a/src/Sky/Build/Compile.hs
+++ b/src/Sky/Build/Compile.hs
@@ -7252,6 +7252,52 @@ exprToGoExpectGo goRendering e@(A.At _ expr)
             , all (/= "any") paramTys -> do
                 lowerTypedLambda pats paramTys retTy body
 
+        -- #590 — Stage C curried-shape arm.  When the slot type is
+        -- `func(T1) func(T2) ... func(TN) R` (a curried Go function)
+        -- AND the Sky lambda has N patterns, peel the curried shape
+        -- with `splitCurriedFuncTypeStr` and emit each level with its
+        -- typed param via `curryLambdaPatTyped[Pre]`.  Mirrors the
+        -- working `coerceFallback` site at Compile.hs:9364 and
+        -- `kernelCoerceArg` at 10190.  Pre-fix, multi-arg Sky lambdas
+        -- at curried HOF call sites (e.g. `\t acc -> ...` against
+        -- foldl's `(a -> b -> b)`) fell through to the generic
+        -- `coerceReturnExprT` path and emitted `func(any) func(any) R`
+        -- — the `acc` param stayed `any` even when the slot pinned it
+        -- to a concrete type via the surrounding function's generic
+        -- substitution.  Go then rejected the call at type-check time
+        -- when the lambda's emitted return-type (concretely typed via
+        -- the body's leaf expression) conflicted with the unrefined
+        -- `any` param.
+        Can.Lambda pats body
+            | length pats > 1
+            , (inputTypes, finalRet0) <-
+                splitCurriedFuncTypeStr (length pats) goRendering
+            , length inputTypes == length pats
+            , length inputTypes > 0
+            , all (/= "any") inputTypes
+            , all isEmittableGoType inputTypes ->
+                let finalRet =
+                        if finalRet0 == "any"
+                            then case inferGoType
+                                    (Rec._cg_solvedTypes getCgEnv)
+                                    body of
+                                "any" -> "any"
+                                concrete -> concrete
+                            else finalRet0
+                    skyTys = map goTypeStrToSkyType inputTypes
+                    bindings = patVarTypes pats skyTys
+                    bodyPreTyped = isEmittableGoType finalRet
+                    rawBody =
+                        if bodyPreTyped
+                            then exprToGoExpectGo finalRet body
+                            else exprToGo body
+                    body' = withScopedLambdaTypes bindings rawBody
+                in if bodyPreTyped
+                    then curryLambdaPatTypedPre inputTypes finalRet
+                            pats body'
+                    else curryLambdaPatTyped inputTypes finalRet
+                            pats body'
+
         -- v0.15 Stage C.2 — type-directed list literal.
         --
         -- When `goRendering` parses as `[]T`, each list element is

--- a/test/Sky/Build/CurriedLambdaStageCSpec.hs
+++ b/test/Sky/Build/CurriedLambdaStageCSpec.hs
@@ -1,0 +1,82 @@
+module Sky.Build.CurriedLambdaStageCSpec (spec) where
+
+import Test.Hspec
+import System.Directory (getCurrentDirectory, createDirectoryIfMissing,
+                         copyFile, doesFileExist, listDirectory, doesDirectoryExist)
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import System.Process (readCreateProcessWithExitCode, proc, CreateProcess(..))
+import System.Exit (ExitCode(..))
+import Data.List (isInfixOf)
+
+
+findSky :: IO FilePath
+findSky = do
+    cwd <- getCurrentDirectory
+    let c = cwd </> "sky-out" </> "sky"
+    ok <- doesFileExist c
+    if ok then return c else fail ("missing: " ++ c)
+
+
+copyTree :: FilePath -> FilePath -> IO ()
+copyTree src dst = do
+    createDirectoryIfMissing True dst
+    entries <- listDirectory src
+    mapM_ (\e -> do
+        let s = src </> e
+            d = dst </> e
+        isF <- doesFileExist s
+        if isF
+            then copyFile s d
+            else do
+                isD <- doesDirectoryExist s
+                if isD then copyTree s d else return ()) entries
+
+
+spec :: Spec
+spec = do
+    describe "#590 Stage C curried-shape lambda lowering" $ do
+        it "compiles a multi-arg lambda at a curried Int->Int->Int slot" $ do
+            -- Pre-fix this fixture failed `go build` because the
+            -- lambda's inner func returned `any` while the slot's
+            -- tail required `int`.  Post-fix the typed Stage C
+            -- arm emits `func(_lp_x int) func(int) int` end-to-end.
+            sky <- findSky
+            cwd <- getCurrentDirectory
+            let fixtureRoot = cwd </> "test" </> "fixtures"
+                                  </> "curried-lambda-stage-c"
+            withSystemTempDirectory "sky-csc" $ \tmp -> do
+                copyTree fixtureRoot tmp
+                let cp = (proc sky ["build", "src/Main.sky"])
+                          { cwd = Just tmp }
+                (ec, out, err) <- readCreateProcessWithExitCode cp ""
+                let combined = out ++ err
+                ec `shouldBe` ExitSuccess
+                ("Build complete" `isInfixOf` combined) `shouldBe` True
+
+        it "emits typed param shape, not func(any) any widening" $ do
+            -- Inspect the emitted Go.  The Stage C curried arm
+            -- routes through `curryLambdaPatTyped[Pre]` whose
+            -- per-step param idents are prefixed `_lp_`.  We
+            -- assert the typed shape is present AND the legacy
+            -- `func(x any) any { return func(y any) any` shape is
+            -- gone for this lambda.
+            sky <- findSky
+            cwd <- getCurrentDirectory
+            let fixtureRoot = cwd </> "test" </> "fixtures"
+                                  </> "curried-lambda-stage-c"
+            withSystemTempDirectory "sky-csc-emit" $ \tmp -> do
+                copyTree fixtureRoot tmp
+                let cp = (proc sky ["build", "src/Main.sky"])
+                          { cwd = Just tmp }
+                _ <- readCreateProcessWithExitCode cp ""
+                body <- readFile (tmp </> "sky-out" </> "main.go")
+                -- Typed shape present: the lambda's first param
+                -- binds via the `_lp_<name>` convention used by
+                -- `curryLambdaPatTyped[Pre]`.
+                ("_lp_x int" `isInfixOf` body) `shouldBe` True
+                -- And the body's inner step is typed too.
+                ("_lp_y int" `isInfixOf` body) `shouldBe` True
+                -- Helper signature stays typed.
+                ("f func(int) func(int) int" `isInfixOf` body)
+                    `shouldBe` True

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -95,6 +95,7 @@ import qualified Sky.Build.PointFreePolyAliasSpec
 import qualified Sky.Build.PartialKernelAppSpec
 import qualified Sky.Build.PartialUserHofSpec
 import qualified Sky.Build.HofTypedMsgSpec
+import qualified Sky.Build.CurriedLambdaStageCSpec
 import qualified Sky.Build.CoerceArgParametricSpec
 import qualified Sky.Build.UnannotatedParametricCfgViewSpec
 import qualified Sky.Build.LiveApiHandlerShapeSpec
@@ -574,6 +575,14 @@ allSpecs fastMode = do
     -- the inner-function return as `any`, breaking helpers with typed
     -- (String -> Msg) callbacks. Now routes via typeStrWithAliasesReg.
     describeT "Sky.Build.HofTypedMsg"        Sky.Build.HofTypedMsgSpec.spec
+    -- #590 Stage C — multi-arg Sky lambdas flowing into a curried
+    -- Go callback slot (`func(T1) func(T2) ... R`) used to fall
+    -- through the type-directed lambda lowerer and emit
+    -- `func(x any) any { return func(y any) any { ... } }` wrapped
+    -- in `rt.Coerce[...]`. Stage C peels the curried shape and
+    -- emits each level typed via `curryLambdaPatTyped[Pre]`.
+    describeT "Sky.Build.CurriedLambdaStageC"
+        Sky.Build.CurriedLambdaStageCSpec.spec
     -- v0.15.x hardening / Gap A1 / Plan Item P1 — coerceArg's
     -- parametric-alias short-circuit was gated on `goExprGoType e`
     -- returning Just. For let-bound polymorphic-call results the

--- a/test/fixtures/curried-lambda-stage-c/sky.toml
+++ b/test/fixtures/curried-lambda-stage-c/sky.toml
@@ -1,0 +1,6 @@
+name = "curried-lambda-stage-c"
+version = "0.0.0"
+entry = "src/Main.sky"
+
+[source]
+root = "src"

--- a/test/fixtures/curried-lambda-stage-c/src/Main.sky
+++ b/test/fixtures/curried-lambda-stage-c/src/Main.sky
@@ -1,0 +1,38 @@
+module Main exposing (main)
+
+{-|
+Regression for #590 — Stage C curried-shape lambda lowering.
+
+Pre-fix, a multi-arg Sky lambda flowing into a curried Go callback
+slot (`func(T1) func(T2) ... R`) fell through the type-directed
+lambda lowerer and emitted `func(x any) any { return func(y any)
+any { ... } }` wrapped in `rt.Coerce[...]`.  When the body's leaf
+expression had a concrete return type (here `Int` via `(+)`), Go
+rejected the call because the lambda's inner func returned `any`
+while the slot's tail required `int`.
+
+Post-fix: when the slot type is a curried `func(T1) func(T2) ...
+func(TN) R` AND the Sky lambda has N patterns, `splitCurried-
+FuncTypeStr` peels each level and `curryLambdaPatTyped[Pre]`
+emits a typed shape for every step — no `any/any` widening, no
+`rt.Coerce` wrap.
+-}
+
+import Sky.Core.Prelude exposing (..)
+import Std.Log exposing (println)
+
+
+-- Helper with a curried, fully-typed callback param.  Pre-fix
+-- the multi-arg lambda at the call site forced `func(any) func(any)
+-- any` here; post-fix it emits the typed shape end-to-end.
+helper : (Int -> Int -> Int) -> Int -> Int -> Int
+helper f a b =
+    f a b
+
+
+main =
+    let
+        result =
+            helper (\x y -> x + y) 2 3
+    in
+        println (String.fromInt result)


### PR DESCRIPTION
## Summary

- **#590 close** — multi-arg Sky lambdas at a curried Go callback slot (`func(T1) func(T2) ... R`) now emit fully-typed end-to-end instead of falling through to `func(x any) any { return func(y any) any { … } }` wrapped in `rt.Coerce[…]`.
- New arm in `exprToGoExpectGo`: when `goRendering` parses as a curried function via `splitCurriedFuncTypeStr` and the Sky lambda has matching pattern arity, peel each level and emit typed via `curryLambdaPatTyped[Pre]` — mirroring the working `coerceFallback` site at Compile.hs:9364 and `kernelCoerceArg` at 10190.
- Regression spec + fixture asserting both successful `go build` and the typed `_lp_x int` / `_lp_y int` / `f func(int) func(int) int` shapes in emitted Go.

## What this fixes

The pre-fix shape that triggered the dominant symptom:

```go
// before — Go rejects: cannot use any as int in return statement
rt.Coerce[func(string) func(rt.SkyResult[…, string]) string](
    func(d any) any { return func(r any) any { … } })
```

```go
// after — Stage C arm fires, typed end-to-end
func(_lp_d string) func(rt.SkyResult[…, string]) string {
    d := _lp_d; _ = d
    return func(_lp_r rt.SkyResult[…, string]) string {
        r := _lp_r; _ = r
        return …
    }
}
```

## Verification

| Example | Result |
|---|---|
| `26-ui-showcase` | **byte-identical** (arm dormant — monomorphised variants already concrete here) |
| `06-json` | **byte-identical** |
| `13-skyshop` | typed shape replaces `func(d any) any { … }` widening on the `Result.withDefault`-style let-bound HOF — canonical #590 repro firing in real user code |
| All 26 examples in `scripts/example-sweep.sh` | clean |
| Targeted spec `-m \"Stage C\"` | 2/2 pass |

## Test plan

- [x] `scripts/example-sweep.sh --build-only` — 26/26 green
- [x] New `Sky.Build.CurriedLambdaStageCSpec` regression — 2/2 pass
- [x] Byte-identity verified on 26-ui-showcase + 06-json against true main baseline
- [x] 13-skyshop diff verified as the intended typed-codegen improvement
- [ ] CI cabal-test full sweep
- [ ] CI example sweep on macOS + Linux

## Notes

This is Phase 2 of the larger plan to close the annotation-vs-HM reconciliation gap (parent task #592). Phase 1 (#591, drop the `hasAnnotation` filter at Compile.hs:1625) and Phase 3 (#589, the 4-site coordinated `depSkyToGoTVars` symmetrisation) follow in their own PRs once the architecture is properly staged.