### PR TITLE
fix(missing) Implement List.sortWith in the Go backend

### DIFF
--- a/runtime-go/rt/list_sortwith_test.go
+++ b/runtime-go/rt/list_sortwith_test.go
@@ -1,0 +1,47 @@
+package rt
+
+import (
+	"reflect"
+	"testing"
+)
+
+// List.sortWith : (a -> a -> Int) -> List a -> List a (Elm's List.sortWith).
+// The comparator returns < 0 when a precedes b, > 0 when it follows, 0 equal.
+
+func TestListSortWithDescending(t *testing.T) {
+	// `\a b -> b - a` — descending numeric order.
+	cmp := func(a, b any) any { return AsInt(b) - AsInt(a) }
+	got := List_sortWith(cmp, []any{1, 4, 2, 5, 3})
+	want := []any{5, 4, 3, 2, 1}
+	if !reflect.DeepEqual(got.([]any), want) {
+		t.Fatalf("sortWith descending = %v, want %v", got, want)
+	}
+}
+
+func TestListSortWithAscending(t *testing.T) {
+	// `\a b -> a - b` — ascending numeric order.
+	cmp := func(a, b any) any { return AsInt(a) - AsInt(b) }
+	got := List_sortWith(cmp, []any{3, 1, 2})
+	want := []any{1, 2, 3}
+	if !reflect.DeepEqual(got.([]any), want) {
+		t.Fatalf("sortWith ascending = %v, want %v", got, want)
+	}
+}
+
+func TestListSortWithStable(t *testing.T) {
+	// All-equal comparator must preserve input order (SliceStable).
+	cmp := func(_, _ any) any { return 0 }
+	got := List_sortWith(cmp, []any{3, 1, 2})
+	want := []any{3, 1, 2}
+	if !reflect.DeepEqual(got.([]any), want) {
+		t.Fatalf("sortWith stable = %v, want %v", got, want)
+	}
+}
+
+func TestListSortWithEmpty(t *testing.T) {
+	cmp := func(a, b any) any { return AsInt(a) - AsInt(b) }
+	got := List_sortWith(cmp, []any{})
+	if len(got.([]any)) != 0 {
+		t.Fatalf("sortWith empty = %v, want []", got)
+	}
+}

--- a/runtime-go/rt/rt.go
+++ b/runtime-go/rt/rt.go
@@ -7139,6 +7139,21 @@ func List_sortBy(keyFn any, list any) any {
 	return result
 }
 
+// List_sortWith(cmp, xs) — stable sort by a custom comparator (Elm's
+// List.sortWith). `cmp a b : Int` returns < 0 when a precedes b, > 0 when it
+// follows, 0 when equal — the same contract as the kernel's type signature
+// (`(a -> a -> Int) -> List a -> List a`) in Sky.Type.Constrain.Expression.
+// SliceStable preserves input order for equal keys (matches List_sortBy).
+func List_sortWith(cmp any, list any) any {
+	items := asList(list)
+	result := make([]any, len(items))
+	copy(result, items)
+	sort.SliceStable(result, func(i, j int) bool {
+		return AsInt(SkyCall(cmp, result[i], result[j])) < 0
+	})
+	return result
+}
+
 // skyLessThan — generic ordering used by List_sortBy. Treats numeric types
 // specially; falls back to lexicographic string compare for everything else.
 func skyLessThan(a, b any) bool {

--- a/src/Sky/Generate/Go/Kernel.hs
+++ b/src/Sky/Generate/Go/Kernel.hs
@@ -175,6 +175,7 @@ registry = Map.fromList
     , (("List", "reverse"),       KernelInfo "rt.List_reverseAny" 1 False)
     , (("List", "sort"),          KernelInfo "rt.List_sort" 1 False)
     , (("List", "sortBy"),        KernelInfo "rt.List_sortBy" 2 False)
+    , (("List", "sortWith"),      KernelInfo "rt.List_sortWith" 2 False)
     , (("List", "member"),        KernelInfo "rt.List_member" 2 False)
     , (("List", "any"),           KernelInfo "rt.List_any" 2 False)
     , (("List", "all"),           KernelInfo "rt.List_all" 2 False)


### PR DESCRIPTION
## Problem

`List.sortWith : (a -> a -> Int) -> List a -> List a` (Elm's custom-comparator
sort) is already typed in the shared type-constrainer
(`Sky.Type.Constrain.Expression`), as a sibling of `List.sort` / `List.sortBy`.
But the Go backend never implemented it — neither the `kernelToGo` mapping in
`src/Sky/Generate/Go/Kernel.hs` nor a `List_sortWith` in `runtime-go/rt`.

So a well-typed program that calls `List.sortWith` passes the shared front-end
type-check, then fails at Go codegen:

```elm
List.sortWith (\a b -> b - a) [ 1, 4, 2, 5, 3 ]   -- type-checks…
```

```
… correct the kernel name in src/Sky/Generate/Go/Kernel.hs /
   src/Sky/Build/Compile.hs's kernelToGo default
```

This is a "type-checks but codegen-fails" gap for a standard list function.

## Fix

- Register the kernel: `(("List", "sortWith"), KernelInfo "rt.List_sortWith" 2 False)`.
- Add the runtime function, mirroring `List_sortBy`: a `sort.SliceStable` keyed
  on the comparator (`cmp a b < 0` ⇒ `a` precedes `b`), so equal elements keep
  their input order.

After the fix the same program builds and runs:

```
sortDesc = [5, 4, 3, 2, 1]
```

## Tests

`runtime-go/rt/list_sortwith_test.go` covers ascending / descending / stable
(equal-key order preserved) / empty. `go test ./rt/` passes.