### PR TITLE
fix(math fns) Math.min/Math.max truncating Float (and String) arguments

### DIFF
--- a/runtime-go/rt/console_app/main.go
+++ b/runtime-go/rt/console_app/main.go
@@ -4100,8 +4100,8 @@ func Std_Ui_Chart_xRangeHelp(lo float64, hi float64, pts []rt.SkyTuple2) rt.SkyT
 			_ = rt.AsTuple2(__sky_h___tco_subject).V1
 			rest := any(rt.AsList(__tco_subject)[1:])
 			_ = rest
-			__tco_t0 := rt.Math_minT(rt.AsInt(lo), rt.AsInt(x))
-			__tco_t1 := rt.Math_maxT(rt.AsInt(hi), rt.AsInt(x))
+			__tco_t0 := rt.Math_min(lo, x)
+			__tco_t1 := rt.Math_max(hi, x)
 			__tco_t2 := rest
 			lo = rt.CoerceFloat(__tco_t0)
 			hi = rt.CoerceFloat(__tco_t1)
@@ -4149,8 +4149,8 @@ func Std_Ui_Chart_yRangeHelp(lo float64, hi float64, pts []rt.SkyTuple2) rt.SkyT
 			_ = y
 			rest := any(rt.AsList(__tco_subject)[1:])
 			_ = rest
-			__tco_t0 := rt.Math_minT(rt.AsInt(lo), rt.AsInt(y))
-			__tco_t1 := rt.Math_maxT(rt.AsInt(hi), rt.AsInt(y))
+			__tco_t0 := rt.Math_min(lo, y)
+			__tco_t1 := rt.Math_max(hi, y)
 			__tco_t2 := rest
 			lo = rt.CoerceFloat(__tco_t0)
 			hi = rt.CoerceFloat(__tco_t1)
@@ -4206,7 +4206,7 @@ func Std_Ui_Chart_xRangeAllHelp(acc rt.SkyTuple2, seriesList []Std_Ui_Chart_Seri
 					_ = blo
 					bhi := rt.AsTuple2(__destruct__).V1
 					_ = bhi
-					return Std_Ui_Chart_xRangeAllHelp(rt.SkyTuple2{V0: rt.Math_minT(rt.AsInt(alo), rt.AsInt(blo)), V1: rt.Math_maxT(rt.AsInt(ahi), rt.AsInt(bhi))}, rt.AsListT[Std_Ui_Chart_Series_R](rest))
+					return Std_Ui_Chart_xRangeAllHelp(rt.SkyTuple2{V0: rt.Math_min(alo, blo), V1: rt.Math_max(ahi, bhi)}, rt.AsListT[Std_Ui_Chart_Series_R](rest))
 				}())
 			}()
 		}
@@ -4259,7 +4259,7 @@ func Std_Ui_Chart_yRangeAllHelp(acc rt.SkyTuple2, seriesList []Std_Ui_Chart_Seri
 					_ = blo
 					bhi := rt.AsTuple2(__destruct__).V1
 					_ = bhi
-					return Std_Ui_Chart_yRangeAllHelp(rt.SkyTuple2{V0: rt.Math_minT(rt.AsInt(alo), rt.AsInt(blo)), V1: rt.Math_maxT(rt.AsInt(ahi), rt.AsInt(bhi))}, rt.AsListT[Std_Ui_Chart_Series_R](rest))
+					return Std_Ui_Chart_yRangeAllHelp(rt.SkyTuple2{V0: rt.Math_min(alo, blo), V1: rt.Math_max(ahi, bhi)}, rt.AsListT[Std_Ui_Chart_Series_R](rest))
 				}())
 			}()
 		}
@@ -4302,7 +4302,7 @@ func Std_Ui_Chart_effectiveYRange(cfg Std_Ui_Chart_Cfg_R, seriesList []Std_Ui_Ch
 				hi := rt.AsTuple2(__destruct__).V1
 				_ = hi
 				return rt.Coerce[rt.SkyTuple2](func() any {
-					lo2 := rt.Math_minT(rt.AsInt(lo), 0.0)
+					lo2 := rt.Math_min(rt.CoerceFloat(lo), 0.0)
 					_ = lo2
 					return func() any {
 						pad := rt.Mul(rt.Sub(hi, lo2), 5.0e-2)
@@ -4741,7 +4741,7 @@ func Std_Ui_Chart_sparkline(cfg Std_Ui_Chart_Cfg_R, values []float64) Std_Ui_Ele
 								ySpan := rt.Sub(yMax, yMin)
 								_ = ySpan
 								return rt.Coerce[Std_Ui_Element](func() Std_Ui_Element {
-									nF := Std_Ui_Chart_intToFloat(rt.CoerceInt(rt.Math_maxT(1, rt.AsInt(rt.Sub(n, 1)))))
+									nF := Std_Ui_Chart_intToFloat(rt.CoerceInt(rt.Math_max(1, rt.CoerceInt(rt.Sub(n, 1)))))
 									_ = nF
 									return rt.Coerce[Std_Ui_Element](func() Std_Ui_Element {
 										projected := Sky_Core_List_indexedMap__Float_Tup2Of_Float_Float(func(_lp_i int) func(float64) rt.SkyTuple2 {
@@ -4824,8 +4824,8 @@ func Std_Ui_Chart_yRangeOfFloatsHelp(lo float64, hi float64, vals []float64) rt.
 			_ = v
 			rest := any(rt.AsList(__tco_subject)[1:])
 			_ = rest
-			__tco_t0 := rt.Math_minT(rt.AsInt(lo), rt.AsInt(v))
-			__tco_t1 := rt.Math_maxT(rt.AsInt(hi), rt.AsInt(v))
+			__tco_t0 := rt.Math_min(lo, v)
+			__tco_t1 := rt.Math_max(hi, v)
 			__tco_t2 := rest
 			lo = rt.CoerceFloat(__tco_t0)
 			hi = rt.CoerceFloat(__tco_t1)

--- a/runtime-go/rt/math_minmax_poly_test.go
+++ b/runtime-go/rt/math_minmax_poly_test.go
@@ -1,0 +1,41 @@
+package rt
+
+import "testing"
+
+// Math.min / Math.max are polymorphic (`a -> a -> a`). They must compare by the
+// VALUE's type, not by truncating to int — a Float `Math.min` over [0.4..1.3]
+// previously collapsed to 0..1 (AsInt), mis-scaling every Std.Ui.Chart.
+
+func TestMathMinMaxFloat(t *testing.T) {
+	if got := Math_min(0.4, 1.3); got != 0.4 {
+		t.Fatalf("Math_min(0.4, 1.3) = %v, want 0.4", got)
+	}
+	if got := Math_max(0.4, 1.3); got != 1.3 {
+		t.Fatalf("Math_max(0.4, 1.3) = %v, want 1.3", got)
+	}
+	// Both < 1 — AsInt would tie at 0 and pick wrong; value-compare is correct.
+	if got := Math_min(0.6, 0.4); got != 0.4 {
+		t.Fatalf("Math_min(0.6, 0.4) = %v, want 0.4 (AsInt-truncation regression)", got)
+	}
+	if got := Math_max(0.6, 0.4); got != 0.6 {
+		t.Fatalf("Math_max(0.6, 0.4) = %v, want 0.6 (AsInt-truncation regression)", got)
+	}
+}
+
+func TestMathMinMaxInt(t *testing.T) {
+	if got := Math_min(3, 7); got != 3 {
+		t.Fatalf("Math_min(3, 7) = %v, want 3", got)
+	}
+	if got := Math_max(3, 7); got != 7 {
+		t.Fatalf("Math_max(3, 7) = %v, want 7", got)
+	}
+}
+
+func TestMathMinMaxString(t *testing.T) {
+	if got := Math_min("apple", "banana"); got != "apple" {
+		t.Fatalf("Math_min(apple, banana) = %v, want apple", got)
+	}
+	if got := Math_max("apple", "banana"); got != "banana" {
+		t.Fatalf("Math_max(apple, banana) = %v, want banana", got)
+	}
+}

--- a/runtime-go/rt/rt.go
+++ b/runtime-go/rt/rt.go
@@ -4670,14 +4670,18 @@ func Math_abs(n any) any {
 	}
 	return x
 }
+// Math.min / Math.max are polymorphic (`a -> a -> a`, "any comparable type" —
+// Sky.Core.Math). Compare via skyLessThan, NOT AsInt: AsInt truncates Floats to
+// Int (so `Math.min` over `[0.4 … 1.3]` collapsed the range to 0..1, mis-scaling
+// every Std.Ui.Chart sparkline/heatmap) and is meaningless for Strings.
 func Math_min(a any, b any) any {
-	if AsInt(a) < AsInt(b) {
+	if skyLessThan(a, b) {
 		return a
 	}
 	return b
 }
 func Math_max(a any, b any) any {
-	if AsInt(a) > AsInt(b) {
+	if skyLessThan(b, a) {
 		return a
 	}
 	return b

--- a/src/Sky/Build/Compile.hs
+++ b/src/Sky/Build/Compile.hs
@@ -8610,8 +8610,12 @@ typedKernelArgCoerce = Map.fromList
     , (("String", "replace"),    ["AsString", "AsString", "AsString"])
     -- Math
     , (("Math",   "abs"),  ["AsInt"])
-    , (("Math",   "min"),  ["AsInt", "AsInt"])
-    , (("Math",   "max"),  ["AsInt", "AsInt"])
+    -- NOTE: Math.min / Math.max are POLYMORPHIC (`a -> a -> a`) — deliberately
+    -- NOT routed to the Int-typed companion here. `AsInt` would truncate Float
+    -- args (mis-scaling every Std.Ui.Chart sparkline/heatmap) and is meaningless
+    -- for Strings. They lower to the polymorphic `rt.Math_min`/`rt.Math_max`
+    -- (which compare via skyLessThan); the use-site coercion narrows the `any`
+    -- result. `abs` stays (its Sky type is `Int -> Int`, so AsInt is correct).
     , (("Math",   "sqrt"), ["AsFloat"])
     , (("Math",   "pow"),  ["AsFloat", "AsFloat"])
     , (("Math",   "floor"),["AsFloat"])
@@ -8723,7 +8727,9 @@ typedKernelLiterals = Set.fromList
     , ("String", "contains"),   ("String", "startsWith"), ("String", "endsWith")
     , ("String", "append"),     ("String", "fromInt"),    ("String", "fromFloat")
     , ("String", "replace"),    ("String", "slice")
-    , ("Math",   "abs"),        ("Math",   "min"),        ("Math",   "max")
+    -- Math.min / Math.max omitted on purpose: polymorphic (`a -> a -> a`), so the
+    -- Int-typed-literal companion would truncate a Float literal. `abs` is Int-only.
+    , ("Math",   "abs")
     , ("Math",   "sqrt"),       ("Math",   "pow"),        ("Math",   "floor")
     , ("Math",   "ceil"),       ("Math",   "round"),      ("Math",   "sin")
     , ("Math",   "cos"),        ("Math",   "tan"),        ("Math",   "log")
@@ -15745,8 +15751,20 @@ runtimeGoSource = unlines
     , "// ═══════════════════════════════════════════════════════════"
     , ""
     , "func Math_abs(n any) any { x := AsInt(n); if x < 0 { return -x }; return x }"
-    , "func Math_min(a any, b any) any { if AsInt(a) < AsInt(b) { return a }; return b }"
-    , "func Math_max(a any, b any) any { if AsInt(a) > AsInt(b) { return a }; return b }"
+    -- Math.min / Math.max are polymorphic (`a -> a -> a`): compare type-aware, not
+    -- via AsInt (which truncates Floats + is meaningless for Strings). Mirrors the
+    -- embedded runtime's skyLessThan.
+    , "func mathLessAny(a, b any) bool {"
+    , "\tswitch x := a.(type) {"
+    , "\tcase int: if y, ok := b.(int); ok { return x < y }"
+    , "\tcase int64: if y, ok := b.(int64); ok { return x < y }"
+    , "\tcase float64: if y, ok := b.(float64); ok { return x < y }"
+    , "\tcase string: if y, ok := b.(string); ok { return x < y }"
+    , "\t}"
+    , "\treturn fmt.Sprintf(\"%v\", a) < fmt.Sprintf(\"%v\", b)"
+    , "}"
+    , "func Math_min(a any, b any) any { if mathLessAny(a, b) { return a }; return b }"
+    , "func Math_max(a any, b any) any { if mathLessAny(b, a) { return a }; return b }"
     , ""
     , "func Field(record any, field string) any {"
     , "\tv := reflect.ValueOf(record)"


### PR DESCRIPTION
## Problem

`Math.min` / `Math.max` are polymorphic — `a -> a -> a` ("any comparable type",
per `Sky.Core.Math`). But the Go backend coerced their arguments through `AsInt`:

- the typed-companion pass emitted `rt.Math_minT(rt.AsInt(x), rt.AsInt(y))`
  (`typedKernelArgCoerce` + `typedKernelLiterals`), and
- the polymorphic fallback `rt.Math_min` / `rt.Math_max` also compared via `AsInt`.

So a **Float** `Math.min` / `max` **truncated to Int**. The range of `[0.4 … 1.3]`
collapses to `0..1`, which mis-scales every `Std.Ui.Chart` sparkline and heatmap —
the heatmap renders a **single cell** instead of the full grid. String args were
meaningless too.

```elm
-- range computed with Math.min / Math.max over a List Float
Chart.heatmap cfg grid
Chart.sparkline cfg [ 0.4, 0.6, 0.5, 0.8, 0.7, 0.9, 1.0, 0.95, 1.2, 1.15, 1.3 ]
```

### Before / After

<img width="296" height="87" alt="26-sparkline-before-after" src="https://github.com/user-attachments/assets/6353aad5-0b20-455d-b50d-eaa4306c4a9f" />


<img width="1356" height="234" alt="26-heatmap-before-after" src="https://github.com/user-attachments/assets/d3702fef-2cf9-4ac2-9ed5-dc7720551e2c" />



## Fix

1. `rt.Math_min` / `rt.Math_max` compare via `skyLessThan` (the polymorphic
   comparator already used by `List_sortBy`) instead of `AsInt`.
2. Drop `Math.min` / `Math.max` from `typedKernelArgCoerce` + `typedKernelLiterals`
   so they lower to the now-correct polymorphic kernel; the use-site coercion
   narrows the result.
3. Same float/string-aware comparison in the `runtimeGoSource` fallback.

`Math.abs` is intentionally left untouched — its Sky type is `Int -> Int`, so
`AsInt` is correct.

## Tests

`runtime-go/rt/math_minmax_poly_test.go` covers Float / Int / String `min`/`max`.
`go test ./rt/` passes.

## Related — Elm conformance

`Sky.Core.Math` mirrors Elm's
[`Basics`](https://package.elm-lang.org/packages/elm/core/latest/Basics); this
restores `min` / `max` to Elm's polymorphic `comparable -> comparable -> comparable`.
It may be worth a broader review of Sky's **conformance to Elm `Basics`** — for
example, Elm's `abs : number -> number` accepts `Float`, whereas Sky's `abs` is
currently `Int -> Int`.
