### PR TITLE
feat(canonicalise): explicit alias wins over bare-import auto-qualifier

### DIFF
--- a/src/Sky/Canonicalise/Module.hs
+++ b/src/Sky/Canonicalise/Module.hs
@@ -260,7 +260,28 @@ canonicaliseImpl deps ffiKernelFns kernelMods srcMod =
         -- v0.17 close P1 step 5 — thread FFI kernel functions
         -- map into 'processImport' so 'kernelVarsFor' reads the
         -- value channel instead of the legacy IORef.
-        env1 = foldl (processImport ffiKernelFns kernelMods deps modName)
+        -- v0.17.5 — explicit-alias-wins rule.  Collect every import
+        -- whose qualifier is an EXPLICIT `as X` alias (paired with
+        -- the canonical import path it aliases).  A bare
+        -- `import M exposing (…)` whose last-segment default matches
+        -- an explicit alias for a DIFFERENT module suppresses its
+        -- own auto-qualifier registration (the explicit alias wins).
+        -- Unqualified `exposing` names still land in scope; only the
+        -- last-segment shortcut is dropped.  Same-module double
+        -- imports (e.g. `Std.Ui as Ui` + `Std.Ui exposing (Element)`)
+        -- are unaffected because their explicit + implicit qualifiers
+        -- resolve to the SAME canonical module.
+        explicitAliasClaims :: Map.Map String String
+        explicitAliasClaims = Map.fromList
+            [ (alias, path)
+            | imp <- Src._imports srcMod
+            , Just alias <- [Src._importAlias imp]
+            , let segs = case Src._importName imp of A.At _ s -> s
+                  path = ModuleName.joinWith "." segs
+            ]
+
+        env1 = foldl (processImport ffiKernelFns kernelMods deps modName
+                                    explicitAliasClaims)
                      env0 (Src._imports srcMod)
 
         -- Register top-level declarations in env
@@ -478,18 +499,33 @@ processImport
     -- ^ v0.17 close P1 step 6b — merged kernel-modules map.
     -> Map.Map String DepInfo
     -> ModuleName.Canonical
+    -> Map.Map String String
+    -- ^ v0.17.5 — {explicit-alias → aliased-canonical-path} across
+    -- the whole file.  Used to suppress an auto-qualifier when a
+    -- bare `import M exposing (…)`'s last-segment default collides
+    -- with an explicit `as X` binding for a DIFFERENT module.
     -> Env.Env
     -> Src.Import
     -> Env.Env
-processImport ffiKernelFns kernelMods deps _home env imp =
+processImport ffiKernelFns kernelMods deps _home explicitAliasClaims env imp =
     let
         importSegs = case Src._importName imp of A.At _ segs -> segs
         importPath = ModuleName.joinWith "." importSegs
         importMod = ModuleName.Canonical importPath
 
-        qualifier = case Src._importAlias imp of
-            Just alias -> alias
-            Nothing -> last importSegs
+        (qualifier, suppressAutoQualifier) = case Src._importAlias imp of
+            Just alias -> (alias, False)
+            Nothing ->
+                let lastSeg = last importSegs
+                in case Map.lookup lastSeg explicitAliasClaims of
+                    -- Another explicit alias claims this last-segment
+                    -- default AND it points at a different module.
+                    -- Suppress the auto-qualifier — the explicit alias
+                    -- wins.  The bare import's exposing list still
+                    -- flows through unchanged.
+                    Just claimedPath | claimedPath /= importPath ->
+                        (lastSeg, True)
+                    _ -> (lastSeg, False)
 
         -- FFI-over-kernel precedence (2026-04-24): when an import
         -- path matches BOTH a Sky kernel module and a Go FFI dep,
@@ -547,11 +583,19 @@ processImport ffiKernelFns kernelMods deps _home env imp =
                 ]
             _ -> []
 
-        envWithQual = Env.addQualifiedImport qualifier importMod
-            -- v0.17 close P1 step 5 — value-channel read.
-            (if useKernel then kernelVarsFor ffiKernelFns kernelName else depVars)
-            (qualCtors ++ depCtors)
-            env
+        -- v0.17.5 — when the auto-qualifier is suppressed by the
+        -- explicit-alias-wins rule, skip the qualifier binding
+        -- entirely.  Names still land in scope via the exposing
+        -- list below; only `<lastSegment>.foo` becomes unavailable
+        -- (the explicit-alias binding for that qualifier survives
+        -- because we never touched it).
+        envWithQual
+            | suppressAutoQualifier = env
+            | otherwise = Env.addQualifiedImport qualifier importMod
+                -- v0.17 close P1 step 5 — value-channel read.
+                (if useKernel then kernelVarsFor ffiKernelFns kernelName else depVars)
+                (qualCtors ++ depCtors)
+                env
 
         -- P2: the dep's own `exposing` list limits what an importer may
         -- pull in. Build the exported-name set (kernels export everything
@@ -840,7 +884,27 @@ detectImportAliasCollisions
     -- ^ v0.17 close P1 step 6b — merged kernel-modules map.
     -> [Src.Import] -> [String]
 detectImportAliasCollisions kernelMods imps =
-    let -- For each import, derive (qualifier, canonical-source, region, importPath).
+    let -- v0.17.5 — mirror the explicit-alias-wins rule from
+        -- processImport.  A bare import whose last-segment default
+        -- collides with an EXPLICIT alias binding for a different
+        -- module is suppressed at binding time, so it must not count
+        -- toward a collision either.  The gate now fires only on
+        -- genuinely ambiguous shapes:
+        --   * two bare imports auto-registering the SAME
+        --     last-segment for different modules (no explicit alias
+        --     to break the tie)
+        --   * two explicit `as X` aliases both pointing at that
+        --     same `X` for different modules (user error)
+        explicitAliasClaims :: Map.Map String String
+        explicitAliasClaims = Map.fromList
+            [ (alias, path)
+            | imp <- imps
+            , Just alias <- [Src._importAlias imp]
+            , let segs = case Src._importName imp of A.At _ s -> s
+                  path = ModuleName.joinWith "." segs
+            ]
+
+        -- For each import, derive (qualifier, canonical-source, region, importPath).
         -- canonical-source folds kernel modules onto their pseudo-module
         -- name so multiple kernel paths to the same dispatch table don't
         -- count as a collision.
@@ -851,12 +915,23 @@ detectImportAliasCollisions kernelMods imps =
             , let segs = case Src._importName imp of A.At _ s -> s
                   region = case Src._importName imp of A.At r _ -> r
                   importPath = ModuleName.joinWith "." segs
-                  qualifier = case Src._importAlias imp of
-                      Just alias -> alias
-                      Nothing    -> case segs of
-                          [] -> importPath  -- defensive — parser shouldn't allow
-                          _  -> last segs
                   src = Map.findWithDefault importPath importPath kernelMods
+            , (qualifier, isBoundQualifier) <- case Src._importAlias imp of
+                  Just alias -> [(alias, True)]
+                  Nothing    -> case segs of
+                      [] -> [(importPath, True)]  -- defensive
+                      _  ->
+                          let lastSeg = last segs
+                          in case Map.lookup lastSeg explicitAliasClaims of
+                              Just claimedPath | claimedPath /= importPath ->
+                                  -- Auto-qualifier suppressed — the
+                                  -- explicit-alias binding wins.  This
+                                  -- import contributes no qualifier
+                                  -- binding, so cannot participate in
+                                  -- a collision.
+                                  []
+                              _ -> [(lastSeg, True)]
+            , isBoundQualifier
             ]
 
         -- Group entries by qualifier. Earliest-region first per group so
@@ -888,41 +963,17 @@ detectImportAliasCollisions kernelMods imps =
             (_, firstRegion, _) = head sorted
             leader = case firstRegion of
                 A.Region (A.Position r c) _ -> show r ++ ":" ++ show c ++ ": "
-            -- Pick the LAST offending path as the default fix target
-            -- (preserves the user's intent that the first import owns
-            -- the qualifier).
+            -- Suggest aliasing the LAST offender (preserves the intent
+            -- that the first import owns the qualifier).  v0.17.5's
+            -- explicit-alias-wins rule silently resolves the shape
+            -- where ONE side is explicit — so any collision that
+            -- reaches this diagnostic has all-bare offenders.  The
+            -- fix-it points at adding an explicit alias to one side.
             lastPath = case reverse sorted of
                 ((_, _, p):_) -> p
                 _             -> "Other.Mod"
-            -- The offender's canonical import path. If ANOTHER import
-            -- of the same path already exists with an explicit alias,
-            -- the correct fix is to merge the `exposing` list into
-            -- THAT line, not to add a fresh alias — two lines
-            -- importing the same module each contribute a qualifier
-            -- binding, which is what caused the collision. Check the
-            -- LAST offender first, then the first, so the more
-            -- actionable of the two suggestions wins when both sides
-            -- have pre-existing aliases.
-            existingAliasHit = case reverse sorted of
-                ((_, _, p):_) -> case findExistingAlias p of
-                    Just hit -> Just (p, hit)
-                    Nothing  -> case sorted of
-                        ((_, _, p'):_) -> fmap (\h -> (p', h)) (findExistingAlias p')
-                        _ -> Nothing
-                _ -> Nothing
-            suggestion = case existingAliasHit of
-                Just (path, (alias, aliasRegion)) ->
-                    "You already have `import " ++ path ++ " as " ++ alias
-                    ++ "` at " ++ formatPos aliasRegion ++ " — merge the "
-                    ++ "`exposing` list into that line "
-                    ++ "(`import " ++ path ++ " as " ++ alias
-                    ++ " exposing (...)`).  A bare `import " ++ path
-                    ++ " exposing (...)` re-registers `" ++ qualifier
-                    ++ "` as an alias for `" ++ path
-                    ++ "` even when an `as` line exists elsewhere."
-                Nothing ->
-                    "Add `as <Alias>` to one of them, e.g. `import "
-                    ++ lastPath ++ " as " ++ camelCasePath lastPath ++ "`."
+            suggestion = "Add `as <Alias>` to one of them, e.g. `import "
+                ++ lastPath ++ " as " ++ camelCasePath lastPath ++ "`."
             body = "Import error: two imports both bind the qualifier `"
                 ++ qualifier ++ "`:\n"
                 ++ concat
@@ -932,36 +983,6 @@ detectImportAliasCollisions kernelMods imps =
                     ]
                 ++ "  " ++ suggestion
         in leader ++ body
-
-    -- | Look for an import of `targetPath` in the full import list
-    -- that carries an explicit `as X` alias. Used by `formatClash`
-    -- to detect the 3+-import shape:
-    --
-    --     import Std.Db as Db
-    --     import Lib.Db as LibDb      -- ← existing alias for Lib.Db
-    --     import Lib.Db exposing (conn) -- offender that trips D5
-    --
-    -- The user's mental model is often "the second line resolves the
-    -- collision" but Sky's auto-qualifier from the last segment still
-    -- fires on the bare `import Lib.Db exposing (…)`, so the third
-    -- line re-collides with `Std.Db as Db`. Surfacing the pre-existing
-    -- alias in the diagnostic points them straight at the fix.
-    findExistingAlias :: String -> Maybe (String, A.Region)
-    findExistingAlias targetPath =
-        let hits =
-                [ (alias, aliasRegion)
-                | imp <- imps
-                , Just alias <- [Src._importAlias imp]
-                , let A.At aliasRegion segs = Src._importName imp
-                      importPath = ModuleName.joinWith "." segs
-                , importPath == targetPath
-                ]
-        in case hits of
-            (h:_) -> Just h
-            _     -> Nothing
-
-    formatPos :: A.Region -> String
-    formatPos (A.Region (A.Position r c) _) = show r ++ ":" ++ show c
 
     -- "App.State" → "AppState"; "Lib.Internal.Foo" → "LibInternalFoo".
     -- Keeps the alias unique against the dangling last-segment qualifier

--- a/test/Sky/Canonicalise/DualImportCollisionSpec.hs
+++ b/test/Sky/Canonicalise/DualImportCollisionSpec.hs
@@ -169,16 +169,53 @@ spec = describe "Cycle 4 D5: dual-import qualifier collision detection" $ do
                 e `shouldNotSatisfy` ("two imports both bind" `isInfixOf`)
 
 
-    it "diagnostic recognises a pre-existing alias line + suggests merging" $ do
-        -- Real-world 3-import shape hit by a downstream project during
-        -- the v0.17.3 upgrade: the user tries to resolve the collision
-        -- by adding a middle `import Lib.Db as LibDb` line, but the
-        -- last bare `import Lib.Db exposing (conn)` still auto-binds
-        -- `Db` from the last-segment default. Pre-fix diagnostic told
-        -- them to "Add `as <Alias>` to one of them, e.g. `import
-        -- Lib.Db as LibDb`" — which is what they thought they had
-        -- already done. Post-fix diagnostic recognises the existing
-        -- `as LibDb` line and points them at the merge fix.
+    it "explicit alias suppresses a bare import's auto-qualifier (2-line shape)" $ do
+        -- v0.17.5 explicit-alias-wins rule.  When one import gives an
+        -- EXPLICIT `as X` and another bare import's last-segment
+        -- default would ALSO auto-register `X` for a different module,
+        -- the bare's auto-qualifier is suppressed silently.  The
+        -- explicit binding is unambiguous; the user gets what they
+        -- wrote.  Pre-v0.17.5 this shape was E1001.
+        let mainSrc = unlines
+                [ "module Main exposing (main)"
+                , ""
+                , "import Sky.Core.Prelude exposing (..)"
+                , "import Std.Log exposing (println)"
+                , "import Std.Db as Db"
+                , "import Lib.Db exposing (conn)"
+                , ""
+                -- `conn` reaches Lib.Db (unqualified exposing).
+                -- `Db.<x>` would resolve to Std.Db (explicit alias wins).
+                , "main = println conn"
+                ]
+            libDbModule = unlines
+                [ "module Lib.Db exposing (conn, dummy)"
+                , ""
+                , "conn : String"
+                , "conn = \"local://\""
+                , ""
+                , "dummy : Int"
+                , "dummy = 0"
+                ]
+        result <- compileInProcessMulti
+            [ ("src/Main.sky", mainSrc)
+            , ("src/Lib/Db.sky", libDbModule)
+            ]
+        case result of
+            CompileOk _ -> return ()
+            CompileErr e -> do
+                -- The collision gate must NOT fire — explicit wins.
+                e `shouldNotSatisfy` ("two imports both bind" `isInfixOf`)
+                expectationFailure ("expected clean build; got: " ++ e)
+
+
+    it "explicit alias suppresses a bare import's auto-qualifier (3-line shape)" $ do
+        -- Same rule applied to the historical ringfence 3-import
+        -- workaround shape.  Under v0.17.5 the extra `import Lib.Db
+        -- as LibDb` line is optional — the bare `import Lib.Db
+        -- exposing (conn)` no longer collides with `Std.Db as Db`
+        -- either way.  This case documents that the workaround
+        -- continues to compile identically to the 2-line shape above.
         let mainSrc = unlines
                 [ "module Main exposing (main)"
                 , ""
@@ -204,15 +241,37 @@ spec = describe "Cycle 4 D5: dual-import qualifier collision detection" $ do
             , ("src/Lib/Db.sky", libDbModule)
             ]
         case result of
-            CompileOk _ -> expectationFailure "expected dual-import qualifier collision to be rejected"
+            CompileOk _ -> return ()
             CompileErr e -> do
-                -- Still detected as a collision.
+                e `shouldNotSatisfy` ("two imports both bind" `isInfixOf`)
+                expectationFailure ("expected clean build; got: " ++ e)
+
+
+    it "two bare imports auto-registering same qualifier still trip E1001" $ do
+        -- The explicit-alias-wins rule only fires when there IS an
+        -- explicit alias to break the tie.  When BOTH sides are bare,
+        -- the qualifier is genuinely ambiguous and the collision gate
+        -- must still fire (silent miscompile prevention, task #347).
+        let mainSrc = unlines
+                [ "module Main exposing (main)"
+                , ""
+                , "import Sky.Core.Prelude exposing (..)"
+                , "import Std.Log exposing (println)"
+                , "import State"
+                , "import App.State"
+                , ""
+                , "main = println \"x\""
+                ]
+        result <- compileInProcessMulti
+            [ ("src/Main.sky", mainSrc)
+            , ("src/State.sky", stateModule)
+            , ("src/App/State.sky", appStateModule)
+            ]
+        case result of
+            CompileOk _ -> expectationFailure "two bare imports must still trip E1001"
+            CompileErr e -> do
                 e `shouldSatisfy` ("two imports both bind the qualifier" `isInfixOf`)
-                -- Merge suggestion surfaces the pre-existing alias line.
-                e `shouldSatisfy` ("import Lib.Db as LibDb exposing" `isInfixOf`)
-                e `shouldSatisfy` ("You already have" `isInfixOf`)
-                -- Falls through to explaining WHY the workaround failed.
-                e `shouldSatisfy` ("re-registers" `isInfixOf`)
+                e `shouldSatisfy` ("`State`" `isInfixOf`)
 
 
     it "does NOT flag kernel imports that share a kernel pseudo-module" $ do

--- a/test/Sky/Lsp/DiagnosticsSpec.hs
+++ b/test/Sky/Lsp/DiagnosticsSpec.hs
@@ -583,22 +583,20 @@ spec = do
                             let msgs = diagnosticMessages payload
                             msgs `shouldBe` []
 
-        it "dual-import qualifier collision surfaces with merge-into-alias fix-it" $ do
-            -- PR follow-up to task #347 (D5). The canonicaliser diagnostic for
-            -- E1001 dual-import collisions was updated to detect a pre-existing
-            -- `import M as X` line for one of the colliding modules and suggest
-            -- MERGING the exposing list into that line, instead of naively
-            -- proposing another alias. This test pins the improved wording at
-            -- the LSP layer — publishDiagnostics is a straight string pipe from
-            -- canonicaliser errors, so a future refactor that truncates or
-            -- filters diagnostic bodies would silently drop the fix-it hint.
+        it "explicit-alias-wins rule silences the 3-import ringfence shape via LSP" $ do
+            -- v0.17.5 semantic change (successor to the v0.17.4 diagnostic
+            -- polish).  When an explicit `as X` alias claims a qualifier for
+            -- one module and a bare `import Y exposing (…)` would auto-
+            -- register the same last-segment default for another module, the
+            -- bare's auto-qualifier is suppressed silently.  Pre-v0.17.5 the
+            -- same shape produced E1001; post-v0.17.5 the LSP should see
+            -- ZERO diagnostics because the file compiles cleanly.
             --
-            -- Real-world context: a downstream project committed the exact
-            -- 3-import shape below during a v0.17.3 upgrade, misled by the
-            -- pre-fix diagnostic's generic "Add `as <Alias>`" suggestion
-            -- (which is what they already had on line 6). The new hint
-            -- surfaces the existing alias line + the reason a bare
-            -- `exposing (…)` still trips E1001.
+            -- Historical context: this exact shape shipped in a downstream
+            -- project during the v0.17.3 upgrade under the workaround
+            -- `import Lib.Db as LibDb exposing (conn)`.  The v0.17.5 rule
+            -- lets that shrink to plain `import Lib.Db exposing (conn)`
+            -- while the intermediate `as LibDb` line stays optional.
             sky <- findSky
             let libDbSrc = unlines
                     [ "module Lib.Db exposing (conn, dummy)"
@@ -638,21 +636,9 @@ spec = do
                             "no publishDiagnostics on 3-import shape"
                         Just payload -> do
                             let msgs = diagnosticMessages payload
-                                codes = diagnosticCodes payload
-                            -- Base E1001 collision surfaces.
-                            anyMatch "E1001" codes `shouldBe` True
-                            anyMatch "two imports both bind the qualifier" msgs
-                                `shouldBe` True
-                            -- The improved fix-it recognises the existing
-                            -- `import Lib.Db as LibDb` line and points the
-                            -- user at the merge shape.
-                            anyMatch "You already have" msgs `shouldBe` True
-                            anyMatch "import Lib.Db as LibDb exposing" msgs
-                                `shouldBe` True
-                            -- And explains WHY the bare exposing still
-                            -- collides — protects the reasoning from being
-                            -- silently truncated in a future refactor.
-                            anyMatch "re-registers" msgs `shouldBe` True
+                            -- Zero diagnostics — the file compiles cleanly
+                            -- under the explicit-alias-wins rule.
+                            msgs `shouldBe` []
 
 
     describe "v0.13 Layer 4 — LSP carries stable diagnostic codes" $ do


### PR DESCRIPTION
## Summary

Relaxes the E1001 dual-import qualifier collision gate (task #347, D5) so that the following shape now compiles cleanly:

```elm
import Std.Db as Db          -- explicit `Db` for Std.Db
import Lib.Db exposing (conn) -- last-segment default: was Db → Lib.Db, now suppressed
```

Rule: **explicit `as X` alias wins over bare-import auto-qualifier.**  A bare `import M exposing (…)` whose last-segment default matches an EXPLICIT alias for a DIFFERENT module in the same file has its auto-qualifier binding suppressed silently.

`conn` still lands in scope unqualified.  `Db.<x>` still resolves to `Std.Db` (the explicit alias).  Only the last-segment shortcut for the bare `Lib.Db` import is dropped — the user gets what they wrote.

## What DOESN'T change

- Two explicit `as X` aliases both claiming `X` for different modules → still E1001 (user error, no way to disambiguate)
- Two bare imports auto-registering the same last-segment for different modules → still E1001 (genuinely ambiguous)
- Two imports of the SAME module under alias + bare → still accepted (Case E, no collision)
- Kernel imports collapsing to their pseudo-module → still accepted

## What DOES change

- 2-import ringfence shape: builds clean
- 3-import ringfence shape (`Std.Db as Db` + `Lib.Db as LibDb` + `Lib.Db exposing (conn)`): builds clean
- v0.17.4 diagnostic hint (\"you already have \`import M as X\`, merge\") is retired — the shape it handled now silently compiles

## Files

- \`src/Sky/Canonicalise/Module.hs\` — \`processImport\` computes \`explicitAliasClaims\` from the full import list and skips \`Env.addQualifiedImport\` when the auto-qualifier would collide with an explicit alias.  \`detectImportAliasCollisions\` mirrors the suppression so the gate does not flag suppressible shapes.
- \`test/Sky/Canonicalise/DualImportCollisionSpec.hs\` — v0.17.4 case (expected E1001 on the 3-import shape) replaced by two positive assertions.  New negative case pins that two bare imports still trip E1001.
- \`test/Sky/Lsp/DiagnosticsSpec.hs\` — flips the LSP case from \"E1001 body carries merge fix-it\" to \"zero diagnostics\".

## Test plan

- [x] \`cabal test --match \"Canonicalise\"\` — 29/29 green
- [x] \`cabal test --match \"LSP\"\` — 41/41 green
- [x] Manual \`sky build\` on:
  - 2-import shape (Std.Db as Db + Lib.Db exposing (conn)) → CLEAN
  - 3-import shape (adds Lib.Db as LibDb in middle) → CLEAN
  - 2 bare imports auto-colliding → still E1001
- [x] Manual LSP probe on 3-import shape → \`diagnostic count: 0\`
- [x] Full \`cabal test\` sweep — **985 examples, 0 failures, 6 pending** (baseline unchanged)
- [ ] CI green (running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013PZXpgCdbQ3A1eSwxCqAQZ