### PR TITLE
fix(examples): drop redundant trailing `Task.run` from app entry points

### DIFF
--- a/examples/20-cli-counter/src/Main.sky
+++ b/examples/20-cli-counter/src/Main.sky
@@ -100,4 +100,3 @@ main =
         , subscriptions = subscriptions
         , onLine = onLine
         }
-        |> Task.run

--- a/examples/21-tui-stopwatch/src/Main.sky
+++ b/examples/21-tui-stopwatch/src/Main.sky
@@ -201,4 +201,3 @@ main =
         , subscriptions = subscriptions
         , onKey = onKey
         }
-        |> Task.run

--- a/examples/22-tui-stopwatch-ui/src/Main.sky
+++ b/examples/22-tui-stopwatch-ui/src/Main.sky
@@ -207,4 +207,3 @@ main =
         , subscriptions = subscriptions
         , onKey = onKey
         }
-        |> Task.run

--- a/examples/23-tui-todo/src/Main.sky
+++ b/examples/23-tui-todo/src/Main.sky
@@ -295,4 +295,3 @@ main =
         , subscriptions = subscriptions
         , onKey = onKey
         }
-        |> Task.run

--- a/examples/24-tui-kitchen-sink/src/Main.sky
+++ b/examples/24-tui-kitchen-sink/src/Main.sky
@@ -502,7 +502,6 @@ main =
                 , routes = [ Live.route "/" KitchenSink ]
                 , notFound = KitchenSink
                 }
-                |> Task.run
 
         _ ->
             Tui.app
@@ -514,4 +513,3 @@ main =
                 , routes = []
                 , notFound = ()
                 }
-                |> Task.run

--- a/examples/29-webview-threejs-spike/src/Main.sky
+++ b/examples/29-webview-threejs-spike/src/Main.sky
@@ -147,4 +147,3 @@ main =
         , subscriptions = subscriptions
         , window = { title = "Sky.Webview spike - three.js", size = ( 1024, 720 ) }
         }
-        |> Task.run

--- a/examples/31-webview-stopwatch-ui/src/Main.sky
+++ b/examples/31-webview-stopwatch-ui/src/Main.sky
@@ -155,4 +155,3 @@ main =
         , subscriptions = subscriptions
         , window = { title = "Sky Webview Stopwatch", size = ( 800, 500 ) }
         }
-        |> Task.run


### PR DESCRIPTION
Hi, @anzellai! This is a "cosmetic" PR, but seems important to me to not confuse newcomers, making them think you have to dispatch `Task.run` manually in all cases.

Feel free to ignore it, of course.

------------
The runtime auto-runs a Task-typed `main` — the generated entry wraps the main body’s tail in `rt.AnyTaskRun` — so a trailing `<app> |> Task.run` at the program entry is a no-op. It has been redundant since the task-everywhere auto-force, and the `Sky.Live` examples already omit it; these Tui / Webview / Cli examples were the last still carrying it.

Removing it keeps the examples consistent and avoids modelling an unnecessary boilerplate line for newcomers.

**Scope:** only the trailing entry `Task.run` is removed. Internal, load-bearing `Task.run` uses (e.g. the module-level `System.args ()` force in `24` and `38`) are left untouched. `24-tui-kitchen-sink` dispatches on args, so both of its backend branches shed the trailing `Task.run`.

**Verified:** all seven examples build and run identically before and after.

Examples touched: `20-cli-counter`, `21-tui-stopwatch`, `22-tui-stopwatch-ui`, `23-tui-todo`, `24-tui-kitchen-sink`, `29-webview-threejs-spike`, `31-webview-stopwatch-ui`.