### PR TITLE
fix(#142): MountConsoleEndpoints honours production+unset auth gate

### DIFF
--- a/runtime-go/rt/console.go
+++ b/runtime-go/rt/console.go
@@ -201,6 +201,22 @@ func MountConsoleEndpoints(mux *http.ServeMux) {
 	if v := os.Getenv("SKY_CONSOLE_AUTH"); v == "off" {
 		return
 	}
+	// v0.17.6 (issue #142): honour the production+unset gate the same
+	// way MountEmbeddedConsole does.  Before this check, when
+	// productionFromEnv() was true AND SKY_CONSOLE_AUTH was unset,
+	// MountEmbeddedConsole correctly declined (consoleAuthModeUnsetProd
+	// arm at console.go:278) but the legacy shell here filled the
+	// vacuum, serving the full Sky Console HTML unauthenticated to any
+	// visitor. The documented contract — "Production (ENV !=
+	// dev/development/local) AND unset → mount declines" — was only
+	// held for the inline path; the legacy fallback silently violated
+	// it. Mirror the same decline semantics here so both mount paths
+	// honour the same gate contract.
+	if productionFromEnv() && strings.TrimSpace(os.Getenv("SKY_CONSOLE_AUTH")) == "" {
+		fmt.Fprintln(os.Stderr, "[sky.console] legacy console skipped reason=auth-unset (production mode requires SKY_CONSOLE_AUTH; see docs/v0.16.x-console/EMBEDDED.md)")
+		logStructured("warn", "console.disabled", "reason", "auth-unset", "path", "legacy")
+		return
+	}
 	// PR 2 (v0.16.1): skip the legacy HTML shell registration when
 	// the inline console (MountEmbeddedConsole, called first from
 	// the boot path) already claimed `/_sky/console`. Previously

--- a/runtime-go/rt/console_boot_test.go
+++ b/runtime-go/rt/console_boot_test.go
@@ -96,6 +96,90 @@ func TestMountConsoleEndpoints_RegistersHTMLShellWhenInlineMissing(t *testing.T)
 	}
 }
 
+// TestMountConsoleEndpoints_DeclinesUnderProductionUnsetAuth (issue
+// #142) covers the security-critical case: when ENV=production AND
+// SKY_CONSOLE_AUTH is unset, the LEGACY HTML shell (this function)
+// must decline just like the inline path
+// (consoleAuthModeUnsetProd) — otherwise the inline path declines
+// and the legacy shell fills the vacuum, serving the console UI to
+// any anon visitor. Pre-fix this test returned 200 (repro) even
+// with ENV=production because MountConsoleEndpoints did not honour
+// productionFromEnv().
+func TestMountConsoleEndpoints_DeclinesUnderProductionUnsetAuth(t *testing.T) {
+	resetReadiness(t)
+	withServerlessEnv(t, nil)
+	ResetConsoleHealthFlagsForTesting()
+	t.Cleanup(ResetConsoleHealthFlagsForTesting)
+
+	// Simulate the vulnerable deploy shape: production gate set,
+	// SKY_CONSOLE_AUTH intentionally unset.  Also clear SKY_ENV so
+	// productionFromEnv reads ENV.
+	t.Setenv("ENV", "production")
+	t.Setenv("SKY_ENV", "")
+	t.Setenv("SKY_CONSOLE_AUTH", "")
+
+	mux := http.NewServeMux()
+	MountConsoleEndpoints(mux)
+
+	if LegacyConsoleHealthy() {
+		t.Fatalf("legacyConsoleHealthy must NOT flip under production + unset auth")
+	}
+	// /_sky/console must decline (404 — nothing registered).
+	req := httptest.NewRequest(http.MethodGet, "/_sky/console", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("/_sky/console: expected 404 under production + unset auth, got %d", w.Code)
+	}
+	// The JSON API endpoints must ALSO decline — under this class
+	// the console is fully off, matching the SKY_CONSOLE_AUTH=off
+	// behaviour.  A leak here would surface logs/traces/metrics
+	// unauthenticated.
+	for _, path := range []string{
+		"/_sky/console/api/overview",
+		"/_sky/console/api/logs",
+		"/_sky/console/api/metrics-summary",
+		"/_sky/console/api/traces",
+		"/_sky/console/api/errors",
+	} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Errorf("%s: expected 404 under production + unset auth, got %d", path, w.Code)
+		}
+	}
+}
+
+// TestMountConsoleEndpoints_MountsInDevWhenAuthUnset covers the
+// converse: dev mode (ENV unset) + SKY_CONSOLE_AUTH unset should
+// STILL mount the legacy shell.  Guards against a regression where
+// the production gate accidentally over-fires in dev.
+func TestMountConsoleEndpoints_MountsInDevWhenAuthUnset(t *testing.T) {
+	resetReadiness(t)
+	withServerlessEnv(t, nil)
+	ResetConsoleHealthFlagsForTesting()
+	t.Cleanup(ResetConsoleHealthFlagsForTesting)
+
+	// Explicit dev shape: no ENV, no SKY_ENV, no SKY_CONSOLE_AUTH.
+	t.Setenv("ENV", "")
+	t.Setenv("SKY_ENV", "")
+	t.Setenv("SKY_CONSOLE_AUTH", "")
+
+	mux := http.NewServeMux()
+	MountConsoleEndpoints(mux)
+
+	if !LegacyConsoleHealthy() {
+		t.Fatalf("legacyConsoleHealthy must flip in dev mode with unset auth (inline unavailable path)")
+	}
+	req := httptest.NewRequest(http.MethodGet, "/_sky/console", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("/_sky/console: expected 200 from legacy HandleConsole in dev, got %d", w.Code)
+	}
+}
+
 // ─── shouldHaveConsole reflects the env-var triple gate ─────────
 
 func TestShouldHaveConsole_OffWhenAuthUnset(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #142.

Legacy HTML-shell mount (\`MountConsoleEndpoints\` in \`runtime-go/rt/console.go\`) gated only on \`SKY_CONSOLE_AUTH=off\`, ignoring \`productionFromEnv()\`.

When the inline path (\`MountEmbeddedConsole\`) correctly declined under the \`consoleAuthModeUnsetProd\` arm — ENV=production AND SKY_CONSOLE_AUTH unset — the legacy shell filled the vacuum and served the full Sky Console UI + all \`/_sky/console/api/*\` JSON endpoints unauthenticated to anon visitors.

The documented CLAUDE.md contract — *\"Production (ENV != dev/development/local) AND unset → mount declines + emits \`console.disabled reason=auth-unset\` warn log\"* — held only for the inline path. This PR closes the legacy path too.

## Root cause

\`runtime-go/rt/console.go:191\` \`MountConsoleEndpoints()\`:

\`\`\`go
func MountConsoleEndpoints(mux *http.ServeMux) {
    if skyGetenv(\"CONSOLE_DISABLED\") == \"1\" { return }
    if v := os.Getenv(\"SKY_CONSOLE_AUTH\"); v == \"off\" { return }
    // ← NO productionFromEnv() gate here.  Bug.
    if !inlineConsoleHealthy.Load() {
        safeMount(mux, \"/_sky/console\", HandleConsole)
        ...
    }
    ...
}
\`\`\`

## Fix

Add a production+unset guard that mirrors the inline decline semantics — early-return before any \`safeMount\` call, emit the same structured warn log + stderr line, tagged \`path=legacy\` for grep-ability.

## Tests

Two new cases in \`console_boot_test.go\`:

* \`TestMountConsoleEndpoints_DeclinesUnderProductionUnsetAuth\` — the security case. Sets \`ENV=production\` + \`SKY_CONSOLE_AUTH=\"\"\` and asserts \`/_sky/console\` AND all 5 \`/_sky/console/api/*\` endpoints return 404, \`legacyConsoleHealthy\` stays false. Pre-fix this returned 200 (repro discovered on ringfence.dev prod).
* \`TestMountConsoleEndpoints_MountsInDevWhenAuthUnset\` — dev-mode guard. Explicit dev shape (ENV unset + SKY_CONSOLE_AUTH unset) must STILL mount the legacy shell, catching a regression that flipped the production gate the wrong way.

## Verification

- [x] \`go test ./rt/... \` — green (rt / console_app / hub / jobs / telemetry all pass)
- [x] Regression cases: 4/4 \`TestMountConsoleEndpoints_*\` pass, including the two new ones
- [ ] Full cabal-test sweep + example sweep (CI)

## Impact

Any Sky.Live prod binary compiled from a Sky ≤ v0.17.5 runtime + deployed with \`ENV=production\` but without \`SKY_CONSOLE_AUTH\` set was exposing \`/_sky/console\`. Existing deploys can work around by setting \`SKY_CONSOLE_AUTH=off\` explicitly; after this PR ships in v0.17.6 the documented default behaviour holds.

Recommended: hotfix release as v0.17.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013PZXpgCdbQ3A1eSwxCqAQZ