### PR TITLE
fix(#144): sky fmt honours SKY_FMT_FORCE in file mode + clearer message

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1508,9 +1508,34 @@ runCommand cmd = case cmd of
                     Right srcMod -> do
                         let baseOut = T.pack (Format.formatModule srcMod)
                             withComments = preserveTopLevelComments src baseOut
-                        case fmtSafetyCheck src withComments of
-                            Just msg -> return (Left msg)
-                            Nothing -> do
+                        -- v0.17.7 (#144): the escape hatch that the
+                        -- refusal message documents (`SKY_FMT_FORCE=1`)
+                        -- was only wired up in the `--stdin` mode
+                        -- below.  In file mode we ignored the env var
+                        -- entirely, so users hitting the safety guard
+                        -- had NO way to write the formatted output —
+                        -- the message told them to re-run with
+                        -- `SKY_FMT_FORCE=1` but the re-run refused
+                        -- identically.  Now file mode honours the same
+                        -- contract: force=set → write anyway; force=
+                        -- unset → refuse + exit 1 as before.
+                        force <- System.Environment.lookupEnv "SKY_FMT_FORCE"
+                        case (force, fmtSafetyCheck src withComments) of
+                            (Nothing, Just msg) ->
+                                return (Left msg)
+                            (Just _, Just _) -> do
+                                TIO.writeFile path withComments
+                                -- Loud on stderr so the user knows the
+                                -- forced write dropped comments; keep
+                                -- exit 0 so CI gates like
+                                -- `SKY_FMT_FORCE=1 sky fmt … &&
+                                -- git diff --exit-code` still work.
+                                hPutStrLn stderr $
+                                    fmtForceMessage src withComments
+                                putStrLn $ "Formatted " ++ path
+                                    ++ " (forced)"
+                                return (Right ())
+                            (_, Nothing) -> do
                                 TIO.writeFile path withComments
                                 putStrLn $ "Formatted " ++ path
                                 return (Right ())
@@ -2319,27 +2344,56 @@ detectPlatform = do
 -- restacking can collapse a trailing comment onto an earlier line
 -- (e.g. two-line `case ... of\n    -- doc` becoming `case ... of  -- doc`)
 -- which legitimately reduces the per-line count.
+-- | Counts of source vs formatted-output comment lines, plus the
+-- computed slack threshold.  Callers (safety guard, force-write,
+-- test) use the raw counts to build their own messages instead of
+-- hard-coding a "re-run" hint into one message that fires in every
+-- code path.
+data FmtCommentTally = FmtCommentTally
+    { fctInput  :: !Int
+    , fctOutput :: !Int
+    , fctSlack  :: !Int  -- ^ max 1 or 5% of input, whichever's higher
+    }
+
+fmtCommentTally :: T.Text -> T.Text -> FmtCommentTally
+fmtCommentTally srcIn srcOut =
+    let ci = countComments srcIn
+        co = countComments srcOut
+    in FmtCommentTally { fctInput = ci, fctOutput = co, fctSlack = max 1 (ci `div` 20) }
+  where
+    countComments t =
+        length [l | l <- map T.strip (T.lines t)
+                  , T.pack "--" `T.isPrefixOf` l || T.pack "{-" `T.isPrefixOf` l]
+
 fmtSafetyCheck :: T.Text -> T.Text -> Maybe String
 fmtSafetyCheck srcIn srcOut =
-    let commentsBefore = countComments srcIn
-        commentsAfter  = countComments srcOut
-        threshold      = max 1 (commentsBefore `div` 20)  -- ~5% slack
-    in if commentsBefore > commentsAfter + threshold
+    let t = fmtCommentTally srcIn srcOut
+    in if fctInput t > fctOutput t + fctSlack t
          then Just $ unlines
-             [ "refusing to format: " ++ show commentsBefore
+             [ "refusing to format: " ++ show (fctInput t)
                  ++ " comment line(s) in input but only "
-                 ++ show commentsAfter ++ " in output (dropped "
-                 ++ show (commentsBefore - commentsAfter) ++ ", threshold "
-                 ++ show threshold ++ ")."
+                 ++ show (fctOutput t) ++ " in output (dropped "
+                 ++ show (fctInput t - fctOutput t) ++ ", threshold "
+                 ++ show (fctSlack t) ++ ")."
              , "This is a sky fmt bug — please report at"
              , "https://github.com/anzellai/sky/issues with the source file."
              , "To format anyway, re-run with SKY_FMT_FORCE=1."
              ]
        else Nothing
-  where
-    countComments t =
-        length [l | l <- map T.strip (T.lines t)
-                  , T.pack "--" `T.isPrefixOf` l || T.pack "{-" `T.isPrefixOf` l]
+
+-- | The counterpart message for the SKY_FMT_FORCE=1 path: user
+-- already opted in, so the "re-run" hint from `fmtSafetyCheck`
+-- would be confusing.  Reports the same counts but frames it as
+-- "wrote despite drops" rather than "refusing".
+fmtForceMessage :: T.Text -> T.Text -> String
+fmtForceMessage srcIn srcOut =
+    let t = fmtCommentTally srcIn srcOut
+    in "SKY_FMT_FORCE=1: wrote formatted output despite the safety guard ("
+        ++ show (fctInput t) ++ " comment line(s) in input but only "
+        ++ show (fctOutput t) ++ " in output — dropped "
+        ++ show (fctInput t - fctOutput t) ++ ", threshold "
+        ++ show (fctSlack t) ++ "). Please still consider reporting the "
+        ++ "underlying formatter bug at https://github.com/anzellai/sky/issues."
 
 -- ─── Comment preservation across sky fmt ─────────────────────────
 -- The parser discards comments before they reach the AST, so

--- a/test/Sky/Cli/FmtSpec.hs
+++ b/test/Sky/Cli/FmtSpec.hs
@@ -15,6 +15,7 @@ import System.FilePath ((</>))
 import System.IO.Temp (withSystemTempDirectory)
 import System.Process (readCreateProcessWithExitCode, proc, CreateProcess(..))
 import System.Exit (ExitCode(..))
+import Data.List (isInfixOf)
 
 
 findSky :: IO FilePath
@@ -57,3 +58,57 @@ spec = do
                 ec2 `shouldBe` ExitSuccess
                 pass2 <- readFile path
                 pass2 `shouldBe` pass1
+
+        -- Regression for #144: `sky fmt <file>` used to check
+        -- SKY_FMT_FORCE ONLY in `--stdin` mode.  In file mode the
+        -- refusal was unconditional — the escape hatch the message
+        -- itself advertised was a no-op.  Both branches now honour
+        -- the same contract.  The fixture below (a lambda-body
+        -- comment) is the exact shape that dropped 3 of 9 comments
+        -- in `StatsTest.sky` on the issue's attachment.
+        it "SKY_FMT_FORCE=1 file mode: writes despite the safety guard" $ do
+            sky <- findSky
+            withSystemTempDirectory "sky-fmt-force" $ \tmp -> do
+                let path = tmp </> "F.sky"
+                writeFile path $ unlines
+                    [ "module F exposing (tests)"
+                    , ""
+                    , ""
+                    , "tests ="
+                    , "    [ pair 1 (\\_ ->"
+                    , "        -- head comment on the lambda body"
+                    , "        step 5.0)"
+                    , "    , pair 2 (\\_ ->"
+                    , "        -- second dropped comment"
+                    , "        step 10.0)"
+                    , "    , pair 3 (\\_ ->"
+                    , "        -- third dropped comment"
+                    , "        step 15.0)"
+                    , "    , pair 4 (\\_ ->"
+                    , "        -- fourth dropped comment"
+                    , "        step 20.0)"
+                    , "    ]"
+                    ]
+                original <- readFile path
+                -- Without force: should refuse (exit 1) and leave
+                -- the file untouched.
+                (ec1, _, err1) <- readCreateProcessWithExitCode
+                    (proc sky ["fmt", path]) ""
+                ec1 `shouldBe` ExitFailure 1
+                ("refusing to format" `isInfixOf` err1) `shouldBe` True
+                after1 <- readFile path
+                after1 `shouldBe` original
+                -- With SKY_FMT_FORCE=1: should exit 0 and write
+                -- despite the drop.  Message reflects "wrote
+                -- despite" instead of the confusing "re-run with
+                -- SKY_FMT_FORCE=1" that the same env-var-already-
+                -- set caller had just seen.
+                let cp = (proc sky ["fmt", path])
+                        { env = Just [("SKY_FMT_FORCE", "1"), ("PATH", "/usr/bin:/bin")] }
+                (ec2, _, err2) <- readCreateProcessWithExitCode cp ""
+                ec2 `shouldBe` ExitSuccess
+                ("SKY_FMT_FORCE=1" `isInfixOf` err2) `shouldBe` True
+                ("wrote formatted output despite" `isInfixOf` err2)
+                    `shouldBe` True
+                after2 <- readFile path
+                (after2 /= original) `shouldBe` True


### PR DESCRIPTION
Fixes half of #144.

## Repro (from the issue)

`sky fmt StatsTest.sky.txt` refuses to format:
```
refusing to format: 9 comment line(s) in input but only 6 in output (dropped 3, threshold 1).
This is a sky fmt bug — please report at
https://github.com/anzellai/sky/issues with the source file.
To format anyway, re-run with SKY_FMT_FORCE=1.
```

Re-running with `SKY_FMT_FORCE=1 sky fmt StatsTest.sky.txt` prints the same refusal + exits 1 + leaves the file byte-identical. The documented escape hatch was a no-op.

## Root cause

Two orthogonal bugs:

1. **`SKY_FMT_FORCE` ignored in `FmtFile` mode** (app/Main.hs:1502-1516). The env var was checked ONLY in the `--stdin` branch below it. In file mode the refusal path was unconditional.
2. **Refusal message hard-codes "re-run with `SKY_FMT_FORCE=1`"** even when the caller ALREADY had the env var set. When the guard also fired in the force-set path this made the message actively misleading.

## Fix

Split `fmtSafetyCheck` into a pure `fmtCommentTally` helper + a `fmtSafetyCheck` (unchanged no-force behaviour) + a new `fmtForceMessage` for the SKY_FMT_FORCE=1 path. Wire `SKY_FMT_FORCE` into the FmtFile branch with three arms:

- `(Nothing, Just msg)` → return `Left msg` → prints refusal + exit 1 (as before)
- `(Just _, Just _)` → **write anyway** + stderr the "wrote despite" message + putStrLn "Formatted X (forced)" + exit 0
- `(_, Nothing)` → normal write path

## Verification

```
$ sky fmt StatsTest.sky        # no force
refusing to format: 9 comment line(s) in input but only 6 in output (dropped 3, threshold 1).
...
To format anyway, re-run with SKY_FMT_FORCE=1.
exit=1
comments in file after: 9  ✓

$ SKY_FMT_FORCE=1 sky fmt StatsTest.sky
SKY_FMT_FORCE=1: wrote formatted output despite the safety guard (9 comment line(s) in input but only 6 in output — dropped 3, threshold 1). Please still consider reporting the underlying formatter bug at https://github.com/anzellai/sky/issues.
Formatted /tmp/sky144/case-file.sky (forced)
exit=0
comments after force: 6  ✓
```

Regression test in `Sky.Cli.FmtSpec`:
- no-force: refuses (exit 1), file untouched, stderr contains "refusing to format"
- SKY_FMT_FORCE=1: exits 0, file written, stderr contains "SKY_FMT_FORCE=1: wrote formatted output despite"

`cabal test --match "sky fmt"`: 16/16 green including the new case.

## What's NOT in this PR

The deeper regression the issue reports — comments dropped inside `(\_ -> body)` lambda bodies — is a comment-reanchoring gap in `preserveTopLevelComments`. The formatter reshapes `f "..." (\_ -> body)` differently than the input, and the prev/next-line anchor system loses the position. Tracked as a follow-up so v0.17.7 can ship the working escape hatch immediately; the anchoring fix needs deeper formatter surgery.

## Test plan
- [x] Reproduce issue #144's SKY_FMT_FORCE-is-a-no-op behavior locally
- [x] Verify no-force still refuses with exit 1
- [x] Verify SKY_FMT_FORCE=1 in file mode writes + exits 0
- [x] Verify SKY_FMT_FORCE=1 message reflects "wrote despite" not "re-run"
- [x] `cabal test --match "sky fmt"` green (16/16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013PZXpgCdbQ3A1eSwxCqAQZ